### PR TITLE
v3.6.3: Basic docker support

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -106,14 +106,14 @@ jobs:
       - name: Build image
         if: steps.tag_check.outputs.exists_tag == 'false' && github.event.pull_request.merged == true
         run: |
-          docker build . -t "${PKG_TAG}" --build-arg PACKAGE_VERSION=${PACKAGE_VERSION}
-          docker tag "${PKG_TAG}" "${HUB_TAG}"
-          docker tag "${PKG_TAG}" "${HUB_LATEST_TAG}"
+          docker build . -t "${HUB_TAG}" --build-arg PACKAGE_VERSION=${PACKAGE_VERSION}
+          docker tag "${HUB_TAG}" "${HUB_TAG}"
+          docker tag "${HUB_TAG}" "${HUB_LATEST_TAG}"
         working-directory: ./docker
       - name: Print version
         if: steps.tag_check.outputs.exists_tag == 'false' && github.event.pull_request.merged == true
         run: |
-          docker run --rm ${PKG_TAG} --version
+          docker run --rm ${HUB_TAG} --version
         working-directory: ./docker
       - name: Login to Registries
         if: steps.tag_check.outputs.exists_tag == 'false' && github.event.pull_request.merged == true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,22 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [3.6.3](https://github.com/honkit/honkit/compare/v3.6.1...v3.6.3) (2020-08-31)
+
+
+### Bug Fixes
+
+* change versionup script ([7ed4bb3](https://github.com/honkit/honkit/commit/7ed4bb3d4668e18f016909e29e942f394643735d))
+
+
+### Features
+
+* **docker:** add basic Dockerfile ([4a56826](https://github.com/honkit/honkit/commit/4a568261516e809434521683b67a1659df248530))
+
+
+
+
+
 ## [3.6.2](https://github.com/honkit/honkit/compare/v3.6.1...v3.6.2) (2020-08-31)
 
 

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ HonKit aim to smooth migration from GitBook (Legacy) to HonKit.
 - TypeScript
 - Monorepo codebase
     - Easy to maintain
-- Docker
+- Docker support
 
 ### Migration from GitBook
 

--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ HonKit aim to smooth migration from GitBook (Legacy) to HonKit.
 - TypeScript
 - Monorepo codebase
     - Easy to maintain
+- Docker
 
 ### Migration from GitBook
 

--- a/examples/benchmark/CHANGELOG.md
+++ b/examples/benchmark/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [3.6.3](https://github.com/honkit/honkit/compare/v3.6.1...v3.6.3) (2020-08-31)
+
+**Note:** Version bump only for package @example/benchmark
+
+
+
+
+
 ## [3.6.2](https://github.com/honkit/honkit/compare/v3.6.1...v3.6.2) (2020-08-31)
 
 **Note:** Version bump only for package @example/benchmark

--- a/examples/benchmark/package.json
+++ b/examples/benchmark/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@example/benchmark",
-  "version": "3.6.2",
+  "version": "3.6.3",
   "private": true,
   "description": "benchmark book",
   "license": "MIT",
@@ -27,7 +27,7 @@
     "gitbook-plugin-js-console": "^2.0.4",
     "gitbook-plugin-page-toc-button": "^0.1.1",
     "gitbook-summary-to-path": "^1.1.0",
-    "honkit": "^3.6.2",
+    "honkit": "^3.6.3",
     "jest": "^26.0.1",
     "ts-jest": "^26.1.1"
   }

--- a/examples/book/CHANGELOG.md
+++ b/examples/book/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [3.6.3](https://github.com/honkit/honkit/compare/v3.6.1...v3.6.3) (2020-08-31)
+
+**Note:** Version bump only for package @example/book
+
+
+
+
+
 ## [3.6.2](https://github.com/honkit/honkit/compare/v3.6.1...v3.6.2) (2020-08-31)
 
 **Note:** Version bump only for package @example/book

--- a/examples/book/package.json
+++ b/examples/book/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@example/book",
-  "version": "3.6.2",
+  "version": "3.6.3",
   "private": true,
   "description": "",
   "keywords": [],
@@ -13,6 +13,6 @@
     "help": "honkit --help"
   },
   "devDependencies": {
-    "honkit": "^3.6.2"
+    "honkit": "^3.6.3"
   }
 }

--- a/lerna.json
+++ b/lerna.json
@@ -2,5 +2,5 @@
     "npmClient": "yarn",
     "useWorkspaces": true,
     "includeMergedTags": true,
-    "version": "3.6.2"
+    "version": "3.6.3"
 }

--- a/packages/honkit/CHANGELOG.md
+++ b/packages/honkit/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [3.6.3](https://github.com/honkit/honkit/compare/v3.6.1...v3.6.3) (2020-08-31)
+
+**Note:** Version bump only for package honkit
+
+
+
+
+
 ## [3.6.2](https://github.com/honkit/honkit/compare/v3.6.1...v3.6.2) (2020-08-31)
 
 **Note:** Version bump only for package honkit

--- a/packages/honkit/package.json
+++ b/packages/honkit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "honkit",
-  "version": "3.6.2",
+  "version": "3.6.3",
   "description": "HonKit is building beautiful books using Markdown.",
   "keywords": [
     "git",


### PR DESCRIPTION
We start to support Docker(basic)

- https://hub.docker.com/r/honkit/honkit

## Installation

    docker pull honkit/honkit

## Usage

Show help 

    $ docker run -v `pwd`:`pwd` -w `pwd` --rm -it honkit/honkit honkit  --help

Build

    $ docker run -v `pwd`:`pwd` -w `pwd` --rm -it honkit/honkit honkit build


We need to improve docker support. 
For example, we want to get `ebook-convert` integration for `honkit pdf` or `honkit epub`

refs #32 