### PR TITLE
fix(theme-default): fix Uncaught TypeError when click a page

### DIFF
--- a/packages/@honkit/theme-default/src/js/theme/navigation.js
+++ b/packages/@honkit/theme-default/src/js/theme/navigation.js
@@ -367,7 +367,11 @@ function preparePage(resetScroll) {
     updateNavigationPosition();
 
     // Focus on content
-    $pageWrapper.focus({ preventScroll: true });
+    if ($pageWrapper && $pageWrapper[0]) {
+        // use Native focus
+        // https://developer.mozilla.org/en-US/docs/Web/API/HTMLOrForeignElement/focus
+        $pageWrapper[0].focus({ preventScroll: true });
+    }
 
     // Get scroller
     var $scroller = getScroller();


### PR DESCRIPTION
Currently, click body and throw an Error.

```
Uncaught TypeError: ((ke.event.special[i.origType] || {}).handle || i.handler).apply is not a function
    at HTMLDivElement.dispatch (theme.js:2)
    at HTMLDivElement.v.handle (theme.js:2)
```

This PR fixes it.

use native `.focus({ preventScroll :true })` instead of jQuery.
It seems that jQuery does not support  `preventScroll`.

- [jQuery focus without scroll - Stack Overflow](https://stackoverflow.com/questions/4898203/jquery-focus-without-scroll)

fix https://github.com/honkit/honkit/issues/191
refs https://github.com/honkit/honkit/issues/135