### PR TITLE
Replace newlines with white space in pdf headers + footers

### DIFF
--- a/packages/honkit/src/output/ebook/getPDFTemplate.ts
+++ b/packages/honkit/src/output/ebook/getPDFTemplate.ts
@@ -37,6 +37,7 @@ function getPDFTemplate(output, type) {
                     },
                 });
             })
+            .then((tplOut) => tplOut.replace(/\n/g, " ")) // PDF templates need to be on one line for inclusion in spawned command
     );
 }
 


### PR DESCRIPTION
Possible fix for https://github.com/honkit/honkit/issues/236