### PR TITLE
fix (output/modifiers): unescape characteres of output html

### DIFF
--- a/packages/honkit/src/__tests__/__fixtures__/honkit/docs/SUMMARY.md
+++ b/packages/honkit/src/__tests__/__fixtures__/honkit/docs/SUMMARY.md
@@ -47,4 +47,8 @@
 * [Examples](examples.md)
 * [Release notes](https://github.com/honkit/honkit/blob/master/CHANGELOG.md)
 
+--
+
+* [Encoding](encoding.md)
+
 

--- a/packages/honkit/src/__tests__/__fixtures__/honkit/docs/encoding.md
+++ b/packages/honkit/src/__tests__/__fixtures__/honkit/docs/encoding.md
@@ -5,7 +5,7 @@
 | Japanese             | こんにちは |
 | Chinese(Simplified)  | 你好 |
 | Portuguese           | olá  |
-| Russin               | приветствие |
+| Russian              | приветствие |
 | Korean               | 안녕하세요 |
 | Emoji (`u+1f91d`)    | 🤝 |
 

--- a/packages/honkit/src/__tests__/__fixtures__/honkit/docs/encoding.md
+++ b/packages/honkit/src/__tests__/__fixtures__/honkit/docs/encoding.md
@@ -1,0 +1,11 @@
+# Encoding
+
+| Category             | Text |
+| --                   | --   |
+| Japanese             | こんにちは |
+| Chinese(Simplified)  | 你好 |
+| Portuguese           | olá  |
+| Russin               | приветствие |
+| Korean               | 안녕하세요 |
+| Emoji (`u+1f91d`)    | 🤝 |
+

--- a/packages/honkit/src/__tests__/__snapshots__/snapshot-honkit.ts.snap
+++ b/packages/honkit/src/__tests__/__snapshots__/snapshot-honkit.ts.snap
@@ -593,6 +593,26 @@ Object {
     
 
     
+        
+        <li class=\\"divider\\"></li>
+        
+        
+    
+        <li class=\\"chapter \\" data-level=\\"5.1\\" data-path=\\"encoding.html\\">
+            
+                <a href=\\"encoding.html\\">
+            
+                    
+                    Encoding
+            
+                </a>
+            
+
+            
+        </li>
+    
+
+    
 
     <li class=\\"divider\\"></li>
 
@@ -1522,6 +1542,26 @@ Object {
     
 
     
+        
+        <li class=\\"divider\\"></li>
+        
+        
+    
+        <li class=\\"chapter \\" data-level=\\"5.1\\" data-path=\\"encoding.html\\">
+            
+                <a href=\\"encoding.html\\">
+            
+                    
+                    Encoding
+            
+                </a>
+            
+
+            
+        </li>
+    
+
+    
 
     <li class=\\"divider\\"></li>
 
@@ -1724,6 +1764,823 @@ $ honkit mobi ./ ./mybook.mobi
 
 ",
   "filePath": "ebook.html",
+  "stats": Object {
+    "isDirectory": false,
+    "isFile": true,
+    "isSocket": false,
+    "isSymbolicLink": false,
+  },
+}
+`;
+
+exports[`HonKit snapshots: encoding.html 1`] = `
+Object {
+  "contents": "
+<!DOCTYPE HTML>
+<html lang=\\"\\" >
+    <head>
+        <meta charset=\\"UTF-8\\">
+        <meta content=\\"text/html; charset=utf-8\\" http-equiv=\\"Content-Type\\">
+        <title>Encoding · HonKit Documentation</title>
+        <meta http-equiv=\\"X-UA-Compatible\\" content=\\"IE=edge\\" />
+        <meta name=\\"description\\" content=\\"\\">
+        
+        
+        
+        
+    
+    <link rel=\\"stylesheet\\" href=\\"gitbook/style.css\\">
+
+    
+            
+                
+                <link rel=\\"stylesheet\\" href=\\"gitbook/gitbook-plugin-highlight/website.css\\">
+                
+            
+                
+                <link rel=\\"stylesheet\\" href=\\"gitbook/gitbook-plugin-search/search.css\\">
+                
+            
+                
+                <link rel=\\"stylesheet\\" href=\\"gitbook/gitbook-plugin-fontsettings/website.css\\">
+                
+            
+        
+
+    
+
+    
+        
+        <link rel=\\"stylesheet\\" href=\\"styles/website.css\\">
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+
+        
+    
+    
+    <meta name=\\"HandheldFriendly\\" content=\\"true\\"/>
+    <meta name=\\"viewport\\" content=\\"width=device-width, initial-scale=1, user-scalable=no\\">
+    <meta name=\\"apple-mobile-web-app-capable\\" content=\\"yes\\">
+    <meta name=\\"apple-mobile-web-app-status-bar-style\\" content=\\"black\\">
+    <link rel=\\"apple-touch-icon-precomposed\\" sizes=\\"152x152\\" href=\\"gitbook/images/apple-touch-icon-precomposed-152.png\\">
+    <link rel=\\"shortcut icon\\" href=\\"gitbook/images/favicon.ico\\" type=\\"image/x-icon\\">
+
+    
+    
+
+    </head>
+    <body>
+        
+<div class=\\"book honkit-cloak\\">
+    <div class=\\"book-summary\\">
+        
+            
+<div id=\\"book-search-input\\" role=\\"search\\">
+    <input type=\\"text\\" placeholder=\\"Type to search\\" />
+</div>
+
+            
+                <nav role=\\"navigation\\">
+                
+
+
+<ul class=\\"summary\\">
+    
+    
+
+    
+
+    
+        
+        <li class=\\"header\\">Getting Started</li>
+        
+        
+    
+        <li class=\\"chapter \\" data-level=\\"1.1\\" data-path=\\"./\\">
+            
+                <a href=\\"./\\">
+            
+                    
+                    About this documentation
+            
+                </a>
+            
+
+            
+        </li>
+    
+        <li class=\\"chapter \\" data-level=\\"1.2\\" data-path=\\"setup.html\\">
+            
+                <a href=\\"setup.html\\">
+            
+                    
+                    Installation and Setup
+            
+                </a>
+            
+
+            
+        </li>
+    
+
+    
+        
+        <li class=\\"header\\">Your Content</li>
+        
+        
+    
+        <li class=\\"chapter \\" data-level=\\"2.1\\" data-path=\\"structure.html\\">
+            
+                <a href=\\"structure.html\\">
+            
+                    
+                    Directory structure
+            
+                </a>
+            
+
+            
+        </li>
+    
+        <li class=\\"chapter \\" data-level=\\"2.2\\" data-path=\\"pages.html\\">
+            
+                <a href=\\"pages.html\\">
+            
+                    
+                    Pages and Summary
+            
+                </a>
+            
+
+            
+        </li>
+    
+        <li class=\\"chapter \\" data-level=\\"2.3\\" data-path=\\"config.html\\">
+            
+                <a href=\\"config.html\\">
+            
+                    
+                    Configuration
+            
+                </a>
+            
+
+            
+        </li>
+    
+        <li class=\\"chapter \\" data-level=\\"2.4\\" data-path=\\"lexicon.html\\">
+            
+                <a href=\\"lexicon.html\\">
+            
+                    
+                    Glossary
+            
+                </a>
+            
+
+            
+        </li>
+    
+        <li class=\\"chapter \\" data-level=\\"2.5\\" data-path=\\"languages.html\\">
+            
+                <a href=\\"languages.html\\">
+            
+                    
+                    Multi-Lingual
+            
+                </a>
+            
+
+            
+        </li>
+    
+        <li class=\\"chapter \\" data-level=\\"2.6\\" data-path=\\"syntax/markdown.html\\">
+            
+                <a href=\\"syntax/markdown.html\\">
+            
+                    
+                    Markdown
+            
+                </a>
+            
+
+            
+            <ul class=\\"articles\\">
+                
+    
+        <li class=\\"chapter \\" data-level=\\"2.6.1\\" data-path=\\"syntax/markdown.html\\">
+            
+                <a href=\\"syntax/markdown.html#headings\\">
+            
+                    
+                    Headings
+            
+                </a>
+            
+
+            
+        </li>
+    
+        <li class=\\"chapter \\" data-level=\\"2.6.2\\" data-path=\\"syntax/markdown.html\\">
+            
+                <a href=\\"syntax/markdown.html#paragraphs\\">
+            
+                    
+                    Paragraphs
+            
+                </a>
+            
+
+            
+        </li>
+    
+        <li class=\\"chapter \\" data-level=\\"2.6.3\\" data-path=\\"syntax/markdown.html\\">
+            
+                <a href=\\"syntax/markdown.html#lists\\">
+            
+                    
+                    Lists
+            
+                </a>
+            
+
+            
+        </li>
+    
+        <li class=\\"chapter \\" data-level=\\"2.6.4\\" data-path=\\"syntax/markdown.html\\">
+            
+                <a href=\\"syntax/markdown.html#links\\">
+            
+                    
+                    Links
+            
+                </a>
+            
+
+            
+        </li>
+    
+        <li class=\\"chapter \\" data-level=\\"2.6.5\\" data-path=\\"syntax/markdown.html\\">
+            
+                <a href=\\"syntax/markdown.html#images\\">
+            
+                    
+                    Images
+            
+                </a>
+            
+
+            
+        </li>
+    
+        <li class=\\"chapter \\" data-level=\\"2.6.6\\" data-path=\\"syntax/markdown.html\\">
+            
+                <a href=\\"syntax/markdown.html#blockquotes\\">
+            
+                    
+                    Blockquotes
+            
+                </a>
+            
+
+            
+        </li>
+    
+        <li class=\\"chapter \\" data-level=\\"2.6.7\\" data-path=\\"syntax/markdown.html\\">
+            
+                <a href=\\"syntax/markdown.html#tables\\">
+            
+                    
+                    Tables
+            
+                </a>
+            
+
+            
+        </li>
+    
+        <li class=\\"chapter \\" data-level=\\"2.6.8\\" data-path=\\"syntax/markdown.html\\">
+            
+                <a href=\\"syntax/markdown.html#code\\">
+            
+                    
+                    Code
+            
+                </a>
+            
+
+            
+        </li>
+    
+        <li class=\\"chapter \\" data-level=\\"2.6.9\\" data-path=\\"syntax/markdown.html\\">
+            
+                <a href=\\"syntax/markdown.html#html\\">
+            
+                    
+                    HTML
+            
+                </a>
+            
+
+            
+        </li>
+    
+        <li class=\\"chapter \\" data-level=\\"2.6.10\\" data-path=\\"syntax/markdown.html\\">
+            
+                <a href=\\"syntax/markdown.html#footnotes\\">
+            
+                    
+                    Footnotes
+            
+                </a>
+            
+
+            
+        </li>
+    
+
+            </ul>
+            
+        </li>
+    
+        <li class=\\"chapter \\" data-level=\\"2.7\\" data-path=\\"syntax/asciidoc.html\\">
+            
+                <a href=\\"syntax/asciidoc.html\\">
+            
+                    
+                    AsciiDoc
+            
+                </a>
+            
+
+            
+        </li>
+    
+        <li class=\\"chapter \\" data-level=\\"2.8\\" data-path=\\"ebook.html\\">
+            
+                <a href=\\"ebook.html\\">
+            
+                    
+                    eBook and PDF
+            
+                </a>
+            
+
+            
+        </li>
+    
+
+    
+        
+        <li class=\\"header\\">Customization</li>
+        
+        
+    
+        <li class=\\"chapter \\" data-level=\\"3.1\\" data-path=\\"templating/\\">
+            
+                <a href=\\"templating/\\">
+            
+                    
+                    Templating
+            
+                </a>
+            
+
+            
+            <ul class=\\"articles\\">
+                
+    
+        <li class=\\"chapter \\" data-level=\\"3.1.1\\" data-path=\\"templating/conrefs.html\\">
+            
+                <a href=\\"templating/conrefs.html\\">
+            
+                    
+                    Content References
+            
+                </a>
+            
+
+            
+        </li>
+    
+        <li class=\\"chapter \\" data-level=\\"3.1.2\\" data-path=\\"templating/variables.html\\">
+            
+                <a href=\\"templating/variables.html\\">
+            
+                    
+                    Variables
+            
+                </a>
+            
+
+            
+        </li>
+    
+        <li class=\\"chapter \\" data-level=\\"3.1.3\\" data-path=\\"templating/builtin.html\\">
+            
+                <a href=\\"templating/builtin.html\\">
+            
+                    
+                    Builtin
+            
+                </a>
+            
+
+            
+        </li>
+    
+
+            </ul>
+            
+        </li>
+    
+        <li class=\\"chapter \\" data-level=\\"3.2\\" data-path=\\"plugins/\\">
+            
+                <a href=\\"plugins/\\">
+            
+                    
+                    Plugins
+            
+                </a>
+            
+
+            
+            <ul class=\\"articles\\">
+                
+    
+        <li class=\\"chapter \\" data-level=\\"3.2.1\\" data-path=\\"plugins/create.html\\">
+            
+                <a href=\\"plugins/create.html\\">
+            
+                    
+                    Create a plugin
+            
+                </a>
+            
+
+            
+        </li>
+    
+        <li class=\\"chapter \\" data-level=\\"3.2.2\\" data-path=\\"plugins/hooks.html\\">
+            
+                <a href=\\"plugins/hooks.html\\">
+            
+                    
+                    Hooks
+            
+                </a>
+            
+
+            
+        </li>
+    
+        <li class=\\"chapter \\" data-level=\\"3.2.3\\" data-path=\\"plugins/blocks.html\\">
+            
+                <a href=\\"plugins/blocks.html\\">
+            
+                    
+                    Blocks
+            
+                </a>
+            
+
+            
+        </li>
+    
+        <li class=\\"chapter \\" data-level=\\"3.2.4\\" data-path=\\"plugins/filters.html\\">
+            
+                <a href=\\"plugins/filters.html\\">
+            
+                    
+                    Filters
+            
+                </a>
+            
+
+            
+        </li>
+    
+        <li class=\\"chapter \\" data-level=\\"3.2.5\\" data-path=\\"plugins/api.html\\">
+            
+                <a href=\\"plugins/api.html\\">
+            
+                    
+                    API & Context
+            
+                </a>
+            
+
+            
+        </li>
+    
+        <li class=\\"chapter \\" data-level=\\"3.2.6\\" data-path=\\"plugins/testing.html\\">
+            
+                <a href=\\"plugins/testing.html\\">
+            
+                    
+                    Test your plugin
+            
+                </a>
+            
+
+            
+        </li>
+    
+
+            </ul>
+            
+        </li>
+    
+        <li class=\\"chapter \\" data-level=\\"3.3\\" data-path=\\"themes/\\">
+            
+                <a href=\\"themes/\\">
+            
+                    
+                    Theming
+            
+                </a>
+            
+
+            
+        </li>
+    
+
+    
+        
+        <li class=\\"divider\\"></li>
+        
+        
+    
+        <li class=\\"chapter \\" data-level=\\"4.1\\" data-path=\\"faq.html\\">
+            
+                <a href=\\"faq.html\\">
+            
+                    
+                    FAQ
+            
+                </a>
+            
+
+            
+        </li>
+    
+        <li class=\\"chapter \\" data-level=\\"4.2\\" data-path=\\"examples.md\\">
+            
+                <span>
+            
+                    
+                    Examples
+            
+                </a>
+            
+
+            
+        </li>
+    
+        <li class=\\"chapter \\" data-level=\\"4.3\\" >
+            
+                <a target=\\"_blank\\" href=\\"https://github.com/honkit/honkit/blob/master/CHANGELOG.md\\">
+            
+                    
+                    Release notes
+            
+                </a>
+            
+
+            
+        </li>
+    
+
+    
+        
+        <li class=\\"divider\\"></li>
+        
+        
+    
+        <li class=\\"chapter active\\" data-level=\\"5.1\\" data-path=\\"encoding.html\\">
+            
+                <a href=\\"encoding.html\\">
+            
+                    
+                    Encoding
+            
+                </a>
+            
+
+            
+        </li>
+    
+
+    
+
+    <li class=\\"divider\\"></li>
+
+    <li>
+        <a href=\\"https://github.com/honkit/honkit\\" target=\\"blank\\" class=\\"gitbook-link\\">
+            Published with HonKit
+        </a>
+    </li>
+</ul>
+
+
+                </nav>
+            
+        
+    </div>
+
+    <div class=\\"book-body\\">
+        
+            <div class=\\"body-inner\\">
+                
+                    
+
+<div class=\\"book-header\\" role=\\"navigation\\">
+    
+
+    <!-- Title -->
+    <h1>
+        <i class=\\"fa fa-circle-o-notch fa-spin\\"></i>
+        <a href=\\".\\" >Encoding</a>
+    </h1>
+</div>
+
+
+
+
+                    <div class=\\"page-wrapper\\" tabindex=\\"-1\\" role=\\"main\\">
+                        <div class=\\"page-inner\\">
+                            
+<div id=\\"book-search-results\\">
+    <div class=\\"search-noresults\\">
+    
+                                <section class=\\"normal markdown-section\\">
+                                
+
+                                <h1 id=\\"encoding\\">Encoding</h1>
+<table>
+<thead>
+<tr>
+<th>Category</th>
+<th>Text</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>Japanese</td>
+<td>こんにちは</td>
+</tr>
+<tr>
+<td>Chinese(Simplified)</td>
+<td>你好</td>
+</tr>
+<tr>
+<td>Portuguese</td>
+<td>olá</td>
+</tr>
+<tr>
+<td>Russian</td>
+<td>приветствие</td>
+</tr>
+<tr>
+<td>Korean</td>
+<td>안녕하세요</td>
+</tr>
+<tr>
+<td>Emoji (<code>u+1f91d</code>)</td>
+<td>🤝</td>
+</tr>
+</tbody>
+</table>
+
+                                
+<hr>
+<div class=\\"btn-group btn-group-justified\\">
+    
+    
+</div>
+
+                                </section>
+                            
+    </div>
+    <div class=\\"search-results\\">
+        <div class=\\"has-results\\">
+            
+            <h1 class=\\"search-results-title\\"><span class='search-results-count'></span> results matching \\"<span class='search-query'></span>\\"</h1>
+            <ul class=\\"search-results-list\\"></ul>
+            
+        </div>
+        <div class=\\"no-results\\">
+            
+            <h1 class=\\"search-results-title\\">No results matching \\"<span class='search-query'></span>\\"</h1>
+            
+        </div>
+    </div>
+</div>
+
+                        </div>
+                    </div>
+                
+            </div>
+
+            
+                
+                
+            
+        
+    </div>
+
+    <script>
+        var gitbook = gitbook || [];
+        gitbook.push(function() {
+            
+        });
+    </script>
+</div>
+
+        
+    <noscript>
+        <style>
+            .honkit-cloak {
+                display: block !important;
+            }
+        </style>
+    </noscript>
+    <script>
+        // Restore sidebar state as critical path for prevent layout shift
+        function __init__getSidebarState(defaultValue){
+            var baseKey = \\"\\";
+            var key = baseKey + \\":sidebar\\";
+            try {
+                var value = localStorage[key];
+                if (value === undefined) {
+                    return defaultValue;
+                }
+                var parsed = JSON.parse(value);
+                return parsed == null ? defaultValue : parsed;
+            } catch (e) {
+                return defaultValue;
+            }
+        }
+        function __init__restoreLastSidebarState() {
+            var isMobile = window.matchMedia(\\"(max-width: 600px)\\").matches;
+            if (isMobile) {
+                // Init last state if not mobile
+                return;
+            }
+            var sidebarState = __init__getSidebarState(true);
+            var book = document.querySelector(\\".book\\");
+            // Show sidebar if it enabled
+            if (sidebarState && book) {
+                book.classList.add(\\"without-animation\\", \\"with-summary\\");
+            }
+        }
+
+        try {
+            __init__restoreLastSidebarState();
+        } finally {
+            var book = document.querySelector(\\".book\\");
+            book.classList.remove(\\"honkit-cloak\\");
+        }
+    </script>
+    <script src=\\"gitbook/gitbook.js\\"></script>
+    <script src=\\"gitbook/theme.js\\"></script>
+    
+        
+        <script src=\\"gitbook/gitbook-plugin-search/search-engine.js\\"></script>
+        
+    
+        
+        <script src=\\"gitbook/gitbook-plugin-search/search.js\\"></script>
+        
+    
+        
+        <script src=\\"gitbook/gitbook-plugin-lunr/lunr.min.js\\"></script>
+        
+    
+        
+        <script src=\\"gitbook/gitbook-plugin-lunr/search-lunr.js\\"></script>
+        
+    
+        
+        <script src=\\"gitbook/gitbook-plugin-fontsettings/fontsettings.js\\"></script>
+        
+    
+
+    </body>
+</html>
+
+",
+  "filePath": "encoding.html",
   "stats": Object {
     "isDirectory": false,
     "isFile": true,
@@ -2317,6 +3174,26 @@ Object {
             
                     
                     Release notes
+            
+                </a>
+            
+
+            
+        </li>
+    
+
+    
+        
+        <li class=\\"divider\\"></li>
+        
+        
+    
+        <li class=\\"chapter \\" data-level=\\"5.1\\" data-path=\\"encoding.html\\">
+            
+                <a href=\\"encoding.html\\">
+            
+                    
+                    Encoding
             
                 </a>
             
@@ -3134,6 +4011,26 @@ Object {
     
 
     
+        
+        <li class=\\"divider\\"></li>
+        
+        
+    
+        <li class=\\"chapter \\" data-level=\\"5.1\\" data-path=\\"encoding.html\\">
+            
+                <a href=\\"encoding.html\\">
+            
+                    
+                    Encoding
+            
+                </a>
+            
+
+            
+        </li>
+    
+
+    
 
     <li class=\\"divider\\"></li>
 
@@ -3918,6 +4815,26 @@ Object {
     
 
     
+        
+        <li class=\\"divider\\"></li>
+        
+        
+    
+        <li class=\\"chapter \\" data-level=\\"5.1\\" data-path=\\"encoding.html\\">
+            
+                <a href=\\"encoding.html\\">
+            
+                    
+                    Encoding
+            
+                </a>
+            
+
+            
+        </li>
+    
+
+    
 
     <li class=\\"divider\\"></li>
 
@@ -3968,7 +4885,7 @@ Object {
 
 <span class=\\"hljs-bullet\\">* </span>[<span class=\\"hljs-string\\">English</span>](<span class=\\"hljs-link\\">en/</span>)
 <span class=\\"hljs-bullet\\">* </span>[<span class=\\"hljs-string\\">French</span>](<span class=\\"hljs-link\\">fr/</span>)
-<span class=\\"hljs-bullet\\">* </span>[<span class=\\"hljs-string\\">Espa&#xF1;ol</span>](<span class=\\"hljs-link\\">es/</span>)
+<span class=\\"hljs-bullet\\">* </span>[<span class=\\"hljs-string\\">Español</span>](<span class=\\"hljs-link\\">es/</span>)
 </code></pre>
 <h3 id=\\"configuration-for-each-language\\">Configuration for each language</h3>
 <p>When a language book (ex: <code>en</code>) has a <code>book.json</code>, its configuration will extend the main configuration.</p>
@@ -4698,6 +5615,26 @@ Object {
             
                     
                     Release notes
+            
+                </a>
+            
+
+            
+        </li>
+    
+
+    
+        
+        <li class=\\"divider\\"></li>
+        
+        
+    
+        <li class=\\"chapter \\" data-level=\\"5.1\\" data-path=\\"encoding.html\\">
+            
+                <a href=\\"encoding.html\\">
+            
+                    
+                    Encoding
             
                 </a>
             
@@ -5486,6 +6423,26 @@ Object {
             
                     
                     Release notes
+            
+                </a>
+            
+
+            
+        </li>
+    
+
+    
+        
+        <li class=\\"divider\\"></li>
+        
+        
+    
+        <li class=\\"chapter \\" data-level=\\"5.1\\" data-path=\\"encoding.html\\">
+            
+                <a href=\\"encoding.html\\">
+            
+                    
+                    Encoding
             
                 </a>
             
@@ -6338,6 +7295,26 @@ Object {
             
                     
                     Release notes
+            
+                </a>
+            
+
+            
+        </li>
+    
+
+    
+        
+        <li class=\\"divider\\"></li>
+        
+        
+    
+        <li class=\\"chapter \\" data-level=\\"5.1\\" data-path=\\"../encoding.html\\">
+            
+                <a href=\\"../encoding.html\\">
+            
+                    
+                    Encoding
             
                 </a>
             
@@ -7202,6 +8179,26 @@ Object {
     
 
     
+        
+        <li class=\\"divider\\"></li>
+        
+        
+    
+        <li class=\\"chapter \\" data-level=\\"5.1\\" data-path=\\"../encoding.html\\">
+            
+                <a href=\\"../encoding.html\\">
+            
+                    
+                    Encoding
+            
+                </a>
+            
+
+            
+        </li>
+    
+
+    
 
     <li class=\\"divider\\"></li>
 
@@ -8013,6 +9010,26 @@ Object {
             
                     
                     Release notes
+            
+                </a>
+            
+
+            
+        </li>
+    
+
+    
+        
+        <li class=\\"divider\\"></li>
+        
+        
+    
+        <li class=\\"chapter \\" data-level=\\"5.1\\" data-path=\\"../encoding.html\\">
+            
+                <a href=\\"../encoding.html\\">
+            
+                    
+                    Encoding
             
                 </a>
             
@@ -8857,6 +9874,26 @@ Object {
     
 
     
+        
+        <li class=\\"divider\\"></li>
+        
+        
+    
+        <li class=\\"chapter \\" data-level=\\"5.1\\" data-path=\\"../encoding.html\\">
+            
+                <a href=\\"../encoding.html\\">
+            
+                    
+                    Encoding
+            
+                </a>
+            
+
+            
+        </li>
+    
+
+    
 
     <li class=\\"divider\\"></li>
 
@@ -9662,6 +10699,26 @@ Object {
             
                     
                     Release notes
+            
+                </a>
+            
+
+            
+        </li>
+    
+
+    
+        
+        <li class=\\"divider\\"></li>
+        
+        
+    
+        <li class=\\"chapter \\" data-level=\\"5.1\\" data-path=\\"../encoding.html\\">
+            
+                <a href=\\"../encoding.html\\">
+            
+                    
+                    Encoding
             
                 </a>
             
@@ -10555,6 +11612,26 @@ Object {
     
 
     
+        
+        <li class=\\"divider\\"></li>
+        
+        
+    
+        <li class=\\"chapter \\" data-level=\\"5.1\\" data-path=\\"../encoding.html\\">
+            
+                <a href=\\"../encoding.html\\">
+            
+                    
+                    Encoding
+            
+                </a>
+            
+
+            
+        </li>
+    
+
+    
 
     <li class=\\"divider\\"></li>
 
@@ -11346,6 +12423,26 @@ Object {
     
 
     
+        
+        <li class=\\"divider\\"></li>
+        
+        
+    
+        <li class=\\"chapter \\" data-level=\\"5.1\\" data-path=\\"../encoding.html\\">
+            
+                <a href=\\"../encoding.html\\">
+            
+                    
+                    Encoding
+            
+                </a>
+            
+
+            
+        </li>
+    
+
+    
 
     <li class=\\"divider\\"></li>
 
@@ -12124,6 +13221,26 @@ Object {
             
                     
                     Release notes
+            
+                </a>
+            
+
+            
+        </li>
+    
+
+    
+        
+        <li class=\\"divider\\"></li>
+        
+        
+    
+        <li class=\\"chapter \\" data-level=\\"5.1\\" data-path=\\"encoding.html\\">
+            
+                <a href=\\"encoding.html\\">
+            
+                    
+                    Encoding
             
                 </a>
             
@@ -12944,6 +14061,26 @@ Object {
             
                     
                     Release notes
+            
+                </a>
+            
+
+            
+        </li>
+    
+
+    
+        
+        <li class=\\"divider\\"></li>
+        
+        
+    
+        <li class=\\"chapter \\" data-level=\\"5.1\\" data-path=\\"encoding.html\\">
+            
+                <a href=\\"encoding.html\\">
+            
+                    
+                    Encoding
             
                 </a>
             
@@ -13794,6 +14931,26 @@ Object {
     
 
     
+        
+        <li class=\\"divider\\"></li>
+        
+        
+    
+        <li class=\\"chapter \\" data-level=\\"5.1\\" data-path=\\"../encoding.html\\">
+            
+                <a href=\\"../encoding.html\\">
+            
+                    
+                    Encoding
+            
+                </a>
+            
+
+            
+        </li>
+    
+
+    
 
     <li class=\\"divider\\"></li>
 
@@ -14608,6 +15765,26 @@ Object {
             
                     
                     Release notes
+            
+                </a>
+            
+
+            
+        </li>
+    
+
+    
+        
+        <li class=\\"divider\\"></li>
+        
+        
+    
+        <li class=\\"chapter \\" data-level=\\"5.1\\" data-path=\\"../encoding.html\\">
+            
+                <a href=\\"../encoding.html\\">
+            
+                    
+                    Encoding
             
                 </a>
             
@@ -15530,6 +16707,26 @@ Object {
     
 
     
+        
+        <li class=\\"divider\\"></li>
+        
+        
+    
+        <li class=\\"chapter \\" data-level=\\"5.1\\" data-path=\\"../encoding.html\\">
+            
+                <a href=\\"../encoding.html\\">
+            
+                    
+                    Encoding
+            
+                </a>
+            
+
+            
+        </li>
+    
+
+    
 
     <li class=\\"divider\\"></li>
 
@@ -16310,6 +17507,26 @@ Object {
             
                     
                     Release notes
+            
+                </a>
+            
+
+            
+        </li>
+    
+
+    
+        
+        <li class=\\"divider\\"></li>
+        
+        
+    
+        <li class=\\"chapter \\" data-level=\\"5.1\\" data-path=\\"../encoding.html\\">
+            
+                <a href=\\"../encoding.html\\">
+            
+                    
+                    Encoding
             
                 </a>
             
@@ -17116,6 +18333,26 @@ Object {
             
                     
                     Release notes
+            
+                </a>
+            
+
+            
+        </li>
+    
+
+    
+        
+        <li class=\\"divider\\"></li>
+        
+        
+    
+        <li class=\\"chapter \\" data-level=\\"5.1\\" data-path=\\"../encoding.html\\">
+            
+                <a href=\\"../encoding.html\\">
+            
+                    
+                    Encoding
             
                 </a>
             
@@ -17954,6 +19191,26 @@ Object {
             
                     
                     Release notes
+            
+                </a>
+            
+
+            
+        </li>
+    
+
+    
+        
+        <li class=\\"divider\\"></li>
+        
+        
+    
+        <li class=\\"chapter \\" data-level=\\"5.1\\" data-path=\\"../encoding.html\\">
+            
+                <a href=\\"../encoding.html\\">
+            
+                    
+                    Encoding
             
                 </a>
             
@@ -18956,6 +20213,26 @@ Object {
             
                     
                     Release notes
+            
+                </a>
+            
+
+            
+        </li>
+    
+
+    
+        
+        <li class=\\"divider\\"></li>
+        
+        
+    
+        <li class=\\"chapter \\" data-level=\\"5.1\\" data-path=\\"../encoding.html\\">
+            
+                <a href=\\"../encoding.html\\">
+            
+                    
+                    Encoding
             
                 </a>
             

--- a/packages/honkit/src/__tests__/__snapshots__/snapshot-honkit.ts.snap
+++ b/packages/honkit/src/__tests__/__snapshots__/snapshot-honkit.ts.snap
@@ -12191,7 +12191,7 @@ Object {
 <pre><code>$ npm install honkit --save-dev
 # or
 $ yarn add honkit --dev
-</code></pre><p>&#x26A0;&#xFE0F; Warning:</p>
+</code></pre><p>⚠️ Warning:</p>
 <ul>
 <li>If you have installed <code>honkit</code> globally(<code>--global</code>) you must install each plugins rule globally(<code>--global</code>) as well</li>
 <li>If you have installed <code>honkit</code> locally you must install each plugins locally as well</li>
@@ -13001,15 +13001,15 @@ Object {
 <p>HonKit uses a simple directory structure. All Markdown/Asciidoc files listed in the <a href=\\"pages.html\\">SUMMARY</a> will be transformed as HTML. Multi-Lingual books have a slightly <a href=\\"languages.html\\">different structure</a>.</p>
 <p>A basic HonKit usually looks something like this:</p>
 <pre><code>.
-&#x251C;&#x2500;&#x2500; book.json
-&#x251C;&#x2500;&#x2500; README.md
-&#x251C;&#x2500;&#x2500; SUMMARY.md
-&#x251C;&#x2500;&#x2500; chapter-1/
-|   &#x251C;&#x2500;&#x2500; README.md
-|   &#x2514;&#x2500;&#x2500; something.md
-&#x2514;&#x2500;&#x2500; chapter-2/
-    &#x251C;&#x2500;&#x2500; README.md
-    &#x2514;&#x2500;&#x2500; something.md
+├── book.json
+├── README.md
+├── SUMMARY.md
+├── chapter-1/
+|   ├── README.md
+|   └── something.md
+└── chapter-2/
+    ├── README.md
+    └── something.md
 </code></pre><p>An overview of what each of these does:</p>
 <table>
 <thead>
@@ -13052,10 +13052,10 @@ bin/*
 </code></pre><h3 id=\\"subdirectory\\">Project integration with subdirectory </h3>
 <p>For software projects, you can use a subdirectory (like <code>docs/</code>) to store the book for the project&apos;s documentation. You can configure the <a href=\\"config.html\\"><code>root</code> option</a> to indicate the folder where HonKit can find the book&apos;s files:</p>
 <pre><code>.
-&#x251C;&#x2500;&#x2500; book.json
-&#x2514;&#x2500;&#x2500; docs/
-    &#x251C;&#x2500;&#x2500; README.md
-    &#x2514;&#x2500;&#x2500; SUMMARY.md
+├── book.json
+└── docs/
+    ├── README.md
+    └── SUMMARY.md
 </code></pre><p>With <code>book.json</code> containing:</p>
 <pre><code>{
     &quot;root&quot;: &quot;./docs&quot;
@@ -14663,7 +14663,7 @@ Object {
 
                                 <h1 id=\\"markdown\\">Markdown</h1>
 <p>Most of the examples from this documentation are in Markdown. Markdown is default parser for HonKit, but one can also opt for the <a href=\\"asciidoc.html\\">AsciiDoc syntax</a>.</p>
-<p>Here&#x2019;s an overview of Markdown syntax that you can use with HonKit (same as GitHub with some additions).</p>
+<p>Here’s an overview of Markdown syntax that you can use with HonKit (same as GitHub with some additions).</p>
 <h3 id=\\"headings\\">Headings</h3>
 <p>To create a heading, add one to six <code>#</code> symbols before your heading text. The number of # you use will determine the size of the heading.</p>
 <pre><code class=\\"lang-markdown\\"><span class=\\"hljs-section\\"># This is an &lt;h1&gt; tag</span>
@@ -14679,7 +14679,7 @@ Object {
 <span class=\\"hljs-section\\"># Hello # {#id}</span>
 </code></pre>
 <h3 id=\\"paragraphs\\">Paragraphs and Line Breaks </h3>
-<p>A paragraph is simply one or more consecutive lines of text, separated by one or more blank lines. (A blank line is any line that looks like a blank line &#x2014; a line containing nothing but spaces or tabs is considered blank.) Normal paragraphs should not be indented with spaces or tabs.</p>
+<p>A paragraph is simply one or more consecutive lines of text, separated by one or more blank lines. (A blank line is any line that looks like a blank line — a line containing nothing but spaces or tabs is considered blank.) Normal paragraphs should not be indented with spaces or tabs.</p>
 <pre><code>Here&apos;s a line for us to start with.
 
 This line is separated from the one above by two newlines, so it will be a *separate paragraph*.
@@ -14697,7 +14697,7 @@ This line is separated from the one above by two newlines, so it will be a *sepa
 <h3 id=\\"lists\\">Lists </h3>
 <p>Markdown supports ordered (numbered) and unordered (bulleted) lists.</p>
 <h5 id=\\"unordered\\">Unordered</h5>
-<p>Unordered lists use asterisks, pluses, and hyphens &#x2014; interchangably &#x2014; as list markers:</p>
+<p>Unordered lists use asterisks, pluses, and hyphens — interchangably — as list markers:</p>
 <pre><code class=\\"lang-markdown\\"><span class=\\"hljs-bullet\\">* </span>Item 1
 <span class=\\"hljs-bullet\\">* </span>Item 2
   * Item 2a
@@ -14746,7 +14746,7 @@ This line is separated from the one above by two newlines, so it will be a *sepa
 </code></pre>
 <p>The pipes on either end of the table are optional. Cells can vary in width and do not need to be perfectly aligned within columns. There must be at least three hyphens in each column of the header row.</p>
 <h3 id=\\"code\\">Code </h3>
-<p>Markdown supports two different code block styles. One uses lines indented with either four spaces or one tab whereas the other uses lines with tilde characters as delimiters &#x2013; therefore the content does not need to be indented:</p>
+<p>Markdown supports two different code block styles. One uses lines indented with either four spaces or one tab whereas the other uses lines with tilde characters as delimiters – therefore the content does not need to be indented:</p>
 <pre><code class=\\"lang-markdown\\">This is a sample code block.
 
 <span class=\\"hljs-code\\">    Continued here.</span>

--- a/packages/honkit/src/output/modifiers/modifyHTML.ts
+++ b/packages/honkit/src/output/modifiers/modifyHTML.ts
@@ -17,7 +17,10 @@ function modifyHTML(page, operations) {
         return op($);
     }).then(() => {
         const resultHTML = $.html();
-        return page.set("content", resultHTML);
+        const unescapedHtml = resultHTML.replace(/&#x([0-9a-f]{4});/gi, (_, code) =>
+            String.fromCharCode(parseInt(code, 16))
+        );
+        return page.set("content", unescapedHtml);
     });
 }
 

--- a/packages/honkit/src/output/modifiers/modifyHTML.ts
+++ b/packages/honkit/src/output/modifiers/modifyHTML.ts
@@ -17,8 +17,8 @@ function modifyHTML(page, operations) {
         return op($);
     }).then(() => {
         const resultHTML = $.html();
-        const unescapedHtml = resultHTML.replace(/&#x([0-9a-f]{4});/gi, (_, code) =>
-            String.fromCharCode(parseInt(code, 16))
+        const unescapedHtml = resultHTML.replace(/&#x([0-9a-f]{2,});/gi, (_, code) =>
+            String.fromCodePoint(parseInt(code, 16))
         );
         return page.set("content", unescapedHtml);
     });


### PR DESCRIPTION
Non-ASCII charcters of  output html files are escaped.
This PR do replace all `&#x<4 hex diigits>;` to unescaped charctares.
As a result, this PR requires update of snapshot.

Close Issue #87