### PR TITLE
adding Algorithm Archive to honkit examples

### DIFF
--- a/docs/examples.md
+++ b/docs/examples.md
@@ -11,6 +11,9 @@ Real world examples of content published using HonKit.
 - JavaScript Primer
     - [Website](https://jsprimer.net/)
     - [Source](https://github.com/asciidwango/js-primer)
+- Arcane Algorithm Archive
+    - [Website](https://www.algorithm-archive.org/)
+    - [Source](https://github.com/algorithm-archivists/algorithm-archive)
 
 ## Add to examples
 


### PR DESCRIPTION
I know this is a small change, but we are happily using honkit for the Arcane Algorithm Archive now. Thanks a bunch for all the great work!