### PR TITLE
fix(markdown): Do not force convert Indented CodeBlock to Fenced code blocks

### DIFF
--- a/examples/benchmark/resources/gitbook-plugin-include-codeblock.hbs
+++ b/examples/benchmark/resources/gitbook-plugin-include-codeblock.hbs
@@ -1,7 +1,7 @@
 {{#if title}}
-    <div class="code-filename-block">
-        <p class="code-filename">{{title}}</p>
-    </div>
+<div class="code-filename-block">
+    <p class="code-filename">{{title}}</p>
+</div>
 {{/if}}
 
 {{{backtick}}} {{lang}}

--- a/packages/@honkit/markdown/src/__tests__/page.js
+++ b/packages/@honkit/markdown/src/__tests__/page.js
@@ -29,21 +29,56 @@ describe("Page parsing", () => {
             page.prepare("Hello\n```js\nworld test\n```\n"),
             "Hello\n\n{% raw %}```js\nworld test\n```\n\n{% endraw %}"
         );
-        assert.equal(
-            page.prepare("Hello\n```\ntest\n\tworld\n\ttest\n```"),
-            "Hello\n\n{% raw %}```\ntest\n    world\n    test\n```\n\n{% endraw %}"
-        );
+        expect(page.prepare("Hello\n```\ntest\n\tworld\n\ttest\n```")).toMatchInlineSnapshot(`
+            "Hello
+
+            {% raw %}\`\`\`
+            test
+                world
+                test
+            \`\`\`
+
+            {% endraw %}"
+        `);
     });
 
     it("should escape codeblocks in preparation (2)", () => {
-        assert.strictEqual(
-            page.prepare("Hello\n\n\n\tworld\n\thello\n\n\ntest"),
-            "Hello\n\n{% raw %}```\nworld\nhello\n```\n\n{% endraw %}test\n\n"
-        );
-        assert.strictEqual(
-            page.prepare("Hello\n\n\n\tworld\n\thello\n\n\n"),
-            "Hello\n\n{% raw %}```\nworld\nhello\n```\n\n{% endraw %}"
-        );
+        expect(
+            page.prepare(`Hello
+
+
+\tworld
+\thello
+
+
+test`)
+        ).toMatchInlineSnapshot(`
+            "Hello
+
+            {% raw %}        world
+                    hello
+
+            {% endraw %}test
+
+            "
+        `);
+        expect(
+            page.prepare(`Hello
+
+
+\tworld
+\thello
+
+
+`)
+        ).toMatchInlineSnapshot(`
+            "Hello
+
+            {% raw %}        world
+                    hello
+
+            {% endraw %}"
+        `);
     });
 
     it("should escape codeblocks with nunjucks tags", () => {
@@ -71,6 +106,41 @@ describe("Page parsing", () => {
             page.prepare("```\ntest\n```\n\n\n### Test"),
             "{% raw %}```\ntest\n```\n\n{% endraw %}### Test\n\n"
         );
+    });
+    it("escape {% uml %} block tags + Indented code block", () => {
+        const code = `{% uml %}
+@startuml
+
+\tClass Stage
+\tClass Timeout {
+\t\t+constructor:function(cfg)
+\t\t+timeout:function(ctx)
+\t\t+overdue:function(ctx)
+\t\t+stage: Stage
+\t}
+ \tStage <|-- Timeout
+
+@enduml
+{% enduml %}
+`;
+        expect(page.prepare(code)).toMatchInlineSnapshot(`
+            "{% uml %}
+            @startuml
+
+            {% raw %}        Class Stage
+                    Class Timeout {
+                        +constructor:function(cfg)
+                        +timeout:function(ctx)
+                        +overdue:function(ctx)
+                        +stage: Stage
+                    }
+                     Stage <|-- Timeout
+
+            {% endraw %}@enduml
+            {% enduml %}
+
+            "
+        `);
     });
 
     it("should not process math", () => {

--- a/packages/@honkit/markdown/src/__tests__/page.js
+++ b/packages/@honkit/markdown/src/__tests__/page.js
@@ -40,6 +40,17 @@ describe("Page parsing", () => {
 
             {% endraw %}"
         `);
+        // preserve \t in CodeBlock
+        expect(page.prepare("Hello\n```js\n\tvar a = 1;\n\tconsole.log(a);\n```")).toMatchInlineSnapshot(`
+            "Hello
+
+            {% raw %}\`\`\`js
+                var a = 1;
+                console.log(a);
+            \`\`\`
+
+            {% endraw %}"
+        `);
     });
 
     it("should escape codeblocks in preparation (2)", () => {

--- a/packages/@honkit/markup-it/syntaxes/markdown/code.js
+++ b/packages/@honkit/markup-it/syntaxes/markdown/code.js
@@ -39,13 +39,12 @@ const blockRule = MarkupIt.Rule(MarkupIt.BLOCKS.CODE)
         const data = token.getData();
         const syntax = data.get("syntax") || "";
         const type = data.get("type");
-        const hasFences = text.indexOf("`") >= 0;
         // Use fences if syntax is set
         if (syntax) {
             return `\`\`\`${syntax}\n${text}\n` + "```\n\n";
         }
         // Use fences if the original is fences
-        if (hasFences || type === "fences") {
+        if (type === "fences") {
             return `\`\`\`\n${text}\n` + "```\n\n";
         }
 

--- a/packages/@honkit/markup-it/syntaxes/markdown/code.js
+++ b/packages/@honkit/markup-it/syntaxes/markdown/code.js
@@ -12,6 +12,7 @@ const blockRule = MarkupIt.Rule(MarkupIt.BLOCKS.CODE)
             tokens: [MarkupIt.Token.createText(inner)],
             data: {
                 syntax: match[2],
+                type: "fences", // https://spec.commonmark.org/0.29/#fenced-code-blocks
             },
         };
     })
@@ -27,7 +28,7 @@ const blockRule = MarkupIt.Rule(MarkupIt.BLOCKS.CODE)
             tokens: [MarkupIt.Token.createText(inner)],
             data: {
                 syntax: undefined,
-                indented: true, // https://spec.commonmark.org/0.29/#indented-code-blocks
+                type: "indented", // https://spec.commonmark.org/0.29/#indented-code-blocks
             },
         };
     })
