### PR TITLE
Replace deprecated `fs.rmdir` with `fs.rm`

### DIFF
--- a/packages/honkit/src/utils/fs.ts
+++ b/packages/honkit/src/utils/fs.ts
@@ -93,7 +93,7 @@ function ensureFile(filename) {
 
 // Remove a folder
 function rmDir(base) {
-    return Promise.nfcall(fs.rmdir, base, {
+    return Promise.nfcall(fs.rm, base, {
         recursive: true,
     });
 }


### PR DESCRIPTION
Just a quick PR to fix #285 :)