### PR TITLE
chore(release): v3.6.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [3.6.8](https://github.com/honkit/honkit/compare/v3.6.6...v3.6.8) (2020-10-22)
+
+
+### Bug Fixes
+
+* **honkit:** call "page" and "page:before" if honkit has the cache ([3742225](https://github.com/honkit/honkit/commit/374222514c41d6164ca1c1804f4c18169c466daa))
+
+
+
+
+
 ## [3.6.7](https://github.com/honkit/honkit/compare/v3.6.6...v3.6.7) (2020-10-22)
 
 

--- a/examples/benchmark/CHANGELOG.md
+++ b/examples/benchmark/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [3.6.8](https://github.com/honkit/honkit/compare/v3.6.6...v3.6.8) (2020-10-22)
+
+**Note:** Version bump only for package @example/benchmark
+
+
+
+
+
 ## [3.6.7](https://github.com/honkit/honkit/compare/v3.6.6...v3.6.7) (2020-10-22)
 
 **Note:** Version bump only for package @example/benchmark

--- a/examples/benchmark/package.json
+++ b/examples/benchmark/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@example/benchmark",
-  "version": "3.6.7",
+  "version": "3.6.8",
   "private": true,
   "description": "benchmark book",
   "license": "MIT",
@@ -27,7 +27,7 @@
     "gitbook-plugin-js-console": "^2.0.4",
     "gitbook-plugin-page-toc-button": "^0.1.1",
     "gitbook-summary-to-path": "^1.1.0",
-    "honkit": "^3.6.7",
+    "honkit": "^3.6.8",
     "jest": "^26.0.1",
     "ts-jest": "^26.1.1"
   }

--- a/examples/book/CHANGELOG.md
+++ b/examples/book/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [3.6.8](https://github.com/honkit/honkit/compare/v3.6.6...v3.6.8) (2020-10-22)
+
+**Note:** Version bump only for package @example/book
+
+
+
+
+
 ## [3.6.7](https://github.com/honkit/honkit/compare/v3.6.6...v3.6.7) (2020-10-22)
 
 **Note:** Version bump only for package @example/book

--- a/examples/book/package.json
+++ b/examples/book/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@example/book",
-  "version": "3.6.7",
+  "version": "3.6.8",
   "private": true,
   "description": "",
   "keywords": [],
@@ -13,6 +13,6 @@
     "help": "honkit --help"
   },
   "devDependencies": {
-    "honkit": "^3.6.7"
+    "honkit": "^3.6.8"
   }
 }

--- a/lerna.json
+++ b/lerna.json
@@ -2,5 +2,5 @@
     "npmClient": "yarn",
     "useWorkspaces": true,
     "includeMergedTags": true,
-    "version": "3.6.7"
+    "version": "3.6.8"
 }

--- a/packages/@honkit/theme-default/CHANGELOG.md
+++ b/packages/@honkit/theme-default/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [3.6.8](https://github.com/honkit/honkit/compare/v3.6.6...v3.6.8) (2020-10-22)
+
+**Note:** Version bump only for package @honkit/honkit-plugin-theme-default
+
+
+
+
+
 ## [3.6.7](https://github.com/honkit/honkit/compare/v3.6.6...v3.6.7) (2020-10-22)
 
 **Note:** Version bump only for package @honkit/honkit-plugin-theme-default

--- a/packages/@honkit/theme-default/package.json
+++ b/packages/@honkit/theme-default/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@honkit/honkit-plugin-theme-default",
-  "version": "3.6.7",
+  "version": "3.6.8",
   "description": "Default theme for HonKit",
   "bugs": {
     "url": "https://github.com/honkit/honkit/issues"

--- a/packages/honkit/CHANGELOG.md
+++ b/packages/honkit/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [3.6.8](https://github.com/honkit/honkit/compare/v3.6.6...v3.6.8) (2020-10-22)
+
+
+### Bug Fixes
+
+* **honkit:** call "page" and "page:before" if honkit has the cache ([3742225](https://github.com/honkit/honkit/commit/374222514c41d6164ca1c1804f4c18169c466daa))
+
+
+
+
+
 ## [3.6.7](https://github.com/honkit/honkit/compare/v3.6.6...v3.6.7) (2020-10-22)
 
 

--- a/packages/honkit/package.json
+++ b/packages/honkit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "honkit",
-  "version": "3.6.7",
+  "version": "3.6.8",
   "description": "HonKit is building beautiful books using Markdown.",
   "keywords": [
     "git",
@@ -47,7 +47,7 @@
   },
   "dependencies": {
     "@honkit/asciidoc": "^3.5.5",
-    "@honkit/honkit-plugin-theme-default": "^3.6.7",
+    "@honkit/honkit-plugin-theme-default": "^3.6.8",
     "@honkit/markdown-legacy": "^3.5.5",
     "bash-color": "0.0.4",
     "cheerio": "^0.20.0",

--- a/packages/honkit/tsconfig.json
+++ b/packages/honkit/tsconfig.json
@@ -2,6 +2,7 @@
   "extends": "../../tsconfig.json",
   "compilerOptions": {
     "outDir": "lib",
+    // for importing package.json
     "rootDir": "src",
     "allowJs": true,
     "resolveJsonModule": true

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,11 +1,76 @@
 {
   "compilerOptions": {
-    "target": "es2018",
+    /* Visit https://aka.ms/tsconfig.json to read more about this file */
+
+    /* Basic Options */
+    // "incremental": true,                   /* Enable incremental compilation */
+    "target": "ES2018",
+    /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019', 'ES2020', or 'ESNEXT'. */
     "module": "commonjs",
+    /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', 'es2020', or 'ESNext'. */
+    // "lib": [],                             /* Specify library files to be included in the compilation. */
+    // "allowJs": true,                       /* Allow javascript files to be compiled. */
+    // "checkJs": true,                       /* Report errors in .js files. */
+    // "jsx": "preserve",                     /* Specify JSX code generation: 'preserve', 'react-native', or 'react'. */
+    // "declaration": true,                   /* Generates corresponding '.d.ts' file. */
+    // "declarationMap": true,                /* Generates a sourcemap for each corresponding '.d.ts' file. */
+    // "sourceMap": true,                     /* Generates corresponding '.map' file. */
+    // "outFile": "./",                       /* Concatenate and emit output to single file. */
+    // "outDir": "./",                        /* Redirect output structure to the directory. */
+    // "rootDir": "./",                       /* Specify the root directory of input files. Use to control the output directory structure with --outDir. */
+    // "composite": true,                     /* Enable project compilation */
+    // "tsBuildInfoFile": "./",               /* Specify file to store incremental compilation information */
+    // "removeComments": true,                /* Do not emit comments to output. */
+    // "noEmit": true,                        /* Do not emit outputs. */
+    // "importHelpers": true,                 /* Import emit helpers from 'tslib'. */
+    // "downlevelIteration": true,            /* Provide full support for iterables in 'for-of', spread, and destructuring when targeting 'ES5' or 'ES3'. */
+    // "isolatedModules": true,               /* Transpile each file as a separate module (similar to 'ts.transpileModule'). */
+
+    /* Strict Type-Checking Options */
     "strict": false,
-    "esModuleInterop": true,
-    "skipLibCheck": true,
+    /* Enable all strict type-checking options. */
+    // "noImplicitAny": true,                 /* Raise error on expressions and declarations with an implied 'any' type. */
+    // "strictNullChecks": true,              /* Enable strict null checks. */
+    // "strictFunctionTypes": true,           /* Enable strict checking of function types. */
+    // "strictBindCallApply": true,           /* Enable strict 'bind', 'call', and 'apply' methods on functions. */
+    // "strictPropertyInitialization": true,  /* Enable strict checking of property initialization in classes. */
+    // "noImplicitThis": true,                /* Raise error on 'this' expressions with an implied 'any' type. */
+    // "alwaysStrict": true,                  /* Parse in strict mode and emit "use strict" for each source file. */
+
+    /* Additional Checks */
+    // "noUnusedLocals": true,                /* Report errors on unused locals. */
+    // "noUnusedParameters": true,            /* Report errors on unused parameters. */
+    // "noImplicitReturns": true,             /* Report error when not all code paths in function return a value. */
+    // "noFallthroughCasesInSwitch": true,    /* Report errors for fallthrough cases in switch statement. */
+
+    /* Module Resolution Options */
     "moduleResolution": "node",
+    /* Specify module resolution strategy: 'node' (Node.js) or 'classic' (TypeScript pre-1.6). */
+    // "baseUrl": "./",                       /* Base directory to resolve non-absolute module names. */
+    // "paths": {},                           /* A series of entries which re-map imports to lookup locations relative to the 'baseUrl'. */
+    // "rootDirs": [],                        /* List of root folders whose combined content represents the structure of the project at runtime. */
+    // "typeRoots": [],                       /* List of folders to include type definitions from. */
+    // "types": [],                           /* Type declaration files to be included in compilation. */
+    // "allowSyntheticDefaultImports": true,  /* Allow default imports from modules with no default export. This does not affect code emit, just typechecking. */
+    "esModuleInterop": true,
+    /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */
+    // "preserveSymlinks": true,              /* Do not resolve the real path of symlinks. */
+    // "allowUmdGlobalAccess": true,          /* Allow accessing UMD globals from modules. */
+
+    /* Source Map Options */
+    // "sourceRoot": "",                      /* Specify the location where debugger should locate TypeScript files instead of source locations. */
+    // "mapRoot": "",                         /* Specify the location where debugger should locate map files instead of generated locations. */
+    // "inlineSourceMap": true,               /* Emit a single file with source maps instead of having a separate file. */
+    // "inlineSources": true,                 /* Emit the source alongside the sourcemaps within a single file; requires '--inlineSourceMap' or '--sourceMap' to be set. */
+
+    /* Experimental Options */
+    // "experimentalDecorators": true,        /* Enables experimental support for ES7 decorators. */
+    // "emitDecoratorMetadata": true,         /* Enables experimental support for emitting type metadata for decorators. */
+
+    /* Advanced Options */
+    "skipLibCheck": true,
+    /* Skip type checking of declaration files. */
     "forceConsistentCasingInFileNames": true
+    /* Disallow inconsistently-cased references to the same file. */
   }
 }


### PR DESCRIPTION
## Fixes

- [Bug: ignore "page" hook of plugin when cache is enabled · Issue #137 · honkit/honkit](https://github.com/honkit/honkit/issues/137)

Previously, skip "page" and "page:before" hook when HonKit has the cache for the page.
However, this logic breaks some plugin like [plugin-lunr](https://github.com/GitbookIO/plugin-lunr).

In 3.6.8, HonKit always call `"page"` and `"page:before"`.