### PR TITLE
fix(markdown-legacy): normalize some characters for kramed's annotate function

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,6 +11,9 @@ jobs:
         node-version: [10, 12, 14]
         os: [macos-latest, windows-latest, ubuntu-18.04]
     steps:
+      - name: Disable autocrlf
+        run: git config --global core.autocrlf false
+        if: matrix.os == 'windows-latest'
       - name: checkout
         uses: actions/checkout@v2
       - name: setup Node.js ${{ matrix.node-version }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,9 +11,6 @@ jobs:
         node-version: [10, 12, 14]
         os: [macos-latest, windows-latest, ubuntu-18.04]
     steps:
-      - name: Disable autocrlf
-        run: git config --global core.autocrlf false
-        if: matrix.os == 'windows-latest'
       - name: checkout
         uses: actions/checkout@v2
       - name: setup Node.js ${{ matrix.node-version }}

--- a/packages/@honkit/markdown-legacy/__tests__/page.js
+++ b/packages/@honkit/markdown-legacy/__tests__/page.js
@@ -70,6 +70,13 @@ describe("Page parsing", function () {
         assert.equal(page.prepare("```\ntest\n```\n\n\n### Test"), "{% raw %}```\ntest\n```\n{% endraw %}\n\n### Test");
     });
 
+    it("should normalize some characters for kramed's annotate function", function () {
+        assert.equal(
+            page.prepare("Hello\r\nworld\rhello\u2424world\ttest\u00a0"),
+            "Hello\nworld\nhello\nworld    test "
+        );
+    });
+
     it("should not process math", function () {
         assert.equal(page.prepare("Hello $world$"), "Hello $world$");
         assert.equal(page.prepare("Hello $$world$$"), "Hello $$world$$");

--- a/packages/@honkit/markdown-legacy/__tests__/page.js
+++ b/packages/@honkit/markdown-legacy/__tests__/page.js
@@ -31,18 +31,18 @@ describe("Page parsing", function () {
         );
         assert.equal(
             page.prepare("Hello\n```\ntest\n\tworld\n\ttest\n```"),
-            "Hello\n{% raw %}```\ntest\n\tworld\n\ttest\n```{% endraw %}"
+            "Hello\n{% raw %}```\ntest\n    world\n    test\n```{% endraw %}"
         );
     });
 
     it("should escape codeblocks in preparation (2)", function () {
         assert.equal(
             page.prepare("Hello\n\n\n\tworld\n\thello\n\n\ntest"),
-            "Hello\n\n\n{% raw %}\tworld\n\thello\n\n\n{% endraw %}test"
+            "Hello\n\n\n{% raw %}    world\n    hello\n\n\n{% endraw %}test"
         );
         assert.equal(
             page.prepare("Hello\n\n\n\tworld\n\thello\n\n\n"),
-            "Hello\n\n\n{% raw %}\tworld\n\thello\n\n\n{% endraw %}"
+            "Hello\n\n\n{% raw %}    world\n    hello\n\n\n{% endraw %}"
         );
     });
 
@@ -167,16 +167,16 @@ This is the default content
             "{% uml %}
             @startuml
 
-            {% raw %}	Class Stage
-            	Class Timeout {
-            		+constructor:function(cfg)
-            		+timeout:function(ctx)
-            		+overdue:function(ctx)
-            		+stage: Stage
-            	}
-            {% endraw %} 	Stage <|-- Timeout
+            {% raw %}    Class Stage
+                Class Timeout {
+                    +constructor:function(cfg)
+                    +timeout:function(ctx)
+                    +overdue:function(ctx)
+                    +stage: Stage
+                }
+                 Stage <|-- Timeout
 
-            @enduml
+            {% endraw %}@enduml
             {% enduml %}
             "
         `);

--- a/packages/@honkit/markdown-legacy/lib/page.js
+++ b/packages/@honkit/markdown-legacy/lib/page.js
@@ -33,8 +33,8 @@ function combine(nodes) {
     @return {String}
 */
 function preparePage(src) {
-    // annotate.blocks does not normalize src, so windows fail the reason
-    const normalizedSource = src
+    // annotate.blocks does not normalize the following characters
+    var normalizedSource = src
         .replace(/\r\n|\r|\u2424/g, "\n")
         .replace(/\t/g, "    ")
         .replace(/\u00a0/g, " ");

--- a/packages/@honkit/markdown-legacy/lib/page.js
+++ b/packages/@honkit/markdown-legacy/lib/page.js
@@ -33,7 +33,12 @@ function combine(nodes) {
     @return {String}
 */
 function preparePage(src) {
-    var lexed = annotate.blocks(src);
+    // annotate.blocks does not normalize src, so windows fail the reason
+    const normalizedSource = src
+        .replace(/\r\n|\r|\u2424/g, "\n")
+        .replace(/\t/g, "    ")
+        .replace(/\u00a0/g, " ");
+    var lexed = annotate.blocks(normalizedSource);
     var levelRaw = 0;
 
     function escapeCodeElement(el) {

--- a/packages/@honkit/markdown-legacy/lib/page.js
+++ b/packages/@honkit/markdown-legacy/lib/page.js
@@ -33,9 +33,7 @@ function combine(nodes) {
     @return {String}
 */
 function preparePage(src) {
-    // annotate.blocks does not normalize src, so windows fail the reason
-    const normalizedSource = src.replace(/\r\n|\r/g, "\n");
-    var lexed = annotate.blocks(normalizedSource);
+    var lexed = annotate.blocks(src);
     var levelRaw = 0;
 
     function escapeCodeElement(el) {


### PR DESCRIPTION
fix: https://github.com/honkit/honkit/pull/85#discussion_r449770208