### PR TITLE
fix(honkit-plugin-highlight): fix highlight.js warning

### DIFF
--- a/packages/@honkit/honkit-plugin-highlight/index.js
+++ b/packages/@honkit/honkit-plugin-highlight/index.js
@@ -17,6 +17,11 @@ function normalize(lang) {
     return MAP[lower] || lower;
 }
 
+/**
+ * @param {string} lang
+ * @param {string} code
+ * @returns {string|{html: boolean, body}}
+ */
 function highlight(lang, code) {
     if (!lang)
         return {
@@ -28,7 +33,9 @@ function highlight(lang, code) {
     lang = normalize(lang);
 
     try {
-        return hljs.highlight(lang, code).value;
+        return hljs.highlight(code, {
+            language: lang,
+        }).value;
     } catch (e) {
         console.error(e);
     }

--- a/packages/@honkit/honkit-plugin-highlight/package.json
+++ b/packages/@honkit/honkit-plugin-highlight/package.json
@@ -17,7 +17,7 @@
     "css"
   ],
   "dependencies": {
-    "highlight.js": "^10.4.0"
+    "highlight.js": "^10.7.1"
   },
   "devDependencies": {
     "less": "^3.12.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5034,10 +5034,10 @@ he@1.2.0:
   resolved "https://registry.yarnpkg.com/he/-/he-1.2.0.tgz#84ae65fa7eafb165fddb61566ae14baf05664f0f"
   integrity sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==
 
-highlight.js@^10.4.0:
-  version "10.4.1"
-  resolved "https://registry.yarnpkg.com/highlight.js/-/highlight.js-10.4.1.tgz#d48fbcf4a9971c4361b3f95f302747afe19dbad0"
-  integrity sha512-yR5lWvNz7c85OhVAEAeFhVCc/GV4C30Fjzc/rCP0aCWzc1UUOPUk55dK/qdwTZHBvMZo+eZ2jpk62ndX/xMFlg==
+highlight.js@^10.7.1:
+  version "10.7.1"
+  resolved "https://registry.yarnpkg.com/highlight.js/-/highlight.js-10.7.1.tgz#a8ec4152db24ea630c90927d6cae2a45f8ecb955"
+  integrity sha512-S6G97tHGqJ/U8DsXcEdnACbirtbx58Bx9CzIVeYli8OuswCfYI/LsXH2EiGcoGio1KAC3x4mmUwulOllJ2ZyRA==
 
 hmac-drbg@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
Fix a warning

```
Deprecated as of 10.7.0. highlight(lang, code, ...args) has been deprecated.
Deprecated as of 10.7.0. Please use highlight(code, options) instead.
https://github.com/highlightjs/highlight.js/issues/2277
```

fix https://github.com/honkit/honkit/issues/199
refs https://github.com/highlightjs/highlight.js/issues/2277