### PR TITLE
return if src is null or undefined in resolveImages

### DIFF
--- a/packages/honkit/src/output/modifiers/__tests__/resolveImages.js
+++ b/packages/honkit/src/output/modifiers/__tests__/resolveImages.js
@@ -1,0 +1,41 @@
+const path = require("path");
+const cheerio = require("cheerio");
+const resolveImages = require("../resolveImages");
+
+describe("resolveLinks", () => {
+    describe("img tag", () => {
+        const TEST = '<img src="http://www.github.com">';
+
+        test("no error occurs and return undefined", () => {
+            const $ = cheerio.load(TEST);
+
+            return resolveImages("hello.md", $).then(() => {
+                const src = $("img").attr("src");
+                expect(src).toBe("http://www.github.com");
+            });
+        });
+    });
+    describe("img tag with break line", () => {
+        const TEST = '<img \nsrc="http://www.github.com">';
+
+        test("no error occurs and return undefined", () => {
+            const $ = cheerio.load(TEST);
+            return resolveImages("hello.md", $).then(() => {
+                const src = $("img").attr("src");
+                expect(src).toBe("http://www.github.com");
+            });
+        });
+    });
+    describe("img tag with src with plus sign", () => {
+        const TEST = '<img +src="http://www.github.com">';
+
+        test("no error occurs and return undefined", () => {
+            const $ = cheerio.load(TEST);
+
+            return resolveImages("hello.md", $).then(() => {
+                const src = $("img").attr("src");
+                expect(src).toBe(undefined);
+            });
+        });
+    });
+});

--- a/packages/honkit/src/output/modifiers/__tests__/resolveImages.js
+++ b/packages/honkit/src/output/modifiers/__tests__/resolveImages.js
@@ -2,7 +2,7 @@ const path = require("path");
 const cheerio = require("cheerio");
 const resolveImages = require("../resolveImages");
 
-describe("resolveLinks", () => {
+describe("resolveImages", () => {
     describe("img tag", () => {
         const TEST = '<img src="http://www.github.com">';
 

--- a/packages/honkit/src/output/modifiers/resolveImages.js
+++ b/packages/honkit/src/output/modifiers/resolveImages.js
@@ -16,7 +16,7 @@ function resolveImages(currentFile, $) {
     return editHTMLElement($, "img", ($img) => {
         let src = $img.attr("src");
 
-        if (LocationUtils.isExternal(src) || LocationUtils.isDataURI(src)) {
+        if (src === null || src === undefined || LocationUtils.isExternal(src) || LocationUtils.isDataURI(src)) {
             return;
         }
 


### PR DESCRIPTION
in resolveImages, if src is null or undefined, LocationUtils.toAbsolute occurs error.

This occurs the following content and using gitbook-plugin-changelog.

```
<img
src="....">
```

This file's diff is like the following
```
+<img
+src="...">
```

In this case, resolveImages occurs error  because LocationUtils.toAbsolute used in resolveImages expects src is string.
