### PR TITLE
Fix browser print layout in default theme

### DIFF
--- a/packages/@honkit/theme-default/src/less/website/body.less
+++ b/packages/@honkit/theme-default/src/less/website/body.less
@@ -4,12 +4,12 @@
     height: 100%;
 
     &.with-summary {
-        @media (min-width: @sidebar-breakpoint) {
+        @media screen and (min-width: @sidebar-breakpoint) {
             .book-body {
                 left: @sidebar-width;
             }
         }
-        @media (max-width: @sidebar-breakpoint) {
+        @media screen and (max-width: @sidebar-breakpoint) {
             overflow: hidden;
 
             .book-body {
@@ -46,7 +46,7 @@
         overflow-y: auto;
     }
 
-    @media (max-width: @mobileMaxWidth) {
+    @media screen and (max-width: @mobileMaxWidth) {
         .transition-transform(@sidebar-transition-duration ease);
         padding-bottom: 20px;
 
@@ -61,4 +61,18 @@
 // It does not enable JavaScript, display by <noscript>
 .honkit-cloak {
     display: none;
+}
+
+@media print {
+    .book {
+        position: static;
+    }
+
+    .book-body {
+        position: static;
+
+        .body-inner {
+            position: static;
+        }
+    }
 }

--- a/packages/@honkit/theme-default/src/less/website/header.less
+++ b/packages/@honkit/theme-default/src/less/website/header.less
@@ -56,7 +56,7 @@
             text-decoration: none;
         }
 
-        @media (max-width: 1000px) {
+        @media screen and (max-width: 1000px) {
             display: none;
         }
 
@@ -82,5 +82,11 @@
                 display: none;
             }
         }
+    }
+}
+
+@media print {
+    .book-header {
+        display: none;
     }
 }

--- a/packages/@honkit/theme-default/src/less/website/navigation.less
+++ b/packages/@honkit/theme-default/src/less/website/navigation.less
@@ -35,7 +35,7 @@
     }
 }
 
-@media (max-width: @mobileMaxWidth) {
+@media screen and (max-width: @mobileMaxWidth) {
     .navigation {
         position: static;
         top: auto;
@@ -51,3 +51,8 @@
     }
 }
 
+@media print {
+    .navigation {
+        display: none;
+    }
+}

--- a/packages/@honkit/theme-default/src/less/website/summary.less
+++ b/packages/@honkit/theme-default/src/less/website/summary.less
@@ -91,7 +91,7 @@
         }
     }
 
-    @media (max-width: @sidebar-breakpoint) {
+    @media screen and (max-width: @sidebar-breakpoint) {
         width: calc(~"100% - 60px");
         bottom: 0px;
         left: -100%;
@@ -109,5 +109,14 @@
         .book-summary {
             .transition(none) !important;
         }
+    }
+}
+
+@media print {
+    .book-summary {
+        display: none;
+    }
+    .book-body {
+        left: 0;
     }
 }


### PR DESCRIPTION
While Honkit has a dedicated `print` command to generate the entire book, users also expect to be able to print a specific page with their browser's "Print" feature. This doesn't currently look great because of a few minor CSS issues.

**Before:**
<img width="1792" alt="before" src="https://user-images.githubusercontent.com/772570/99377482-5cef3080-291a-11eb-9561-654ed399f053.png">

**After:**
<img width="1792" alt="after" src="https://user-images.githubusercontent.com/772570/99377499-624c7b00-291a-11eb-9f1d-9bd4ede47c37.png">
