### PR TITLE
fix(honkit): fix cache algorithm

### DIFF
--- a/docs/plugins/hooks.md
+++ b/docs/plugins/hooks.md
@@ -21,6 +21,8 @@ Hooks is a method of augmenting or altering the behavior of the process, with cu
 | `page:before` | Called before running the templating engine on the page | Page Object |
 | `page` | Called before outputting and indexing the page. | Page Object |
 
+:memo: HonKit may skip these pages hooks on non-changed page when incremental mode(`honkit serve`)
+
 ##### Page Object
 
 ```js

--- a/packages/honkit/src/output/__tests__/generatePage.ts
+++ b/packages/honkit/src/output/__tests__/generatePage.ts
@@ -1,0 +1,54 @@
+import assert from "assert";
+import generatePage from "../generatePage";
+import { generateMockBook } from "../testing/generateMock";
+import Output from "../../models/output";
+import Immutable from "immutable";
+import generatePages from "../generatePages";
+import Plugin from "../../models/plugin";
+import Plugins from "../../plugins";
+import createMockFS from "../../fs/mock";
+import Book from "../../models/book";
+import parseBook from "../../parse/parseBook";
+import { generateBook } from "../generateBook";
+import JSONGenerator from "../json";
+
+describe("generatePage", function () {
+    it("should call page when call generatePage", async () => {
+        let onPageBeforeCount = 0;
+        let onPageCount = 0;
+        const plugin = new Plugin({
+            name: "testplugin",
+            version: "*",
+            path: "test.js",
+            package: Immutable.fromJS({
+                name: "testplugin",
+            }),
+            content: Immutable.fromJS({
+                hooks: {
+                    "page:before": function (page) {
+                        onPageBeforeCount++;
+                        return page;
+                    },
+                    page: function (page) {
+                        onPageCount++;
+                        return page;
+                    },
+                },
+            }),
+        });
+        const { book, output } = await generateMockBook(JSONGenerator, {
+            "README.md": "Hello World",
+        });
+        // Setup plugin
+        const newOutput = output.merge({
+            plugins: [plugin],
+        });
+        // call twice
+        // @ts-ignore
+        await generatePages(JSONGenerator, newOutput);
+        await generatePages(JSONGenerator, newOutput);
+        // assert
+        assert.strictEqual(onPageBeforeCount, 2);
+        assert.strictEqual(onPageCount, 2);
+    });
+});

--- a/packages/honkit/src/output/__tests__/plugin-hooks.ts
+++ b/packages/honkit/src/output/__tests__/plugin-hooks.ts
@@ -1,19 +1,19 @@
 import assert from "assert";
-import generatePage from "../generatePage";
 import { generateMockBook } from "../testing/generateMock";
-import Output from "../../models/output";
 import Immutable from "immutable";
 import generatePages from "../generatePages";
 import Plugin from "../../models/plugin";
-import Plugins from "../../plugins";
-import createMockFS from "../../fs/mock";
-import Book from "../../models/book";
-import parseBook from "../../parse/parseBook";
-import { generateBook } from "../generateBook";
 import JSONGenerator from "../json";
 
-describe("generatePage", function () {
-    it("should call page when call generatePage", async () => {
+const createOutputWithPlugin = async ({ Generator, plugin, files }) => {
+    const { output } = await generateMockBook(Generator, files);
+    // add plugin
+    return output.merge({
+        plugins: [plugin],
+    });
+};
+describe("plugin-hooks", function () {
+    it(`should be called "page" and "page:before" when generate each pages`, async () => {
         let onPageBeforeCount = 0;
         let onPageCount = 0;
         const plugin = new Plugin({
@@ -36,17 +36,16 @@ describe("generatePage", function () {
                 },
             }),
         });
-        const { book, output } = await generateMockBook(JSONGenerator, {
-            "README.md": "Hello World",
-        });
-        // Setup plugin
-        const newOutput = output.merge({
-            plugins: [plugin],
+        const output = await createOutputWithPlugin({
+            Generator: JSONGenerator,
+            plugin,
+            files: {
+                "README.md": "Hello World",
+            },
         });
         // call twice
-        // @ts-ignore
-        await generatePages(JSONGenerator, newOutput);
-        await generatePages(JSONGenerator, newOutput);
+        await generatePages(JSONGenerator, output);
+        await generatePages(JSONGenerator, output);
         // assert
         assert.strictEqual(onPageBeforeCount, 2);
         assert.strictEqual(onPageCount, 2);

--- a/packages/honkit/src/output/callHook.ts
+++ b/packages/honkit/src/output/callHook.ts
@@ -26,7 +26,6 @@ function callHook(name, getArgument, handleResult, output) {
 
     const logger = output.getLogger();
     const plugins = output.getPlugins();
-
     logger.debug.ln(`calling hook "${name}"`);
 
     // Create the JS context for plugins

--- a/packages/honkit/src/output/generateBook.ts
+++ b/packages/honkit/src/output/generateBook.ts
@@ -154,10 +154,10 @@ function processOutput(generator, output) {
  *
  * @param {Generator} generator
  * @param {Book} book
- * @param {Object} options
+ * @param {Object} [options = {}]
  * @return {Promise<Output>}
  */
-function generateBook(generator, book, options) {
+function generateBook(generator, book, options = {}) {
     options = generator.Options(options);
     const state = generator.State ? generator.State({}) : Immutable.Map();
     const start = Date.now();

--- a/packages/honkit/src/output/generatePages.ts
+++ b/packages/honkit/src/output/generatePages.ts
@@ -29,7 +29,7 @@ function generatePages(generator, output) {
         const absoluteFilePath = path.join(root, file.getPath());
         // incremental build
         if (isIncrementBuilding && !output.incrementalChangeFileSet.has(absoluteFilePath)) {
-            logger.debug.ln(`slkip generate page "${file.getPath()}"`);
+            logger.debug.ln(`skip generate page "${file.getPath()}"`);
             return; // Skip build
         }
         // if has compiled pages, use it instead of compiling page

--- a/packages/honkit/src/output/generatePages.ts
+++ b/packages/honkit/src/output/generatePages.ts
@@ -27,25 +27,12 @@ function generatePages(generator, output) {
         const file = page.getFile();
 
         const absoluteFilePath = path.join(root, file.getPath());
-        // incremental build
+        // When incremental build
         if (isIncrementBuilding && !output.incrementalChangeFileSet.has(absoluteFilePath)) {
             logger.debug.ln(`skip generate page "${file.getPath()}"`);
             return; // Skip build
         }
-        // if has compiled pages, use it instead of compiling page
-        const pageHash = page.hash();
-        const cachedPage = cache.getKey(pageHash);
-        const pagePromise = cachedPage
-            ? // @ts-expect-error ts-migrate(2339) FIXME: Property 'fromJSON' does not exist on type 'Class'... Remove this comment to see the full error message
-              Promise(Page.fromJSON(cachedPage))
-            : generatePage(output, page).then((resultPage) => {
-                  logger.debug.ln(`Update new page "${file.getPath()}"`);
-
-                  // @ts-expect-error ts-migrate(2339) FIXME: Property 'toJSON' does not exist on type 'Class'.
-                  cache.setKey(pageHash, Page.toJSON(resultPage));
-                  return resultPage;
-              });
-        return pagePromise
+        return generatePage(output, page)
             .then((resultPage) => {
                 // It call renderToString
                 // Create page file

--- a/packages/honkit/src/output/page-cache.ts
+++ b/packages/honkit/src/output/page-cache.ts
@@ -1,9 +1,9 @@
 import flatCache from "flat-cache";
 
 export const getCache = () => {
-    return flatCache.create("honkit");
+    return flatCache.create("honkit-3.6.7");
 };
 
 export const clearCache = () => {
-    return flatCache.clearCacheById("honkit");
+    return flatCache.clearCacheById("honkit-3.6.7");
 };

--- a/packages/honkit/src/output/testing/generateMock.ts
+++ b/packages/honkit/src/output/testing/generateMock.ts
@@ -11,11 +11,11 @@ import { generateBook } from "../generateBook";
  *
  * FOR TESTING PURPOSE ONLY
  *
- * @param {Generator}
+ * @param Generator
  * @param {Map<String:String|Map>} files
  * @return {Promise<String>}
  */
-function generateMock(Generator, files) {
+export function generateMockBook(Generator, files) {
     const fs = createMockFS(files);
 
     // @ts-expect-error ts-migrate(2339) FIXME: Property 'createForFS' does not exist on type 'Cla... Remove this comment to see the full error message
@@ -30,7 +30,27 @@ function generateMock(Generator, files) {
                 root: dir.name,
             });
         })
-        .thenResolve(dir.name);
+        .then((output) => {
+            return {
+                book,
+                output,
+                dir: dir.name,
+            };
+        });
+}
+
+/**
+ * Generate a book using a generator
+ * And returns the path to the output dir.
+ *
+ * FOR TESTING PURPOSE ONLY
+ *
+ * @param Generator
+ * @param {Map<String:String|Map>} files
+ * @return {Promise<String>}
+ */
+function generateMock(Generator, files) {
+    return generateMockBook(Generator, files).then((ret) => ret.dir);
 }
 
 export default generateMock;

--- a/packages/honkit/src/parse/parsePageFromString.ts
+++ b/packages/honkit/src/parse/parsePageFromString.ts
@@ -6,6 +6,7 @@ import direction from "direction";
  * Parse a page, its content and the YAMl header
  *
  * @param {Page} page
+ * @param {string} content
  * @return {Page}
  */
 

--- a/packages/honkit/src/plugins/PluginResolver.ts
+++ b/packages/honkit/src/plugins/PluginResolver.ts
@@ -23,10 +23,10 @@ const SPECIAL_PACKAGE_NAME = [
  * - gitbook-plugin-*
  */
 
-class PluginResolver {
-    baseDirectory: any;
+export class PluginResolver {
+    baseDirectory: string;
 
-    constructor(config) {
+    constructor(config: { baseDirectory?: string } = {}) {
         /**
          * @type {string} baseDirectory for resolving
          */
@@ -64,5 +64,3 @@ baseDir: ${baseDir}
         return pkgPath.substring(0, pkgPath.length - "/package.json".length);
     }
 }
-
-exports.PluginResolver = PluginResolver;

--- a/packages/honkit/src/plugins/loadForBook.ts
+++ b/packages/honkit/src/plugins/loadForBook.ts
@@ -1,7 +1,6 @@
 import listDepsForBook from "./listDepsForBook";
 import { loadPlugin } from "./loadPlugin";
 
-// @ts-expect-error ts-migrate(2459) FIXME: Module '"./PluginResolver"' declares 'PluginResolv... Remove this comment to see the full error message
 import { PluginResolver } from "./PluginResolver";
 
 /**

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,11 +1,12 @@
 {
-    "compilerOptions": {
-        "target": "es2018",
-        "module": "commonjs",
-        "strict": false,
-        "esModuleInterop": true,
-        "skipLibCheck": true,
-        "moduleResolution": "node",
-        "forceConsistentCasingInFileNames": true
-    }
+  "compilerOptions": {
+    "target": "es2018",
+    "module": "commonjs",
+    "noEmit": true,
+    "strict": false,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "moduleResolution": "node",
+    "forceConsistentCasingInFileNames": true
+  }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,6 @@
   "compilerOptions": {
     "target": "es2018",
     "module": "commonjs",
-    "noEmit": true,
     "strict": false,
     "esModuleInterop": true,
     "skipLibCheck": true,


### PR DESCRIPTION
Previously, skit "page" and "page:before" hook when HonKit has the cache for page.
However, this logic breaks some plugin like lunr plugin.

This PR fixes it.
HonKit always call `"page"` and `"page:before"`.

fix https://github.com/honkit/honkit/issues/137