### PR TITLE
chore(release): v3.6.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [3.6.11](https://github.com/honkit/honkit/compare/v3.6.10...v3.6.11) (2020-11-10)
+
+**Note:** Version bump only for package honkit
+
+
+
+
+
 ## [3.6.10](https://github.com/honkit/honkit/compare/v3.6.8...v3.6.10) (2020-11-10)
 
 

--- a/examples/benchmark/CHANGELOG.md
+++ b/examples/benchmark/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [3.6.11](https://github.com/honkit/honkit/compare/v3.6.10...v3.6.11) (2020-11-10)
+
+**Note:** Version bump only for package @example/benchmark
+
+
+
+
+
 ## [3.6.10](https://github.com/honkit/honkit/compare/v3.6.8...v3.6.10) (2020-11-10)
 
 **Note:** Version bump only for package @example/benchmark

--- a/examples/benchmark/package.json
+++ b/examples/benchmark/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@example/benchmark",
-  "version": "3.6.10",
+  "version": "3.6.11",
   "private": true,
   "description": "benchmark book",
   "license": "MIT",
@@ -27,7 +27,7 @@
     "gitbook-plugin-js-console": "^2.0.4",
     "gitbook-plugin-page-toc-button": "^0.1.1",
     "gitbook-summary-to-path": "^1.1.0",
-    "honkit": "^3.6.10",
+    "honkit": "^3.6.11",
     "jest": "^26.0.1",
     "ts-jest": "^26.1.1"
   }

--- a/examples/book/CHANGELOG.md
+++ b/examples/book/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [3.6.11](https://github.com/honkit/honkit/compare/v3.6.10...v3.6.11) (2020-11-10)
+
+**Note:** Version bump only for package @example/book
+
+
+
+
+
 ## [3.6.10](https://github.com/honkit/honkit/compare/v3.6.8...v3.6.10) (2020-11-10)
 
 **Note:** Version bump only for package @example/book

--- a/examples/book/package.json
+++ b/examples/book/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@example/book",
-  "version": "3.6.10",
+  "version": "3.6.11",
   "private": true,
   "description": "",
   "keywords": [],
@@ -13,6 +13,6 @@
     "help": "honkit --help"
   },
   "devDependencies": {
-    "honkit": "^3.6.10"
+    "honkit": "^3.6.11"
   }
 }

--- a/lerna.json
+++ b/lerna.json
@@ -2,5 +2,5 @@
     "npmClient": "yarn",
     "useWorkspaces": true,
     "includeMergedTags": true,
-    "version": "3.6.10"
+    "version": "3.6.11"
 }

--- a/packages/@honkit/theme-default/CHANGELOG.md
+++ b/packages/@honkit/theme-default/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [3.6.11](https://github.com/honkit/honkit/compare/v3.6.10...v3.6.11) (2020-11-10)
+
+**Note:** Version bump only for package @honkit/honkit-plugin-theme-default
+
+
+
+
+
 ## [3.6.10](https://github.com/honkit/honkit/compare/v3.6.8...v3.6.10) (2020-11-10)
 
 

--- a/packages/@honkit/theme-default/package.json
+++ b/packages/@honkit/theme-default/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@honkit/honkit-plugin-theme-default",
-  "version": "3.6.10",
+  "version": "3.6.11",
   "description": "Default theme for HonKit",
   "bugs": {
     "url": "https://github.com/honkit/honkit/issues"

--- a/packages/honkit/CHANGELOG.md
+++ b/packages/honkit/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [3.6.11](https://github.com/honkit/honkit/compare/v3.6.10...v3.6.11) (2020-11-10)
+
+**Note:** Version bump only for package honkit
+
+
+
+
+
 ## [3.6.10](https://github.com/honkit/honkit/compare/v3.6.8...v3.6.10) (2020-11-10)
 
 

--- a/packages/honkit/package.json
+++ b/packages/honkit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "honkit",
-  "version": "3.6.10",
+  "version": "3.6.11",
   "description": "HonKit is building beautiful books using Markdown.",
   "keywords": [
     "git",
@@ -47,7 +47,7 @@
   },
   "dependencies": {
     "@honkit/asciidoc": "^3.5.5",
-    "@honkit/honkit-plugin-theme-default": "^3.6.10",
+    "@honkit/honkit-plugin-theme-default": "^3.6.11",
     "@honkit/markdown-legacy": "^3.5.5",
     "bash-color": "0.0.4",
     "cheerio": "^0.20.0",


### PR DESCRIPTION
## Note for npm user

No changes from v3.6.10.

It only includes fixing CI error #149 
It aims to publish a new docker image.