### PR TITLE
Link to gitbook comparison in home page

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -13,6 +13,8 @@ This documentation has been generated using `honkit`.
 or as an ebook (PDF, ePub or Mobi).
 
 `honkit` is a fork of [GitBook (Legacy)](https://github.com/GitbookIO/gitbook).
+You can read about compatibility, differences and migration from GitBook
+[here](https://github.com/honkit/honkit#fork-of-gitbook).
 
 ### Help and Support
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -4,20 +4,27 @@ This document aims to be a comprehensive guide to the HonKit command line tool.
 
 ### What is HonKit?
 
-`honkit` is a command line tool (and Node.js library) for building beautiful books using GitHub/Git and Markdown (or AsciiDoc). This documentation has been generated using `honkit`.
+`honkit` is a command line tool (and Node.js library)
+for building beautiful books using GitHub/Git and Markdown (or AsciiDoc).
+This documentation has been generated using `honkit`.
 
-`honkit` can output your content as a website ([customizable](themes/README.md) and [extensibles](plugins/README.md)) or as an ebook (PDF, ePub or Mobi).
+`honkit` can output your content as a website
+([customizable](themes/README.md) and [extensibles](plugins/README.md))
+or as an ebook (PDF, ePub or Mobi).
 
 `honkit` is a fork of [GitBook (Legacy)](https://github.com/GitbookIO/gitbook).
 
 ### Help and Support
 
-If you have problems with the toolchain, you can search for or open a discussion on [GitHub](https://github.com/honkit/honkit).
+If you have problems with the toolchain,
+you can search for or open a discussion on [GitHub](https://github.com/honkit/honkit).
 
 ### FAQ
 
-Some questions are frequently asked. If you have a problem you should  [check this out](faq.md) first.
+Some questions are frequently asked.
+If you have a problem you should [check this out](faq.md) first.
 
 ### Contribute to this documentation
 
-You can contribute to improve this documentation on [GitHub](https://github.com/honkit/honkit) by signaling issues or proposing changes.
+You can contribute to improve this documentation on [GitHub](https://github.com/honkit/honkit)
+by signaling issues or proposing changes.


### PR DESCRIPTION
Also use semantic line breaks to make lines shorter and diffs cleaner.
See https://rhodesmill.org/brandon/2012/one-sentence-per-line/ for more info.