### PR TITLE
fix(honkit): fix to load @scope/honkit-plugin-name

### DIFF
--- a/docs/plugins/create.md
+++ b/docs/plugins/create.md
@@ -39,8 +39,7 @@ The **package name** must begin with following patterns:
 - `@<scope>/gitbook-plugin-`
 - `gitbook-plugin-`
 
-
-And the **package engines** should contains `honkit` or `gitbook`.
+Also, the **package engines** should contain `honkit` or `gitbook`.
 
 #### index.js
 

--- a/packages/honkit/src/models/__tests__/config.ts
+++ b/packages/honkit/src/models/__tests__/config.ts
@@ -90,4 +90,95 @@ describe("Config", () => {
             });
         });
     });
+
+    describe("getPluginDependencies", () => {
+        // @ts-expect-error
+        const config = Config.createWithValues({
+            plugins: [
+                "example",
+                "honkit-plugin-example",
+                "@example/example",
+                "@example/honkit-plugin-example",
+                "@honkit/honkit-plugin-example",
+                "-no-use",
+                "-honkit-plugin-no-use",
+                "-@honkit/honkit-plugin-no-use",
+                // GitBook logic - deprecated
+                "example-v@1.0.0",
+                "gitbook-plugin-example-v@1.0.0",
+                "example@git+ssh://samy@github.com/GitbookIO/plugin-ga.git",
+            ],
+        });
+
+        const dependencies = config.getPluginDependencies();
+
+        expect(dependencies.toJS()).toEqual([
+            {
+                enabled: true,
+                name: "example",
+                path: "",
+                version: "*",
+            },
+            {
+                enabled: true,
+                name: "honkit-plugin-example",
+                path: "",
+                version: "*",
+            },
+            {
+                enabled: true,
+                name: "@example/example",
+                path: "",
+                version: "*",
+            },
+            {
+                enabled: true,
+                name: "@example/honkit-plugin-example",
+                path: "",
+                version: "*",
+            },
+            {
+                enabled: true,
+                name: "@honkit/honkit-plugin-example",
+                path: "",
+                version: "*",
+            },
+            {
+                enabled: false,
+                name: "no-use",
+                path: "",
+                version: "*",
+            },
+            {
+                enabled: false,
+                name: "honkit-plugin-no-use",
+                path: "",
+                version: "*",
+            },
+            {
+                enabled: false,
+                name: "@honkit/honkit-plugin-no-use",
+                path: "",
+                version: "*",
+            },
+            {
+                enabled: true,
+                name: "example-v",
+                path: "",
+                version: "1.0.0",
+            },
+            {
+                enabled: true,
+                name: "gitbook-plugin-example-v",
+                path: "",
+                version: "1.0.0",
+            },
+            {
+                enabled: true,
+                name: "example",
+                path: "",
+                version: "git+ssh://samy@github.com/GitbookIO/plugin-ga.git",
+            },
+        ]);
+    });
 });


### PR DESCRIPTION
Fix to detect logic about scoped module.
Previously, @scope/honkit-plugin-name is just ignored

This commit fix to load scoped module like `@ansanloms/uml`

- https://github.com/ansanloms/honkit-test

fix #68 
