### PR TITLE
fix(honkit): hokit server should not watch node_modules/** changes

### DIFF
--- a/packages/honkit/src/cli/watch.ts
+++ b/packages/honkit/src/cli/watch.ts
@@ -22,7 +22,9 @@ function watch(dir, callback) {
 
     const watcher = chokidar.watch(toWatch, {
         cwd: dir,
-        ignored: "_book/**",
+        // prevent infinity loop
+        // https://github.com/honkit/honkit/issues/269
+        ignored: ["_book/**", "node_modules/**"],
         ignoreInitial: true,
     });
 


### PR DESCRIPTION
Prevent infinitely reload.

fix https://github.com/honkit/honkit/issues/269