@@ -37,12 +38,15 @@ const blockRule = MarkupIt.Rule(MarkupIt.BLOCKS.CODE)
         const text = token.getAsPlainText();
         const data = token.getData();
         const syntax = data.get("syntax") || "";
-        const indented = data.get("indented");
+        const type = data.get("type");
         const hasFences = text.indexOf("`") >= 0;
-
         // Use fences if syntax is set
-        if (!hasFences && !indented) {
+        if (syntax) {
             return `\`\`\`${syntax}\n${text}\n` + "```\n\n";
+        }
+        // Use fences if the original is fences
+        if (hasFences || type === "fences") {
+            return `\`\`\`\n${text}\n` + "```\n\n";
         }
 
         // Use four spaces otherwise

--- a/packages/@honkit/markup-it/syntaxes/markdown/code.js
+++ b/packages/@honkit/markup-it/syntaxes/markdown/code.js
@@ -20,9 +20,6 @@ const blockRule = MarkupIt.Rule(MarkupIt.BLOCKS.CODE)
     .regExp(reBlock.code, (state, match) => {
         let inner = match[0];
 
-        // Remove indentation
-        inner = inner.replace(/^( {4}|\t)/gm, "");
-
         // No pedantic mode
         inner = inner.replace(/\n+$/, "");
 
@@ -30,6 +27,7 @@ const blockRule = MarkupIt.Rule(MarkupIt.BLOCKS.CODE)
             tokens: [MarkupIt.Token.createText(inner)],
             data: {
                 syntax: undefined,
+                indented: true, // https://spec.commonmark.org/0.29/#indented-code-blocks
             },
         };
     })
@@ -39,10 +37,11 @@ const blockRule = MarkupIt.Rule(MarkupIt.BLOCKS.CODE)
         const text = token.getAsPlainText();
         const data = token.getData();
         const syntax = data.get("syntax") || "";
+        const indented = data.get("indented");
         const hasFences = text.indexOf("`") >= 0;
 
         // Use fences if syntax is set
-        if (!hasFences || syntax) {
+        if (!hasFences && !indented) {
             return `\`\`\`${syntax}\n${text}\n` + "```\n\n";
         }
 


### PR DESCRIPTION
This behavior break Fenced code blocks macro like https://github.com/vowstar/gitbook-plugin-uml

- `page:before`: Convert Fenced code blocks to Block Tags that includes Indented CodeBlock
- `plugin.prepare`: Convert Indented CodeBlock to Fenced code blocks <- This break the plugin and This commit fix it
- Convert Block Tags by plugins

This commit remove `plugin.prepare` behavior that convert Indented CodeBlock to Fenced code blocks.
As a result, the plugin receive Indented CodeBlock's content instead of triple tick content.

So, it will make https://github.com/vowstar/gitbook-plugin-uml work in HonKit.

fix #58 