### PR TITLE
Fix missing --flat for cpy 9+

### DIFF
--- a/packages/@honkit/theme-default/package.json
+++ b/packages/@honkit/theme-default/package.json
@@ -45,7 +45,7 @@
     "cp": "npm-run-all -p cp:*",
     "cp:favicon": "cpy logo/favicon.ico _assets/website/images/",
     "cp:font-awesome": "cpy font-awesome/fonts/ _assets/website/fonts/fontawesome/",
-    "cp:logo": "cpy logo/apple-touch-icon.png _assets/website/images/ --rename=apple-touch-icon-precomposed-152.png",
+    "cp:logo": "cpy --flat logo/apple-touch-icon.png _assets/website/images/ --rename=apple-touch-icon-precomposed-152.png",
     "prepublish": "npm run build"
   },
   "devDependencies": {

--- a/packages/@honkit/theme-default/package.json
+++ b/packages/@honkit/theme-default/package.json
@@ -43,7 +43,7 @@
     "build:js:theme": "browserify src/js/theme/index.js | uglifyjs -mc > _assets/website/theme.js",
     "clean": "rimraf _assets && mkdirp _assets/ebook/ _assets/website/ _assets/website/fonts _assets/website/images",
     "cp": "npm-run-all -p cp:*",
-    "cp:favicon": "cpy logo/favicon.ico _assets/website/images/",
+    "cp:favicon": "cpy --flat logo/favicon.ico _assets/website/images/",
     "cp:font-awesome": "cpy font-awesome/fonts/ _assets/website/fonts/fontawesome/",
     "cp:logo": "cpy --flat logo/apple-touch-icon.png _assets/website/images/ --rename=apple-touch-icon-precomposed-152.png",
     "prepublish": "npm run build"


### PR DESCRIPTION
Without this, an additional `logo` directory is created leading to a broken reference.

https://github.com/sindresorhus/cpy-cli/pull/34
https://github.com/sindresorhus/cpy/releases/tag/v9.0.0