### PR TITLE
fix(honkit): fix next/prev button on anchor article

### DIFF
--- a/packages/honkit/src/__tests__/__snapshots__/snapshot-honkit.ts.snap
+++ b/packages/honkit/src/__tests__/__snapshots__/snapshot-honkit.ts.snap
@@ -13184,7 +13184,7 @@ but now stands for &quot;PHP: Hypertext Preprocessor&quot;).
 <hr>
 <div class=\\"btn-group btn-group-justified\\">
     
-    <a class=\\"btn\\" href=\\"markdown.html\\"><b>Previous:</b> Footnotes</a>
+    <a class=\\"btn\\" href=\\"markdown.html\\"><b>Previous:</b> Markdown</a>
     
     
     <a class=\\"btn\\" href=\\"../ebook.html\\"><b>Next:</b> eBook and PDF</a>
@@ -13216,7 +13216,7 @@ but now stands for &quot;PHP: Hypertext Preprocessor&quot;).
 
             
                 
-                <a href=\\"markdown.html#footnotes\\" class=\\"navigation navigation-prev \\" aria-label=\\"Previous page: Footnotes\\">
+                <a href=\\"markdown.html\\" class=\\"navigation navigation-prev \\" aria-label=\\"Previous page: Markdown\\">
                     <i class=\\"fa fa-angle-left\\"></i>
                 </a>
                 
@@ -13339,7 +13339,7 @@ Object {
     <link rel=\\"shortcut icon\\" href=\\"../gitbook/images/favicon.ico\\" type=\\"image/x-icon\\">
 
     
-    <link rel=\\"next\\" href=\\"markdown.html\\" />
+    <link rel=\\"next\\" href=\\"asciidoc.html\\" />
     
     
     <link rel=\\"prev\\" href=\\"../languages.html\\" />
@@ -14056,7 +14056,7 @@ Asterisks
     <a class=\\"btn\\" href=\\"../languages.html\\"><b>Previous:</b> Multi-Lingual</a>
     
     
-    <a class=\\"btn\\" href=\\"markdown.html\\"><b>Next:</b> Headings</a>
+    <a class=\\"btn\\" href=\\"asciidoc.html\\"><b>Next:</b> AsciiDoc</a>
     
 </div>
 
@@ -14090,7 +14090,7 @@ Asterisks
                 </a>
                 
                 
-                <a href=\\"markdown.html#headings\\" class=\\"navigation navigation-next \\" aria-label=\\"Next page: Headings\\">
+                <a href=\\"asciidoc.html\\" class=\\"navigation navigation-next \\" aria-label=\\"Next page: AsciiDoc\\">
                     <i class=\\"fa fa-angle-right\\"></i>
                 </a>
                 

--- a/packages/honkit/src/models/__tests__/summary.ts
+++ b/packages/honkit/src/models/__tests__/summary.ts
@@ -1,30 +1,44 @@
 describe("Summary", () => {
     const File = require("../file");
     const Summary = require("../summary");
-
     const summary = Summary.createFromParts(File(), [
         {
             articles: [
+                // 1.1
                 {
                     title: "My First Article",
-                    ref: "README.md",
+                    ref: "README.md"
                 },
+                // 1.2
                 {
                     title: "My Second Article",
-                    ref: "article.md",
+                    ref: "article.md"
                 },
+                // 1.3
                 {
-                    title: "Article without ref",
+                    title: "My Third Article with anchor",
+                    ref: "article-anchor.md",
+                    articles: [
+                        {
+                            title: "Article with anchor",
+                            ref: "article-anchor.md#anchor"
+                        }
+                    ]
                 },
+                // 1.4
+                {
+                    title: "Article without ref"
+                },
+                // 1.5
                 {
                     title: "Article with absolute ref",
-                    ref: "https://google.fr",
-                },
-            ],
+                    ref: "https://google.fr"
+                }
+            ]
         },
         {
-            title: "Test",
-        },
+            title: "Test"
+        }
     ]);
 
     describe("createFromEntries", () => {
@@ -34,12 +48,35 @@ describe("Summary", () => {
         });
     });
 
