### PR TITLE
fix (parse/listAssets.ts): fix issue #146

### DIFF
--- a/packages/honkit/src/parse/listAssets.ts
+++ b/packages/honkit/src/parse/listAssets.ts
@@ -23,7 +23,8 @@ function listAssets(book, pages) {
     const config = book.getConfig();
     const configFile = config.getFile().getPath();
 
-    function filterFile(file) {
+    function filterFile(rawFile) {
+        const file = rawFile.replace(/\\/g, "/");
         return !(
             file === summaryFile ||
             file === glossaryFile ||


### PR DESCRIPTION
fs.listallFiles returns paths that use '\\' as a path separator on Windows.
`pages` object includes paths that use '/' as a path separator.
So replace all '\\' of path in function filterFile()

fix #146 