### PR TITLE
chore(release): v3.6.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [3.6.4](https://github.com/honkit/honkit/compare/v3.6.3...v3.6.4) (2020-08-31)
+
+
+### Bug Fixes
+
+* **docker:** use latest as default ([ef7f0f1](https://github.com/honkit/honkit/commit/ef7f0f1f8c9a86ae79284d55ab2bc74e4a28481a))
+
+
+
+
+
 ## [3.6.3](https://github.com/honkit/honkit/compare/v3.6.1...v3.6.3) (2020-08-31)
 
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -4,7 +4,7 @@ LABEL maintainer="azu <azuciao@gmail.com>"
 LABEL Description="Docker Container for HonKit"
 
 ARG PACKAGE_VERSION
-ENV PACKAGE_VERSION ${PACKAGE_VERSION:-1.0.0}
+ENV PACKAGE_VERSION ${PACKAGE_VERSION:-latest}
 
 RUN npm install -g honkit@${PACKAGE_VERSION}
 

--- a/examples/benchmark/CHANGELOG.md
+++ b/examples/benchmark/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [3.6.4](https://github.com/honkit/honkit/compare/v3.6.3...v3.6.4) (2020-08-31)
+
+**Note:** Version bump only for package @example/benchmark
+
+
+
+
+
 ## [3.6.3](https://github.com/honkit/honkit/compare/v3.6.1...v3.6.3) (2020-08-31)
 
 **Note:** Version bump only for package @example/benchmark

--- a/examples/benchmark/package.json
+++ b/examples/benchmark/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@example/benchmark",
-  "version": "3.6.3",
+  "version": "3.6.4",
   "private": true,
   "description": "benchmark book",
   "license": "MIT",
@@ -27,7 +27,7 @@
     "gitbook-plugin-js-console": "^2.0.4",
     "gitbook-plugin-page-toc-button": "^0.1.1",
     "gitbook-summary-to-path": "^1.1.0",
-    "honkit": "^3.6.3",
+    "honkit": "^3.6.4",
     "jest": "^26.0.1",
     "ts-jest": "^26.1.1"
   }

--- a/examples/book/CHANGELOG.md
+++ b/examples/book/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [3.6.4](https://github.com/honkit/honkit/compare/v3.6.3...v3.6.4) (2020-08-31)
+
+**Note:** Version bump only for package @example/book
+
+
+
+
+
 ## [3.6.3](https://github.com/honkit/honkit/compare/v3.6.1...v3.6.3) (2020-08-31)
 
 **Note:** Version bump only for package @example/book

--- a/examples/book/package.json
+++ b/examples/book/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@example/book",
-  "version": "3.6.3",
+  "version": "3.6.4",
   "private": true,
   "description": "",
   "keywords": [],
@@ -13,6 +13,6 @@
     "help": "honkit --help"
   },
   "devDependencies": {
-    "honkit": "^3.6.3"
+    "honkit": "^3.6.4"
   }
 }

--- a/lerna.json
+++ b/lerna.json
@@ -2,5 +2,5 @@
     "npmClient": "yarn",
     "useWorkspaces": true,
     "includeMergedTags": true,
-    "version": "3.6.3"
+    "version": "3.6.4"
 }

--- a/packages/honkit/CHANGELOG.md
+++ b/packages/honkit/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [3.6.4](https://github.com/honkit/honkit/compare/v3.6.3...v3.6.4) (2020-08-31)
+
+**Note:** Version bump only for package honkit
+
+
+
+
+
 ## [3.6.3](https://github.com/honkit/honkit/compare/v3.6.1...v3.6.3) (2020-08-31)
 
 **Note:** Version bump only for package honkit

--- a/packages/honkit/package.json
+++ b/packages/honkit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "honkit",
-  "version": "3.6.3",
+  "version": "3.6.4",
   "description": "HonKit is building beautiful books using Markdown.",
   "keywords": [
     "git",


### PR DESCRIPTION
**Fixes**

- **docker**: use latest as default when build without `--build-arg PACKAGE_VERSION=<v>`