+    describe("getNextArticle", function() {
+        it("return next article", function() {
+            const nextArticle = summary.getNextArticle("1.1");
+            expect(nextArticle.getLevel()).toBe("1.2");
+        });
+
+        it("ignore anchor article", function() {
+            const nextArticle = summary.getNextArticle("1.3"); // next is anchor
+            expect(nextArticle.getLevel()).toBe("1.4");
+        });
+    });
+
+    describe("getPrevArticle", function() {
+        it("return prev article", function() {
+            const prevArticle = summary.getPrevArticle("1.2");
+            expect(prevArticle.getLevel()).toBe("1.1");
+        });
+
+        it("ignore anchor article", function() {
+            const prevArticle = summary.getPrevArticle("1.4");
+            expect(prevArticle.getLevel()).toBe("1.3");
+        });
+    });
     describe("getByLevel", () => {
         test("can return a Part", () => {
             const part = summary.getByLevel("1");
 
             expect(part).toBeDefined();
-            expect(part.getArticles().size).toBe(4);
+            expect(part.getArticles().size).toBe(5);
         });
 
         test("can return a Part (2)", () => {

--- a/packages/honkit/src/models/__tests__/summaryArticle.ts
+++ b/packages/honkit/src/models/__tests__/summaryArticle.ts
@@ -64,4 +64,22 @@ describe("SummaryArticle", () => {
             expect(article.isFile(file)).toBe(false);
         });
     });
+
+    describe('hasAnchor', function() {
+        it('must return false when ref does not have anchor', function() {
+            var article = SummaryArticle.create({
+                ref: 'hello.md'
+            }, '1.1');
+
+            expect(article.hasAnchor()).toBe(false);
+        });
+
+        it('must return true when has anchor', function() {
+            var article = SummaryArticle.create({
+                ref: 'hello.md#world'
+            }, '1.1');
+
+            expect(article.hasAnchor()).toBe(true);
+        });
+    });
 });

--- a/packages/honkit/src/models/summary.js
+++ b/packages/honkit/src/models/summary.js
@@ -40,7 +40,7 @@ Summary.prototype.getPart = function (i) {
     if "partIter" is set, it can also return a Part.
 
     @param {Function} iter
-    @param {Function} partIter
+    @param {Function} [partIter]
     @return {Article|Part}
 */
 Summary.prototype.getArticle = function (iter, partIter) {
@@ -104,9 +104,13 @@ Summary.prototype.getNextArticle = function (current) {
     let wasPrev = false;
 
     return this.getArticle((article) => {
-        if (wasPrev) return true;
+        if (wasPrev && !article.hasAnchor()) {
+            return true;
+        }
 
-        wasPrev = article.getLevel() == level;
+        if (!wasPrev) {
+            wasPrev = article.getLevel() === level;
+        }
         return false;
     });
 };
@@ -125,8 +129,9 @@ Summary.prototype.getPrevArticle = function (current) {
         if (article.getLevel() == level) {
             return true;
         }
-
-        prev = article;
+        if (!article.hasAnchor()) {
+            prev = article;
+        }
         return false;
     });
 

--- a/packages/honkit/src/models/summaryArticle.js
+++ b/packages/honkit/src/models/summaryArticle.js
@@ -165,6 +165,16 @@ SummaryArticle.create = function (def, level) {
 };
 
 /**
+ * Has anchor for this article
+ *
+ * @return {Boolean}
+ */
+SummaryArticle.prototype.hasAnchor = function () {
+    const ref = this.getRef();
+    return ref.includes("#");
+};
+
+/**
  * Find an article from a base one
  *
  * @param {Article|Part} base


### PR DESCRIPTION
When next/prev article has anchor(hello.md#anchor), HonKit navigation will ignore it.

For example, The next of `Markdown` page is `Asciidoc`.

`SUMMARY.md`:
```
* [Markdown](syntax/markdown.md)
    * [Headings](syntax/markdown.md#headings)
    * [Paragraphs](syntax/markdown.md#paragraphs)
    * [Lists](syntax/markdown.md#lists)
* [Asciidoc](syntax/asciidoc.md)
```

Previously, The next of `Markdown` was `Headings`, But it is a bug from original GitBook.

- [Fix to ignore anchor points by mizunashi-mana · Pull Request #1467 · GitbookIO/gitbook](https://github.com/GitbookIO/gitbook/pull/1467)

fix https://github.com/honkit/honkit/issues/109