### PR TITLE
fix(honkit): fix empty publish

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [3.6.5](https://github.com/honkit/honkit/compare/v3.6.4...v3.6.5) (2020-08-31)
+
+
+### Bug Fixes
+
+* **honkit:** fix empty publish ([92aabd6](https://github.com/honkit/honkit/commit/92aabd68063b3d5079665e5d863b433e13613548))
+
+
+
+
+
 ## [3.6.4](https://github.com/honkit/honkit/compare/v3.6.3...v3.6.4) (2020-08-31)
 
 

--- a/examples/benchmark/CHANGELOG.md
+++ b/examples/benchmark/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [3.6.5](https://github.com/honkit/honkit/compare/v3.6.4...v3.6.5) (2020-08-31)
+
+**Note:** Version bump only for package @example/benchmark
+
+
+
+
+
 ## [3.6.4](https://github.com/honkit/honkit/compare/v3.6.3...v3.6.4) (2020-08-31)
 
 **Note:** Version bump only for package @example/benchmark

--- a/examples/benchmark/package.json
+++ b/examples/benchmark/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@example/benchmark",
-  "version": "3.6.4",
+  "version": "3.6.5",
   "private": true,
   "description": "benchmark book",
   "license": "MIT",
@@ -27,7 +27,7 @@
     "gitbook-plugin-js-console": "^2.0.4",
     "gitbook-plugin-page-toc-button": "^0.1.1",
     "gitbook-summary-to-path": "^1.1.0",
-    "honkit": "^3.6.4",
+    "honkit": "^3.6.5",
     "jest": "^26.0.1",
     "ts-jest": "^26.1.1"
   }

--- a/examples/book/CHANGELOG.md
+++ b/examples/book/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [3.6.5](https://github.com/honkit/honkit/compare/v3.6.4...v3.6.5) (2020-08-31)
+
+**Note:** Version bump only for package @example/book
+
+
+
+
+
 ## [3.6.4](https://github.com/honkit/honkit/compare/v3.6.3...v3.6.4) (2020-08-31)
 
 **Note:** Version bump only for package @example/book

--- a/examples/book/package.json
+++ b/examples/book/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@example/book",
-  "version": "3.6.4",
+  "version": "3.6.5",
   "private": true,
   "description": "",
   "keywords": [],
@@ -13,6 +13,6 @@
     "help": "honkit --help"
   },
   "devDependencies": {
-    "honkit": "^3.6.4"
+    "honkit": "^3.6.5"
   }
 }

--- a/lerna.json
+++ b/lerna.json
@@ -2,5 +2,5 @@
     "npmClient": "yarn",
     "useWorkspaces": true,
     "includeMergedTags": true,
-    "version": "3.6.4"
+    "version": "3.6.5"
 }

--- a/packages/honkit/CHANGELOG.md
+++ b/packages/honkit/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [3.6.5](https://github.com/honkit/honkit/compare/v3.6.4...v3.6.5) (2020-08-31)
+
+
+### Bug Fixes
+
+* **honkit:** fix empty publish ([92aabd6](https://github.com/honkit/honkit/commit/92aabd68063b3d5079665e5d863b433e13613548))
+
+
+
+
+
 ## [3.6.4](https://github.com/honkit/honkit/compare/v3.6.3...v3.6.4) (2020-08-31)
 
 **Note:** Version bump only for package honkit

--- a/packages/honkit/bin/honkit.js
+++ b/packages/honkit/bin/honkit.js
@@ -1,6 +1,6 @@
 #! /usr/bin/env node
 
-require("../lib/src/bin.js")
+require("../lib/bin.js")
     .run()
     .catch((error) => {
         console.error(error);

--- a/packages/honkit/package.json
+++ b/packages/honkit/package.json
@@ -28,8 +28,8 @@
       "email": "samy@gitbook.com"
     }
   ],
-  "main": "lib/src/index.js",
-  "browser": "./lib/src/browser.js",
+  "main": "lib/index.js",
+  "browser": "./lib/browser.js",
   "bin": {
     "honkit": "./bin/honkit.js"
   },

--- a/packages/honkit/package.json
+++ b/packages/honkit/package.json
@@ -39,7 +39,7 @@
     "!__tests__"
   ],
   "scripts": {
-    "prepublish": "npm run build",
+    "prepublish": "npm run clean && npm run build",
     "build": "tsc -p .",
     "clean": "rimraf lib/",
     "test": "jest src",

--- a/packages/honkit/package.json
+++ b/packages/honkit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "honkit",
-  "version": "3.6.4",
+  "version": "3.6.5",
   "description": "HonKit is building beautiful books using Markdown.",
   "keywords": [
     "git",

--- a/packages/honkit/package.json
+++ b/packages/honkit/package.json
@@ -28,8 +28,8 @@
       "email": "samy@gitbook.com"
     }
   ],
-  "main": "lib/index.js",
-  "browser": "./lib/browser.js",
+  "main": "lib/src/index.js",
+  "browser": "./lib/src/browser.js",
   "bin": {
     "honkit": "./bin/honkit.js"
   },
@@ -39,8 +39,8 @@
     "!__tests__"
   ],
   "scripts": {
-    "prepublish": "npm run clean && npm run build",
-    "build": "rimraf lib && tsc -p .",
+    "prepublish": "npm run build",
+    "build": "tsc -p .",
     "clean": "rimraf lib/",
     "test": "jest src",
     "updateSnapshot": "jest src -u"

--- a/packages/honkit/src/bin.ts
+++ b/packages/honkit/src/bin.ts
@@ -1,7 +1,7 @@
 import assert from "assert";
 import { Command } from "commander";
-import pkg from "../package.json";
 import Honkit from "./index";
+const pkg = require("../package.json");
 
 export const run = (argv = process.argv) => {
     const program = new Command();

--- a/packages/honkit/src/constants/defaultPlugins.ts
+++ b/packages/honkit/src/constants/defaultPlugins.ts
@@ -1,6 +1,7 @@
 import Immutable from "immutable";
 import PluginDependency from "../models/pluginDependency";
-import pkg from "../../package.json";
+
+const pkg = require("../../package.json");
 
 /**
  * Create a PluginDependency from a dependency of gitbook

--- a/packages/honkit/src/honkit.ts
+++ b/packages/honkit/src/honkit.ts
@@ -1,7 +1,6 @@
 import semver from "semver";
 
-import pkg from "../package.json";
-
+const pkg = require("../package.json");
 const VERSION = pkg.version;
 const VERSION_STABLE = VERSION.replace(/-(\S+)/g, "");
 

--- a/packages/honkit/tsconfig.json
+++ b/packages/honkit/tsconfig.json
@@ -2,7 +2,7 @@
   "extends": "../../tsconfig.json",
   "compilerOptions": {
     "outDir": "lib",
-    "rootDir": ".",
+    "rootDir": "src",
     "allowJs": true,
     "resolveJsonModule": true
   },


### PR DESCRIPTION
In sometimes, CI publish empty content

- 3.6.0 ~ 3.6.4 has a this bug.

## Issue

tsc copy `package.json` if use `import pkg from "../package.json"`
`npm pack` fail to pack if the package has two package.json

- package.json
- lib
   - package.json

npm pack refer to `lib/package.json`. 
It creates an empty pack

https://github.com/honkit/honkit/pull/123/commits/50e8e4c0855dd1784912ebd59915f30f5cdc7dc4
