### PR TITLE
fix!(asciidoc): correct include::./relative/path/from/content

### DIFF
--- a/packages/@honkit/asciidoc/jest.config.js
+++ b/packages/@honkit/asciidoc/jest.config.js
@@ -1,3 +1,5 @@
 module.exports = {
     preset: "ts-jest",
+    testEnvironment: "node",
+    testMatch: ["**/__tests__/**/*.+(ts|tsx|js)", "**/?(*.)+(spec|test).+(ts|tsx|js)", "!**/lib/**"]
 };

--- a/packages/@honkit/asciidoc/package.json
+++ b/packages/@honkit/asciidoc/package.json
@@ -32,7 +32,7 @@
   ],
   "scripts": {
     "build": "tsc -p .",
-    "test": "yarn build && jest src",
+    "test": "jest src",
     "prepublish": "npm run --if-present build"
   },
   "dependencies": {
@@ -41,7 +41,8 @@
     "lodash": "^4.13.1"
   },
   "devDependencies": {
-    "mocha": "^10.0.0"
+    "jest": "^29.0.3",
+    "ts-jest": "^29.1.1"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/@honkit/asciidoc/src/__tests__/glossary.ts
+++ b/packages/@honkit/asciidoc/src/__tests__/glossary.ts
@@ -1,14 +1,13 @@
 import fs from "fs";
 import path from "path";
 import assert from "assert";
-
-const glossary = require("../").glossary;
+import asciidoc from "../";
 
 let LEXED;
 
 beforeAll(() => {
     const CONTENT = fs.readFileSync(path.join(__dirname, "fixtures/GLOSSARY.adoc"), "utf8");
-    LEXED = glossary(CONTENT);
+    LEXED = asciidoc.glossary(CONTENT);
 });
 
 it("should only get heading + paragraph pairs", () => {
@@ -25,6 +24,6 @@ it("should output simple name/description objects", () => {
 });
 
 it("should correctly convert it to text", () => {
-    const text = glossary.toText(LEXED);
-    assert.deepEqual(glossary(text), LEXED);
+    const text = asciidoc.glossary.toText(LEXED);
+    assert.deepEqual(asciidoc.glossary(text), LEXED);
 });

--- a/packages/@honkit/asciidoc/src/__tests__/inline.js
+++ b/packages/@honkit/asciidoc/src/__tests__/inline.js
@@ -1,7 +1,0 @@
-var assert = require("assert");
-
-var inline = require("../").inline;
-
-it("should render inline AsciiDoc", function () {
-    assert.equal(inline("Hello **World**").content, "Hello <strong>World</strong>");
-});

--- a/packages/@honkit/asciidoc/src/__tests__/inline.ts
+++ b/packages/@honkit/asciidoc/src/__tests__/inline.ts
@@ -1,0 +1,6 @@
+import assert from "assert";
+import asciidoc from "../";
+
+it("should render inline AsciiDoc", function () {
+    assert.equal(asciidoc.inline("Hello **World**").content, "Hello <strong>World</strong>");
+});

--- a/packages/@honkit/asciidoc/src/__tests__/langs.ts
+++ b/packages/@honkit/asciidoc/src/__tests__/langs.ts
@@ -1,14 +1,13 @@
-var fs = require("fs");
-var path = require("path");
-var assert = require("assert");
-
-var langs = require("../").langs;
+import fs from "fs";
+import path from "path";
+import assert from "assert";
+import asciidoc from "../";
 
 var LEXED;
 
 beforeAll(function () {
     var CONTENT = fs.readFileSync(path.join(__dirname, "./fixtures/LANGS.adoc"), "utf8");
-    LEXED = langs(CONTENT);
+    LEXED = asciidoc.langs(CONTENT);
 });
 
 it("should detect paths and titles", function () {
@@ -20,6 +19,6 @@ it("should detect paths and titles", function () {
 });
 
 it("should correctly convert it to text", function () {
-    var text = langs.toText(LEXED);
-    assert.deepEqual(langs(text), LEXED);
+    var text = asciidoc.langs.toText(LEXED);
+    assert.deepEqual(asciidoc.langs(text), LEXED);
 });

--- a/packages/@honkit/asciidoc/src/__tests__/page.ts
+++ b/packages/@honkit/asciidoc/src/__tests__/page.ts
@@ -1,17 +1,16 @@
-const fs = require("fs");
-const path = require("path");
-const assert = require("assert");
-
-const page = require("../").page;
+import path from "path";
+import fs from "fs";
+import assert from "assert";
+import asciidoc from "../";
 
 it("should gen content", function () {
     const CONTENT = fs.readFileSync(path.join(__dirname, "./fixtures/PAGE.adoc"), "utf8");
-    const LEXED = page(CONTENT);
+    const LEXED = asciidoc.page(CONTENT);
     assert(LEXED.content);
 });
 
 it("should include file", function () {
-    const result = page(`= GitBook User Manual
+    const result = asciidoc.page(`= GitBook User Manual
 
 == Usage
 
@@ -22,7 +21,7 @@ include::src/__tests__/fixtures/usage.adoc[]
 });
 
 it("should use font icons by default", function () {
-    const result = page(`= HonKit User Manual
+    const result = asciidoc.page(`= HonKit User Manual
 
 == Install
 
@@ -33,7 +32,7 @@ IMPORTANT: Do not forgot to install \`yarn\`
 });
 
 it("should allow users to override icons attribute", function () {
-    const result = page(`= HonKit User Manual
+    const result = asciidoc.page(`= HonKit User Manual
 // override icons attribute
 :icons:
 

--- a/packages/@honkit/asciidoc/src/__tests__/readme.ts
+++ b/packages/@honkit/asciidoc/src/__tests__/readme.ts
@@ -1,14 +1,13 @@
-var fs = require("fs");
-var path = require("path");
-var assert = require("assert");
-
-var readme = require("../").readme;
+import fs from "fs";
+import path from "path";
+import assert from "assert";
+import asciidoc from "../";
 
 var LEXED;
 
 beforeAll(function () {
     var CONTENT = fs.readFileSync(path.join(__dirname, "./fixtures/README.adoc"), "utf8");
-    LEXED = readme(CONTENT);
+    LEXED = asciidoc.readme(CONTENT);
 });
 
 it("should contain a title", function () {

--- a/packages/@honkit/asciidoc/src/__tests__/summary.ts
+++ b/packages/@honkit/asciidoc/src/__tests__/summary.ts
@@ -1,14 +1,13 @@
-var fs = require("fs");
-var path = require("path");
-var assert = require("assert");
-
-var summary = require("../").summary;
+import fs from "fs";
+import path from "path";
+import assert from "assert";
+import asciidoc from "../";
 
 var LEXED, PART;
 
 beforeAll(function () {
     var CONTENT = fs.readFileSync(path.join(__dirname, "./fixtures/SUMMARY.adoc"), "utf8");
-    LEXED = summary(CONTENT);
+    LEXED = asciidoc.summary(CONTENT);
     PART = LEXED.parts[0];
     // todo: add support for parts in asciidoc
 });
@@ -48,6 +47,6 @@ it("should normalize paths from .md", function () {
 });
 
 it("should correctly convert it to text", function () {
-    var text = summary.toText(LEXED);
-    assert.deepEqual(summary(text), LEXED);
+    var text = asciidoc.summary.toText(LEXED);
+    assert.deepEqual(asciidoc.summary(text), LEXED);
 });

--- a/packages/@honkit/asciidoc/src/index.ts
+++ b/packages/@honkit/asciidoc/src/index.ts
@@ -1,5 +1,5 @@
-import HTMLParser from "@honkit/html";
+import { createParser } from "@honkit/html";
 import toHTML from "./toHTML";
 import toAsciidoc from "./toAsciidoc";
 
-module.exports = HTMLParser.createParser(toHTML, toAsciidoc);
+export default createParser(toHTML, toAsciidoc);

--- a/packages/@honkit/asciidoc/src/toHTML.ts
+++ b/packages/@honkit/asciidoc/src/toHTML.ts
@@ -1,18 +1,23 @@
 import Asciidoctor from "asciidoctor";
+import { ToHTMLFunction } from "@honkit/html";
 
 const asciidoctor = Asciidoctor();
 
 // Render Asciidoc to HTML (block)
-function asciidocToHTML(content: string) {
-    return asciidoctor.convert(content, { safe: "server", attributes: { showtitle: "", icons: "font@" } });
-}
+const asciidocToHTML: ToHTMLFunction = (content: string, options) => {
+    return asciidoctor.convert(content, {
+        safe: "server",
+        attributes: { showtitle: "", icons: "font@" },
+        base_dir: options?.baseDirectory
+    }) as string;
+};
 
 // Render Asciidoc to HTML (inline)
-function asciidocToHTMLInline(content: string) {
-    return asciidoctor.convert(content, { doctype: "inline" });
-}
+const asciidocToHTMLInline: ToHTMLFunction = (content: string, options) => {
+    return asciidoctor.convert(content, { doctype: "inline", base_dir: options?.baseDirectory }) as string;
+};
 
 export default {
     block: asciidocToHTML,
-    inline: asciidocToHTMLInline,
+    inline: asciidocToHTMLInline
 };

--- a/packages/@honkit/asciidoc/tsconfig.json
+++ b/packages/@honkit/asciidoc/tsconfig.json
@@ -1,8 +1,11 @@
 {
-    "include": ["src"],
-    "extends": "../../../tsconfig.json",
-    "compilerOptions": {
-        "outDir": "lib",
-        "rootDir": "src"
-    }
+  "include": [
+    "src"
+  ],
+  "extends": "../../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "lib",
+    "rootDir": "src",
+    "allowJs": true
+  }
 }

--- a/packages/@honkit/html/.mocharc.json
+++ b/packages/@honkit/html/.mocharc.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "https://json.schemastore.org/mocharc",
+  "spec": [
+    "test/**/*.js"
+  ],
+  "extensions": ["ts", "tsx"],
+  "require": "ts-node/register"
+}

--- a/packages/@honkit/html/package.json
+++ b/packages/@honkit/html/package.json
@@ -34,7 +34,7 @@
   "scripts": {
     "build": "tsc -p .",
     "clean": "rimraf lib/",
-    "test": "mocha test/",
+    "test": "mocha",
     "prepublish": "npm run --if-present build"
   },
   "dependencies": {
@@ -43,8 +43,10 @@
     "q": "^1.1.2"
   },
   "devDependencies": {
-    "mocha": "^10.0.0",
-    "rimraf": "^3.0.2"
+    "mocha": "^10.2.0",
+    "rimraf": "^3.0.2",
+    "ts-node": "^10.9.1",
+    "typescript": "^4.8.3"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/@honkit/html/src/langs.ts
+++ b/packages/@honkit/html/src/langs.ts
@@ -6,7 +6,7 @@ import parseSummary from "./summary";
     @param {string} html
     @return {Array}
 */
-function parseLangs(content) {
+function parseLangs(content: string) {
     const parts = parseSummary(content).parts;
     if (parts.length > 0) {
         return parts[0].articles;

--- a/packages/@honkit/html/src/summary.ts
+++ b/packages/@honkit/html/src/summary.ts
@@ -5,11 +5,11 @@ const SELECTOR_LINK = "> a, p > a";
 const SELECTOR_PART = "h2, h3, h4";
 
 /**
-    Find a list
+ Find a list
 
-    @param {cheerio.Node}
-    @return {cheerio.Node}
-*/
+ @param {cheerio.Node}
+ @return {cheerio.Node}
+ */
 function findList($parent) {
     const $container = $parent.children(".olist");
     if ($container.length > 0) $parent = $container.first();
@@ -18,12 +18,12 @@ function findList($parent) {
 }
 
 /**
-    Parse a ul list and return list of chapters recursvely
+ Parse a ul list and return list of chapters recursvely
 
-    @param {cheerio.Node}
-    @param {cheerio.DOM}
-    @return {Array}
-*/
+ @param {cheerio.Node}
+ @param {cheerio.DOM}
+ @return {Array}
+ */
 function parseList($ul, $) {
     const articles = [];
 
@@ -54,11 +54,11 @@ function parseList($ul, $) {
 }
 
 /**
-     Find all parts and their corresponding lists
+ Find all parts and their corresponding lists
 
-     @param {cheerio.Node}
-     @param {cheerio.DOM}
-     @return {Array<{title: String, list: cheerio.Node}>}
+ @param {cheerio.Node}
+ @param {cheerio.DOM}
+ @return {Array<{title: String, list: cheerio.Node}>}
  */
 function findParts($parent, $) {
     // Find parts and lists
@@ -77,7 +77,7 @@ function findParts($parent, $) {
             }
             previousPart = {
                 title: getPartTitle(el, $),
-                list: null,
+                list: null
             };
         } else {
             // It is a list
@@ -86,7 +86,7 @@ function findParts($parent, $) {
             } else {
                 previousPart = {
                     title: "",
-                    list: el,
+                    list: el
                 };
             }
             parts.push(previousPart);
@@ -103,33 +103,38 @@ function findParts($parent, $) {
 }
 
 /**
-    True if the element is a part
+ True if the element is a part
 
-    @param el
-    @return {boolean}
+ @param el
+ @return {boolean}
  */
 function isPartNode(el) {
     return SELECTOR_PART.indexOf(el.name) !== -1;
 }
 
 /**
-    Parse the title of a part element
+ Parse the title of a part element
 
-    @param el
-    @param {cheerio.DOM} $
-    @return {string}
+ @param el
+ @param {cheerio.DOM} $
+ @return {string}
  */
 function getPartTitle(el, $) {
     return $(el).text().trim();
 }
 
-/**
-    Parse an HTML content into a tree of articles/parts
+export type SummaryPart = {
+    title: string;
+    articles: any[]; // TODO: correct type
+};
 
-    @param {string} html
-    @return {Object}
-*/
-function parseSummary(html: string) {
+/**
+ Parse an HTML content into a tree of articles/parts
+
+ @param {string} html
+ @return {Object}
+ */
+function parseSummary(html: string): { parts: SummaryPart[] } {
     const $: any = dom.parse(html);
     const $root = dom.cleanup(dom.root($), $);
 
@@ -142,12 +147,12 @@ function parseSummary(html: string) {
         part = parts[i];
         parsedParts.push({
             title: part.title,
-            articles: parseList($(part.list), $),
+            articles: parseList($(part.list), $)
         });
     }
 
     return {
-        parts: parsedParts,
+        parts: parsedParts
     };
 }
 

--- a/packages/@honkit/html/test/glossary.js
+++ b/packages/@honkit/html/test/glossary.js
@@ -1,15 +1,13 @@
-const fs = require('fs');
-const path = require('path');
-const assert = require('assert');
-
-const glossary = require('../').glossary;
-
+import fs from "fs";
+import path from "path";
+import assert from "assert";
+import html from "../";
 describe('Glossary parsing', () => {
     let LEXED;
 
     before(() => {
         const CONTENT = fs.readFileSync(path.join(__dirname, './fixtures/GLOSSARY.html'), 'utf8');
-        LEXED = glossary(CONTENT);
+        LEXED = html.glossary(CONTENT);
     });
 
     it('should only get heading + paragraph pairs', () => {
@@ -23,7 +21,7 @@ describe('Glossary parsing', () => {
     });
 
     it('should correctly convert it to text', () => {
-        const text = glossary.toText(LEXED);
-        assertObjectsEqual(glossary(text), LEXED);
+        const text = html.glossary.toText(LEXED);
+        assertObjectsEqual(html.glossary(text), LEXED);
     });
 });

--- a/packages/@honkit/html/test/helper.js
+++ b/packages/@honkit/html/test/helper.js
@@ -1,4 +1,4 @@
-const assert = require("assert");
+import assert from "assert";
 
 global.assertObjectsEqual = function(o1, o2) {
     assert.equal(JSON.stringify(o1, null, 4), JSON.stringify(o2, null, 4));

--- a/packages/@honkit/html/test/langs.js
+++ b/packages/@honkit/html/test/langs.js
@@ -1,15 +1,14 @@
-const fs = require('fs');
-const path = require('path');
-const assert = require('assert');
-
-const langs = require('../').langs;
+import html from "../";
+import fs from "fs";
+import path from "path";
+import assert from "assert";
 
 describe('Languages parsing', () => {
     let LEXED;
 
     before(() => {
         const CONTENT = fs.readFileSync(path.join(__dirname, './fixtures/LANGS.html'), 'utf8');
-        LEXED = langs(CONTENT);
+        LEXED = html.langs(CONTENT);
     });
 
     it('should detect paths and titles', () => {
@@ -21,7 +20,7 @@ describe('Languages parsing', () => {
     });
 
     it('should correctly convert it to text', () => {
-        const text = langs.toText(LEXED);
-        assertObjectsEqual(langs(text), LEXED);
+        const text = html.langs.toText(LEXED);
+        assertObjectsEqual(html.langs(text), LEXED);
     });
 });

--- a/packages/@honkit/html/test/readme.js
+++ b/packages/@honkit/html/test/readme.js
@@ -1,30 +1,28 @@
-const fs = require('fs');
-const path = require('path');
-const assert = require('assert');
-
-const readme = require('../').readme;
-
-describe('Readme parsing', () => {
+import fs from "fs";
+import path from "path";
+import assert from "assert";
+import html from "../";
+describe("Readme parsing", () => {
     let LEXED;
-
+    
     before(() => {
-        const CONTENT = fs.readFileSync(path.join(__dirname, './fixtures/README.html'), 'utf8');
-        LEXED = readme(CONTENT);
+        const CONTENT = fs.readFileSync(path.join(__dirname, "./fixtures/README.html"), "utf8");
+        LEXED = html.readme(CONTENT);
     });
-
-    it('should contain a title', () => {
+    
+    it("should contain a title", () => {
         assert(LEXED.title);
     });
-
-    it('should contain a description', () => {
+    
+    it("should contain a description", () => {
         assert(LEXED.description);
     });
-
-    it('should extract the right title', () => {
+    
+    it("should extract the right title", () => {
         assert.equal(LEXED.title, "This is the title");
     });
-
-    it('should extract the right description', () => {
+    
+    it("should extract the right description", () => {
         assert.equal(LEXED.description, "This is the book description.");
     });
 });

--- a/packages/@honkit/html/test/summary.js
+++ b/packages/@honkit/html/test/summary.js
@@ -1,47 +1,46 @@
-const fs = require('fs');
-const path = require('path');
-const assert = require('assert');
+import fs from "fs";
+import path from "path";
+import assert from "assert";
+import html from "../";
 
-const summary = require('../').summary;
-
-describe('Summary parsing', () => {
+describe("Summary parsing", () => {
     let LEXED, PART;
     let LEXED_EMPTY;
-
+    
     before(() => {
         const CONTENT = fs.readFileSync(
-            path.join(__dirname, './fixtures/SUMMARY.html'), 'utf8');
-        LEXED = summary(CONTENT);
+            path.join(__dirname, "./fixtures/SUMMARY.html"), "utf8");
+        LEXED = html.summary(CONTENT);
         PART = LEXED.parts[0];
-
+        
         const CONTENT_EMPTY = fs.readFileSync(
-            path.join(__dirname, './fixtures/SUMMARY-EMPTY.html'), 'utf8');
-        LEXED_EMPTY = summary(CONTENT_EMPTY);
+            path.join(__dirname, "./fixtures/SUMMARY-EMPTY.html"), "utf8");
+        LEXED_EMPTY = html.summary(CONTENT_EMPTY);
     });
-
-    describe('Parts', () => {
-        it('should detect parts', () => {
+    
+    describe("Parts", () => {
+        it("should detect parts", () => {
             assert.equal(LEXED.parts.length, 3);
         });
-
-        it('should detect title', () => {
-            assert.equal(LEXED.parts[0].title, '');
-            assert.equal(LEXED.parts[1].title, 'Part 2');
-            assert.equal(LEXED.parts[2].title, '');
+        
+        it("should detect title", () => {
+            assert.equal(LEXED.parts[0].title, "");
+            assert.equal(LEXED.parts[1].title, "Part 2");
+            assert.equal(LEXED.parts[2].title, "");
         });
-
-        it('should detect empty parts', () => {
+        
+        it("should detect empty parts", () => {
             const partTitles = LEXED_EMPTY.parts.map((part) => {
                 return part.title;
             });
             const expectedTitles = [
-                'First empty part',
-                'Part 1',
-                '',
-                'Empty part',
-                'Part 2',
-                'Penultimate empty part',
-                'Last empty part'
+                "First empty part",
+                "Part 1",
+                "",
+                "Empty part",
+                "Part 2",
+                "Penultimate empty part",
+                "Last empty part"
             ];
             assert.equal(LEXED_EMPTY.parts.length, 7);
             expectedTitles.forEach((title, index) => {
@@ -49,43 +48,43 @@ describe('Summary parsing', () => {
             });
         });
     });
-
-    it('should detect chapters', () => {
+    
+    it("should detect chapters", () => {
         assert.equal(PART.articles.length, 5);
     });
-
-    it('should detect chapters in other parts', () => {
+    
+    it("should detect chapters in other parts", () => {
         assert.equal(LEXED.parts[1].articles.length, 1);
     });
-
-    it('should support articles', () => {
+    
+    it("should support articles", () => {
         assert.equal(PART.articles[0].articles.length, 2);
         assert.equal(PART.articles[1].articles.length, 0);
         assert.equal(PART.articles[2].articles.length, 0);
     });
-
-    it('should detect paths and titles', () => {
+    
+    it("should detect paths and titles", () => {
         assert(PART.articles[0].ref);
         assert(PART.articles[1].ref);
         assert(PART.articles[2].ref);
         assert(PART.articles[3].ref);
         assert.equal(PART.articles[4].ref, null);
-
+        
         assert(PART.articles[0].title);
         assert(PART.articles[1].title);
         assert(PART.articles[2].title);
         assert(PART.articles[3].title);
         assert(PART.articles[4].title);
     });
-
-    it('should normalize paths from .md', () => {
-        assert.equal(PART.articles[0].ref,'chapter-1/README.md');
-        assert.equal(PART.articles[1].ref,'chapter-2/README.md');
-        assert.equal(PART.articles[2].ref,'chapter-3/README.md');
+    
+    it("should normalize paths from .md", () => {
+        assert.equal(PART.articles[0].ref, "chapter-1/README.md");
+        assert.equal(PART.articles[1].ref, "chapter-2/README.md");
+        assert.equal(PART.articles[2].ref, "chapter-3/README.md");
     });
-
-    it('should correctly convert it to text', () => {
-        const text = summary.toText(LEXED);
-        assertObjectsEqual(summary(text), LEXED);
+    
+    it("should correctly convert it to text", () => {
+        const text = html.summary.toText(LEXED);
+        assertObjectsEqual(html.summary(text), LEXED);
     });
 });

--- a/packages/@honkit/html/tsconfig.json
+++ b/packages/@honkit/html/tsconfig.json
@@ -3,6 +3,7 @@
     "extends": "../../../tsconfig.json",
     "compilerOptions": {
         "outDir": "lib",
-        "rootDir": "src"
+        "rootDir": "src",
+        "allowJs": true
     }
 }

--- a/packages/@honkit/markdown-legacy/lib/index.js
+++ b/packages/@honkit/markdown-legacy/lib/index.js
@@ -1,10 +1,10 @@
-var HTMLParser = require("@honkit/html");
+var { createParser } = require("@honkit/html");
 
 var toHTML = require("./toHTML");
 var toMarkdown = require("./toMarkdown");
 var page = require("./page");
 
-module.exports = HTMLParser.createParser(toHTML, toMarkdown);
-
+module.exports = createParser(toHTML, toMarkdown);
 // Add the custom page escaping
+// TODO: remove it. use parser.page.prepare instead
 module.exports.page.prepare = page.prepare;

--- a/packages/@honkit/markdown/jest.config.js
+++ b/packages/@honkit/markdown/jest.config.js
@@ -2,4 +2,5 @@ module.exports = {
     roots: ["src"],
     preset: "ts-jest",
     testEnvironment: "node",
+    testMatch: ["**/__tests__/**/*.+(ts|tsx|js)", "**/?(*.)+(spec|test).+(ts|tsx|js)", "!**/lib/**"]
 };

--- a/packages/@honkit/markdown/package.json
+++ b/packages/@honkit/markdown/package.json
@@ -44,7 +44,7 @@
   },
   "devDependencies": {
     "jest": "^29.0.3",
-    "ts-jest": "^29.0.1"
+    "ts-jest": "^29.1.1"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/@honkit/markdown/src/__tests__/glossary.ts
+++ b/packages/@honkit/markdown/src/__tests__/glossary.ts
@@ -1,9 +1,9 @@
-const fs = require("fs");
-const path = require("path");
-const assert = require("assert");
+import assert from "assert";
+import path from "path";
+import fs from "fs";
+import markdown from "../";
 
-const glossary = require("../").glossary;
-
+const glossary = markdown.glossary;
 describe("Glossary parsing", () => {
     let LEXED;
 

--- a/packages/@honkit/markdown/src/__tests__/inline.ts
+++ b/packages/@honkit/markdown/src/__tests__/inline.ts
@@ -1,9 +1,7 @@
-const fs = require("fs");
-const path = require("path");
-const assert = require("assert");
+import markdown  from "../";
+import assert from "assert";
 
-const inline = require("../").inline;
-
+const inline = markdown.inline;
 describe("Inline", () => {
     it("should render inline markdown", () => {
         assert.equal(inline("Hello **World**").content, "Hello <strong>World</strong>");

--- a/packages/@honkit/markdown/src/__tests__/langs.ts
+++ b/packages/@honkit/markdown/src/__tests__/langs.ts
@@ -1,9 +1,8 @@
-const fs = require("fs");
-const path = require("path");
-const assert = require("assert");
-
-const langs = require("../").langs;
-
+import markdown from "../";
+import assert from "assert";
+import path from "path";
+import fs from "fs";
+const langs = markdown.langs;
 describe("Languages parsing", () => {
     let LEXED;
 

--- a/packages/@honkit/markdown/src/__tests__/page.ts
+++ b/packages/@honkit/markdown/src/__tests__/page.ts
@@ -1,8 +1,8 @@
-const fs = require("fs");
-const path = require("path");
-const assert = require("assert");
-
-const page = require("../").page;
+import path from "path";
+import fs from "fs";
+import assert from "assert";
+import markdown from "../";
+const page = markdown.page;
 
 describe("Page parsing", () => {
     let LEXED;

--- a/packages/@honkit/markdown/src/__tests__/readme.ts
+++ b/packages/@honkit/markdown/src/__tests__/readme.ts
@@ -1,15 +1,15 @@
-const fs = require("fs");
-const path = require("path");
-const assert = require("assert");
+import path from "path";
+import assert from "assert";
+import markdown from "../";
 
-const readme = require("../").readme;
+import fs from "fs";
 
 describe("Readme parsing", () => {
     let LEXED;
 
     beforeAll(() => {
         const CONTENT = fs.readFileSync(path.join(__dirname, "./fixtures/README.md"), "utf8");
-        LEXED = readme(CONTENT);
+        LEXED = markdown.readme(CONTENT);
     });
 
     it("should contain a title", () => {

--- a/packages/@honkit/markdown/src/__tests__/summary.ts
+++ b/packages/@honkit/markdown/src/__tests__/summary.ts
@@ -1,15 +1,14 @@
-const fs = require("fs");
-const path = require("path");
-const assert = require("assert");
-
-const summary = require("../").summary;
+import path from "path";
+import assert from "assert";
+import fs from "fs";
+import markdown from "../";
 
 function lex(fixtureFile) {
-    return summary(fs.readFileSync(path.join(__dirname, "fixtures", fixtureFile), "utf8"));
+    return markdown.summary(fs.readFileSync(path.join(__dirname, "fixtures", fixtureFile), "utf8"));
 }
 
 describe("Summary parsing", () => {
-    let LEXED;
+    let LEXED, PART;
 
     beforeAll(() => {
         LEXED = lex("SUMMARY.md");
@@ -62,7 +61,7 @@ describe("Summary parsing", () => {
     });
 
     it("should correctly convert it to text", () => {
-        const text = summary.toText(LEXED);
-        assert.deepEqual(summary(text), LEXED);
+        const text = markdown.summary.toText(LEXED);
+        assert.deepEqual(markdown.summary(text), LEXED);
     });
 });

--- a/packages/@honkit/markdown/src/index.ts
+++ b/packages/@honkit/markdown/src/index.ts
@@ -1,10 +1,9 @@
-import HTMLParser from "@honkit/html";
-
+import { createParser } from "@honkit/html";
 import toHTML from "./toHTML";
 import toMarkdown from "./toMarkdown";
-import page from "./page";
+import { preparePage } from "./page";
 
-module.exports = HTMLParser.createParser(toHTML, toMarkdown);
-
+const markdownParser = createParser(toHTML, toMarkdown);
 // Add the custom page escaping
-module.exports.page.prepare = page.prepare;
+markdownParser.page.prepare = preparePage;
+export default markdownParser;

--- a/packages/@honkit/markdown/src/page.ts
+++ b/packages/@honkit/markdown/src/page.ts
@@ -1,9 +1,10 @@
-const MarkupIt = require("@honkit/markup-it");
+import * as MarkupIt from "@honkit/markup-it";
+
 const gitbookSyntax = require("@honkit/markup-it/syntaxes/markdown");
 
 const RAW_START = "{% raw %}";
 const RAW_END = "{% endraw %}";
-const markdown = new MarkupIt(gitbookSyntax);
+const markdown = new MarkupIt.default(gitbookSyntax);
 
 /**
  * Escape a code block's content using raw blocks
@@ -22,11 +23,11 @@ function escape(str: string) {
  * @param {string} src
  * @return {string}
  */
-function preparePage(src) {
+export function preparePage(src: string) {
     let levelRaw = 0;
     const content = markdown.toContent(src, {
         math: true,
-        template: true,
+        template: true
     });
 
     const textMarkdown = markdown.toText(content, {
@@ -51,12 +52,8 @@ function preparePage(src) {
             }
 
             return raw;
-        },
+        }
     });
 
     return textMarkdown;
 }
-
-export default {
-    prepare: preparePage,
-};

--- a/packages/@honkit/markdown/src/toHTML.ts
+++ b/packages/@honkit/markdown/src/toHTML.ts
@@ -1,9 +1,9 @@
-import MarkupIt from "@honkit/markup-it";
+import { Markup } from "@honkit/markup-it";
 import markdownSyntax from "@honkit/markup-it/syntaxes/markdown";
 import htmlSyntax from "@honkit/markup-it/syntaxes/html";
 
-const markdown = new MarkupIt(markdownSyntax);
-const html = new MarkupIt(htmlSyntax);
+const markdown = new Markup(markdownSyntax);
+const html = new Markup(htmlSyntax);
 
 /**
  * Convert Markdown block to HTML
@@ -33,5 +33,5 @@ function convertMdToHTMLInline(src) {
 
 export default {
     block: convertMdToHTMLBlock,
-    inline: convertMdToHTMLInline,
+    inline: convertMdToHTMLInline
 };

--- a/packages/@honkit/markup-it/jest.config.js
+++ b/packages/@honkit/markup-it/jest.config.js
@@ -2,5 +2,6 @@ module.exports = {
     roots: ["."],
     preset: "ts-jest",
     setupFilesAfterEnv: ["./testing/setup.js"],
-    testEnvironment: "node",
+    testMatch: ["**/__tests__/**/*.{js,ts}", "!**/lib/**"],
+    testEnvironment: "node"
 };

--- a/packages/@honkit/markup-it/src/__tests__/syntax.ts
+++ b/packages/@honkit/markup-it/src/__tests__/syntax.ts
@@ -1,5 +1,5 @@
 // @ts-ignore
-import MarkupIt from "..";
+import * as MarkupIt from "..";
 
 describe("Custom Syntax", () => {
     const syntax = MarkupIt.Syntax("mysyntax", {
@@ -13,7 +13,7 @@ describe("Custom Syntax", () => {
                 .toText("**%s**"),
         ],
     });
-    const markup = new MarkupIt(syntax);
+    const markup = new MarkupIt.Markup(syntax);
 
     describe(".toContent", () => {
         it("should return correct syntax name", () => {

--- a/packages/@honkit/markup-it/src/index.ts
+++ b/packages/@honkit/markup-it/src/index.ts
@@ -18,25 +18,26 @@ import JSONUtils from "./json";
 import genKey from "./utils/genKey";
 import transform from "./utils/transform";
 
-module.exports = Markup;
+export default Markup;
+export { Markup };
 
 // Method
-module.exports.parse = parse;
-module.exports.render = render;
+export { parse };
+export { render };
 
 // Models
-module.exports.Content = Content;
-module.exports.Token = Token;
-module.exports.Syntax = Syntax;
-module.exports.Rule = Rule;
-module.exports.RulesSet = RulesSet;
+export { Content };
+export { Token };
+export { Syntax };
+export { Rule };
+export { RulesSet };
 
 // Utils
-module.exports.JSONUtils = JSONUtils;
-module.exports.genKey = genKey;
-module.exports.transform = transform;
+export { JSONUtils };
+export { genKey };
+export { transform };
 
 // Constants
-module.exports.STYLES = STYLES;
-module.exports.ENTITIES = ENTITIES;
-module.exports.BLOCKS = BLOCKS;
+export { STYLES };
+export { ENTITIES };
+export { BLOCKS };

--- a/packages/@honkit/markup-it/src/markup.ts
+++ b/packages/@honkit/markup-it/src/markup.ts
@@ -1,55 +1,54 @@
 import parse from "./parse";
 import render from "./render";
 
-/**
- * Create an instance using a set of rules
- * @param {Syntax} syntax
- */
-function DraftMarkup(syntax) {
-    if (!(this instanceof DraftMarkup)) {
-        // @ts-ignore
-        return new DraftMarkup(syntax);
+class DraftMarkup {
+    private syntax: any;
+
+    /**
+     * Create an instance using a set of rules
+     * @param {Syntax} syntax
+     */
+    constructor(syntax: any) {
+        this.syntax = syntax;
     }
 
-    this.syntax = syntax;
+    /**
+     * Convert a text into an inline parsed content
+     * @param  {string} text
+     * @return {List<Tokens>}
+     */
+    toInlineText(tokens) {
+        return render.asInline(this.syntax, tokens);
+    }
+
+    /**
+     * Convert a content to text
+     * @param  {ContentState} content
+     * @param  {Object} options
+     * @return {string}
+     */
+    toContent(text, options?: {}) {
+        return parse(this.syntax, text, options);
+    }
+
+    /**
+     * Convert a text into an inline parsed content
+     * @param  {string} text
+     * @return {List<Tokens>}
+     */
+    toInlineContent(text) {
+        return parse.asInline(this.syntax, text);
+    }
+
+    /**
+     * Convert a content to text
+     * @param  {ContentState} content
+     * @param  {Object} options
+     * @return {string}
+     */
+    toText(content, options?: {}) {
+        return render(this.syntax, content, options);
+    }
 }
-
-/**
- * Convert a text into a parsed content
- * @param  {string} text
- * @return {ContentState}
- */
-DraftMarkup.prototype.toContent = function toContent(text, options) {
-    return parse(this.syntax, text, options);
-};
-
-/**
- * Convert a text into an inline parsed content
- * @param  {string} text
- * @return {List<Tokens>}
- */
-DraftMarkup.prototype.toInlineContent = function toInlineContent(text) {
-    // @ts-ignore
-    return parse.asInline(this.syntax, text);
-};
-
-/**
- * Convert a content to text
- * @param  {ContentState} content
- * @param  {Object} options
- * @return {string}
- */
-DraftMarkup.prototype.toText = function toText(content, options) {
-    return render(this.syntax, content, options);
-};
-
-/**
- * Convert a content to text
- * @param  {List<Tokens>}
- * @return {string}
- */
-DraftMarkup.prototype.toInlineText = function toInlineText(tokens) {
-    return render.asInline(this.syntax, tokens);
-};
 
 export default DraftMarkup;

--- a/packages/@honkit/markup-it/src/parse/index.ts
+++ b/packages/@honkit/markup-it/src/parse/index.ts
@@ -8,7 +8,7 @@ import matchRule from "./matchRule";
  * @param  {string} text
  * @return {Content}
  */
-function parse(syntax, text, options) {
+function parse(syntax, text, options?: {}) {
     const entryRule = syntax.getEntryRule();
     // @ts-ignore
     const state = new ParsingState(syntax, options);
@@ -23,7 +23,7 @@ function parse(syntax, text, options) {
  * @param  {string} text
  * @return {List<Token>}
  */
-function parseAsInline(syntax, text, options) {
+function parseAsInline(syntax, text, options?: {}) {
     // @ts-ignore
     const state = new ParsingState(syntax, options);
     return state.parseAsInline(text);

--- a/packages/@honkit/markup-it/syntaxes/markdown/__tests__/specs.js
+++ b/packages/@honkit/markup-it/syntaxes/markdown/__tests__/specs.js
@@ -3,7 +3,7 @@ const path = require("path");
 const JSDOM = require("jsdom").JSDOM;
 const assert = require("assert");
 
-const MarkupIt = require("../../..");
+const MarkupIt = require("../../..").Markup;
 const markdownSyntax = require("../");
 const htmlSyntax = require("../../html");
 

--- a/packages/@honkit/markup-it/syntaxes/text/index.js
+++ b/packages/@honkit/markup-it/syntaxes/text/index.js
@@ -1,4 +1,4 @@
-const MarkupIt = require("../../");
+const MarkupIt = require("../../").Markup;
 
 /*
     This syntax uses the default rules (UNSTYLED)
@@ -6,5 +6,5 @@ const MarkupIt = require("../../");
 */
 module.exports = MarkupIt.Syntax("markdown", {
     inline: [],
-    blocks: [MarkupIt.Rule(MarkupIt.BLOCKS.PARAGRAPH).toText("%s\n\n")],
+    blocks: [MarkupIt.Rule(MarkupIt.BLOCKS.PARAGRAPH).toText("%s\n\n")]
 });

--- a/packages/honkit/src/__tests__/__fixtures__/asciidoc/README.adoc
+++ b/packages/honkit/src/__tests__/__fixtures__/asciidoc/README.adoc
@@ -1,0 +1,2 @@
+= Introduction
+

--- a/packages/honkit/src/__tests__/__fixtures__/asciidoc/SUMMARY.adoc
+++ b/packages/honkit/src/__tests__/__fixtures__/asciidoc/SUMMARY.adoc
@@ -1,0 +1,5 @@
+= Summary
+
+. link:README.adoc[README]
+.. link:chapter-1/README.adoc[HONKIT TEST]
+.. link:chapter-1/content1.adoc[content1]

--- a/packages/honkit/src/__tests__/__fixtures__/asciidoc/book.json
+++ b/packages/honkit/src/__tests__/__fixtures__/asciidoc/book.json
@@ -1,0 +1,10 @@
+{
+	"gitbook": ">=3.0.0",
+	"root": "./docs",
+	"title": "HonKit Test Site",
+	"structure": {
+    	"readme": "README.adoc",
+    	"summary": "SUMMARY.adoc"
+	},
+	"language": "jp"
+}

--- a/packages/honkit/src/__tests__/__fixtures__/asciidoc/docs/README.adoc
+++ b/packages/honkit/src/__tests__/__fixtures__/asciidoc/docs/README.adoc
@@ -1,0 +1,2 @@
+= Introduction
+

--- a/packages/honkit/src/__tests__/__fixtures__/asciidoc/docs/SUMMARY.adoc
+++ b/packages/honkit/src/__tests__/__fixtures__/asciidoc/docs/SUMMARY.adoc
@@ -1,0 +1,4 @@
+= Summary
+
+. link:chapter-1/README.adoc[Chapter 1]
+. link:chapter-1/content1.adoc[content1]

--- a/packages/honkit/src/__tests__/__fixtures__/asciidoc/docs/chapter-1/README.adoc
+++ b/packages/honkit/src/__tests__/__fixtures__/asciidoc/docs/chapter-1/README.adoc
@@ -1,0 +1,2 @@
+= Include Test
+

--- a/packages/honkit/src/__tests__/__fixtures__/asciidoc/docs/chapter-1/content1.adoc
+++ b/packages/honkit/src/__tests__/__fixtures__/asciidoc/docs/chapter-1/content1.adoc
@@ -1,0 +1,14 @@
+== Include Test1
+----
+include::./resources/included1.txt[]
+----
+
+== Include Test2
+----
+include::./resources/included2.txt[]
+----
+
+== Include Test3
+----
+include::./resources/included3.txt[]
+----

--- a/packages/honkit/src/__tests__/__fixtures__/asciidoc/docs/chapter-1/resources/included1.txt
+++ b/packages/honkit/src/__tests__/__fixtures__/asciidoc/docs/chapter-1/resources/included1.txt
@@ -1,0 +1,1 @@
+This is the included text1 !

--- a/packages/honkit/src/__tests__/__fixtures__/asciidoc/docs/chapter-1/resources/included2.txt
+++ b/packages/honkit/src/__tests__/__fixtures__/asciidoc/docs/chapter-1/resources/included2.txt
@@ -1,0 +1,1 @@
+This is the included text2 !!

--- a/packages/honkit/src/__tests__/__fixtures__/asciidoc/docs/chapter-1/resources/included3.txt
+++ b/packages/honkit/src/__tests__/__fixtures__/asciidoc/docs/chapter-1/resources/included3.txt
@@ -1,0 +1,1 @@
+This is the included text3 !!!

--- a/packages/honkit/src/__tests__/__snapshots__/snapshot-asciidoc.ts.snap
+++ b/packages/honkit/src/__tests__/__snapshots__/snapshot-asciidoc.ts.snap
@@ -179,7 +179,7 @@ exports[`asciidoc snapshot: chapter-1/content1.html 1`] = `
 <div class="sectionbody">
 <div class="listingblock">
 <div class="content">
-<pre>Unresolved directive in &lt;stdin&gt; - include::./resources/included1.txt[]</pre>
+<pre>This is the included text1 !</pre>
 </div>
 </div>
 </div>
@@ -189,7 +189,7 @@ exports[`asciidoc snapshot: chapter-1/content1.html 1`] = `
 <div class="sectionbody">
 <div class="listingblock">
 <div class="content">
-<pre>Unresolved directive in &lt;stdin&gt; - include::./resources/included2.txt[]</pre>
+<pre>This is the included text2 !!</pre>
 </div>
 </div>
 </div>
@@ -199,7 +199,7 @@ exports[`asciidoc snapshot: chapter-1/content1.html 1`] = `
 <div class="sectionbody">
 <div class="listingblock">
 <div class="content">
-<pre>Unresolved directive in &lt;stdin&gt; - include::./resources/included3.txt[]</pre>
+<pre>This is the included text3 !!!</pre>
 </div>
 </div>
 </div>

--- a/packages/honkit/src/__tests__/__snapshots__/snapshot-asciidoc.ts.snap
+++ b/packages/honkit/src/__tests__/__snapshots__/snapshot-asciidoc.ts.snap
@@ -1,0 +1,941 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`asciidoc snapshot: chapter-1/content1.html 1`] = `
+{
+  "contents": "
+<!DOCTYPE HTML>
+<html lang="jp" >
+    <head>
+        <meta charset="UTF-8">
+        <title>content1 · HonKit Test Site</title>
+        <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+        <meta name="description" content="">
+        
+        
+        
+        
+    
+    <link rel="stylesheet" href="../gitbook/style.css">
+
+    
+            
+                
+                <link rel="stylesheet" href="../gitbook/@honkit/honkit-plugin-highlight/website.css">
+                
+            
+                
+                <link rel="stylesheet" href="../gitbook/gitbook-plugin-search/search.css">
+                
+            
+                
+                <link rel="stylesheet" href="../gitbook/gitbook-plugin-fontsettings/website.css">
+                
+            
+        
+
+    
+
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+
+        
+    
+    
+    <meta name="HandheldFriendly" content="true"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no">
+    <meta name="apple-mobile-web-app-capable" content="yes">
+    <meta name="apple-mobile-web-app-status-bar-style" content="black">
+    <link rel="apple-touch-icon-precomposed" sizes="152x152" href="../gitbook/images/apple-touch-icon-precomposed-152.png">
+    <link rel="shortcut icon" href="../gitbook/images/favicon.ico" type="image/x-icon">
+
+    
+    
+    <link rel="prev" href="./" />
+    
+
+    </head>
+    <body>
+        
+<div class="book honkit-cloak">
+    <div class="book-summary">
+        
+            
+<div id="book-search-input" role="search">
+    <input type="text" placeholder="Type to search" />
+</div>
+
+            
+                <nav role="navigation">
+                
+
+
+<ul class="summary">
+    
+    
+
+    
+
+    
+        
+        
+    
+        <li class="chapter " data-level="1.1" data-path="../">
+            
+                <a href="../">
+            
+                    
+                    Introduction
+            
+                </a>
+            
+
+            
+        </li>
+    
+        <li class="chapter " data-level="1.2" data-path="./">
+            
+                <a href="./">
+            
+                    
+                    Chapter 1
+            
+                </a>
+            
+
+            
+        </li>
+    
+        <li class="chapter active" data-level="1.3" data-path="content1.html">
+            
+                <a href="content1.html">
+            
+                    
+                    content1
+            
+                </a>
+            
+
+            
+        </li>
+    
+
+    
+
+    <li class="divider"></li>
+
+    <li>
+        <a href="https://github.com/honkit/honkit" target="blank" class="gitbook-link">
+            Published with HonKit
+        </a>
+    </li>
+</ul>
+
+
+                </nav>
+            
+        
+    </div>
+
+    <div class="book-body">
+        
+            <div class="body-inner">
+                
+                    
+
+<div class="book-header" role="navigation">
+    
+
+    <!-- Title -->
+    <h1>
+        <i class="fa fa-circle-o-notch fa-spin"></i>
+        <a href=".." >content1</a>
+    </h1>
+</div>
+
+
+
+
+                    <div class="page-wrapper" tabindex="-1" role="main">
+                        <div class="page-inner">
+                            
+<div id="book-search-results">
+    <div class="search-noresults">
+    
+                                <section class="normal markdown-section">
+                                
+                                <div class="sect1">
+<h2 id="_include_test1">Include Test1</h2>
+<div class="sectionbody">
+<div class="listingblock">
+<div class="content">
+<pre>Unresolved directive in &lt;stdin&gt; - include::./resources/included1.txt[]</pre>
+</div>
+</div>
+</div>
+</div>
+<div class="sect1">
+<h2 id="_include_test2">Include Test2</h2>
+<div class="sectionbody">
+<div class="listingblock">
+<div class="content">
+<pre>Unresolved directive in &lt;stdin&gt; - include::./resources/included2.txt[]</pre>
+</div>
+</div>
+</div>
+</div>
+<div class="sect1">
+<h2 id="_include_test3">Include Test3</h2>
+<div class="sectionbody">
+<div class="listingblock">
+<div class="content">
+<pre>Unresolved directive in &lt;stdin&gt; - include::./resources/included3.txt[]</pre>
+</div>
+</div>
+</div>
+</div>
+                                
+                                </section>
+                            
+    </div>
+    <div class="search-results">
+        <div class="has-results">
+            
+            <h1 class="search-results-title"><span class='search-results-count'></span> results matching "<span class='search-query'></span>"</h1>
+            <ul class="search-results-list"></ul>
+            
+        </div>
+        <div class="no-results">
+            
+            <h1 class="search-results-title">No results matching "<span class='search-query'></span>"</h1>
+            
+        </div>
+    </div>
+</div>
+
+                        </div>
+                    </div>
+                
+            </div>
+
+            
+                
+                <a href="./" class="navigation navigation-prev navigation-unique" aria-label="Previous page: Chapter 1">
+                    <i class="fa fa-angle-left"></i>
+                </a>
+                
+                
+            
+        
+    </div>
+
+    <script>
+        var gitbook = gitbook || [];
+        gitbook.push(function() {
+            
+        });
+    </script>
+</div>
+
+        
+    <noscript>
+        <style>
+            .honkit-cloak {
+                display: block !important;
+            }
+        </style>
+    </noscript>
+    <script>
+        // Restore sidebar state as critical path for prevent layout shift
+        function __init__getSidebarState(defaultValue){
+            var baseKey = "";
+            var key = baseKey + ":sidebar";
+            try {
+                var value = localStorage[key];
+                if (value === undefined) {
+                    return defaultValue;
+                }
+                var parsed = JSON.parse(value);
+                return parsed == null ? defaultValue : parsed;
+            } catch (e) {
+                return defaultValue;
+            }
+        }
+        function __init__restoreLastSidebarState() {
+            var isMobile = window.matchMedia("(max-width: 600px)").matches;
+            if (isMobile) {
+                // Init last state if not mobile
+                return;
+            }
+            var sidebarState = __init__getSidebarState(true);
+            var book = document.querySelector(".book");
+            // Show sidebar if it enabled
+            if (sidebarState && book) {
+                book.classList.add("without-animation", "with-summary");
+            }
+        }
+
+        try {
+            __init__restoreLastSidebarState();
+        } finally {
+            var book = document.querySelector(".book");
+            book.classList.remove("honkit-cloak");
+        }
+    </script>
+    <script src="../gitbook/gitbook.js"></script>
+    <script src="../gitbook/theme.js"></script>
+    
+        
+        <script src="../gitbook/gitbook-plugin-search/search-engine.js"></script>
+        
+    
+        
+        <script src="../gitbook/gitbook-plugin-search/search.js"></script>
+        
+    
+        
+        <script src="../gitbook/gitbook-plugin-lunr/lunr.min.js"></script>
+        
+    
+        
+        <script src="../gitbook/gitbook-plugin-lunr/search-lunr.js"></script>
+        
+    
+        
+        <script src="../gitbook/gitbook-plugin-fontsettings/fontsettings.js"></script>
+        
+    
+
+    </body>
+</html>
+
+",
+  "filePath": "chapter-1/content1.html",
+  "stats": {
+    "isDirectory": false,
+    "isFile": true,
+    "isSocket": false,
+    "isSymbolicLink": false,
+  },
+}
+`;
+
+exports[`asciidoc snapshot: chapter-1/index.html 1`] = `
+{
+  "contents": "
+<!DOCTYPE HTML>
+<html lang="jp" >
+    <head>
+        <meta charset="UTF-8">
+        <title>Chapter 1 · HonKit Test Site</title>
+        <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+        <meta name="description" content="">
+        
+        
+        
+        
+    
+    <link rel="stylesheet" href="../gitbook/style.css">
+
+    
+            
+                
+                <link rel="stylesheet" href="../gitbook/@honkit/honkit-plugin-highlight/website.css">
+                
+            
+                
+                <link rel="stylesheet" href="../gitbook/gitbook-plugin-search/search.css">
+                
+            
+                
+                <link rel="stylesheet" href="../gitbook/gitbook-plugin-fontsettings/website.css">
+                
+            
+        
+
+    
+
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+
+        
+    
+    
+    <meta name="HandheldFriendly" content="true"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no">
+    <meta name="apple-mobile-web-app-capable" content="yes">
+    <meta name="apple-mobile-web-app-status-bar-style" content="black">
+    <link rel="apple-touch-icon-precomposed" sizes="152x152" href="../gitbook/images/apple-touch-icon-precomposed-152.png">
+    <link rel="shortcut icon" href="../gitbook/images/favicon.ico" type="image/x-icon">
+
+    
+    <link rel="next" href="content1.html" />
+    
+    
+    <link rel="prev" href="../" />
+    
+
+    </head>
+    <body>
+        
+<div class="book honkit-cloak">
+    <div class="book-summary">
+        
+            
+<div id="book-search-input" role="search">
+    <input type="text" placeholder="Type to search" />
+</div>
+
+            
+                <nav role="navigation">
+                
+
+
+<ul class="summary">
+    
+    
+
+    
+
+    
+        
+        
+    
+        <li class="chapter " data-level="1.1" data-path="../">
+            
+                <a href="../">
+            
+                    
+                    Introduction
+            
+                </a>
+            
+
+            
+        </li>
+    
+        <li class="chapter active" data-level="1.2" data-path="./">
+            
+                <a href="./">
+            
+                    
+                    Chapter 1
+            
+                </a>
+            
+
+            
+        </li>
+    
+        <li class="chapter " data-level="1.3" data-path="content1.html">
+            
+                <a href="content1.html">
+            
+                    
+                    content1
+            
+                </a>
+            
+
+            
+        </li>
+    
+
+    
+
+    <li class="divider"></li>
+
+    <li>
+        <a href="https://github.com/honkit/honkit" target="blank" class="gitbook-link">
+            Published with HonKit
+        </a>
+    </li>
+</ul>
+
+
+                </nav>
+            
+        
+    </div>
+
+    <div class="book-body">
+        
+            <div class="body-inner">
+                
+                    
+
+<div class="book-header" role="navigation">
+    
+
+    <!-- Title -->
+    <h1>
+        <i class="fa fa-circle-o-notch fa-spin"></i>
+        <a href=".." >Chapter 1</a>
+    </h1>
+</div>
+
+
+
+
+                    <div class="page-wrapper" tabindex="-1" role="main">
+                        <div class="page-inner">
+                            
+<div id="book-search-results">
+    <div class="search-noresults">
+    
+                                <section class="normal markdown-section">
+                                
+                                <h1 id="include-test">Include Test</h1>
+
+                                
+                                </section>
+                            
+    </div>
+    <div class="search-results">
+        <div class="has-results">
+            
+            <h1 class="search-results-title"><span class='search-results-count'></span> results matching "<span class='search-query'></span>"</h1>
+            <ul class="search-results-list"></ul>
+            
+        </div>
+        <div class="no-results">
+            
+            <h1 class="search-results-title">No results matching "<span class='search-query'></span>"</h1>
+            
+        </div>
+    </div>
+</div>
+
+                        </div>
+                    </div>
+                
+            </div>
+
+            
+                
+                <a href="../" class="navigation navigation-prev " aria-label="Previous page: Introduction">
+                    <i class="fa fa-angle-left"></i>
+                </a>
+                
+                
+                <a href="content1.html" class="navigation navigation-next " aria-label="Next page: content1">
+                    <i class="fa fa-angle-right"></i>
+                </a>
+                
+            
+        
+    </div>
+
+    <script>
+        var gitbook = gitbook || [];
+        gitbook.push(function() {
+            
+        });
+    </script>
+</div>
+
+        
+    <noscript>
+        <style>
+            .honkit-cloak {
+                display: block !important;
+            }
+        </style>
+    </noscript>
+    <script>
+        // Restore sidebar state as critical path for prevent layout shift
+        function __init__getSidebarState(defaultValue){
+            var baseKey = "";
+            var key = baseKey + ":sidebar";
+            try {
+                var value = localStorage[key];
+                if (value === undefined) {
+                    return defaultValue;
+                }
+                var parsed = JSON.parse(value);
+                return parsed == null ? defaultValue : parsed;
+            } catch (e) {
+                return defaultValue;
+            }
+        }
+        function __init__restoreLastSidebarState() {
+            var isMobile = window.matchMedia("(max-width: 600px)").matches;
+            if (isMobile) {
+                // Init last state if not mobile
+                return;
+            }
+            var sidebarState = __init__getSidebarState(true);
+            var book = document.querySelector(".book");
+            // Show sidebar if it enabled
+            if (sidebarState && book) {
+                book.classList.add("without-animation", "with-summary");
+            }
+        }
+
+        try {
+            __init__restoreLastSidebarState();
+        } finally {
+            var book = document.querySelector(".book");
+            book.classList.remove("honkit-cloak");
+        }
+    </script>
+    <script src="../gitbook/gitbook.js"></script>
+    <script src="../gitbook/theme.js"></script>
+    
+        
+        <script src="../gitbook/gitbook-plugin-search/search-engine.js"></script>
+        
+    
+        
+        <script src="../gitbook/gitbook-plugin-search/search.js"></script>
+        
+    
+        
+        <script src="../gitbook/gitbook-plugin-lunr/lunr.min.js"></script>
+        
+    
+        
+        <script src="../gitbook/gitbook-plugin-lunr/search-lunr.js"></script>
+        
+    
+        
+        <script src="../gitbook/gitbook-plugin-fontsettings/fontsettings.js"></script>
+        
+    
+
+    </body>
+</html>
+
+",
+  "filePath": "chapter-1/index.html",
+  "stats": {
+    "isDirectory": false,
+    "isFile": true,
+    "isSocket": false,
+    "isSymbolicLink": false,
+  },
+}
+`;
+
+exports[`asciidoc snapshot: index.html 1`] = `
+{
+  "contents": "
+<!DOCTYPE HTML>
+<html lang="jp" >
+    <head>
+        <meta charset="UTF-8">
+        <title>Introduction · HonKit Test Site</title>
+        <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+        <meta name="description" content="">
+        
+        
+        
+        
+    
+    <link rel="stylesheet" href="gitbook/style.css">
+
+    
+            
+                
+                <link rel="stylesheet" href="gitbook/@honkit/honkit-plugin-highlight/website.css">
+                
+            
+                
+                <link rel="stylesheet" href="gitbook/gitbook-plugin-search/search.css">
+                
+            
+                
+                <link rel="stylesheet" href="gitbook/gitbook-plugin-fontsettings/website.css">
+                
+            
+        
+
+    
+
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+
+        
+    
+    
+    <meta name="HandheldFriendly" content="true"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no">
+    <meta name="apple-mobile-web-app-capable" content="yes">
+    <meta name="apple-mobile-web-app-status-bar-style" content="black">
+    <link rel="apple-touch-icon-precomposed" sizes="152x152" href="gitbook/images/apple-touch-icon-precomposed-152.png">
+    <link rel="shortcut icon" href="gitbook/images/favicon.ico" type="image/x-icon">
+
+    
+    <link rel="next" href="chapter-1/" />
+    
+    
+
+    </head>
+    <body>
+        
+<div class="book honkit-cloak">
+    <div class="book-summary">
+        
+            
+<div id="book-search-input" role="search">
+    <input type="text" placeholder="Type to search" />
+</div>
+
+            
+                <nav role="navigation">
+                
+
+
+<ul class="summary">
+    
+    
+
+    
+
+    
+        
+        
+    
+        <li class="chapter active" data-level="1.1" data-path="./">
+            
+                <a href="./">
+            
+                    
+                    Introduction
+            
+                </a>
+            
+
+            
+        </li>
+    
+        <li class="chapter " data-level="1.2" data-path="chapter-1/">
+            
+                <a href="chapter-1/">
+            
+                    
+                    Chapter 1
+            
+                </a>
+            
+
+            
+        </li>
+    
+        <li class="chapter " data-level="1.3" data-path="chapter-1/content1.html">
+            
+                <a href="chapter-1/content1.html">
+            
+                    
+                    content1
+            
+                </a>
+            
+
+            
+        </li>
+    
+
+    
+
+    <li class="divider"></li>
+
+    <li>
+        <a href="https://github.com/honkit/honkit" target="blank" class="gitbook-link">
+            Published with HonKit
+        </a>
+    </li>
+</ul>
+
+
+                </nav>
+            
+        
+    </div>
+
+    <div class="book-body">
+        
+            <div class="body-inner">
+                
+                    
+
+<div class="book-header" role="navigation">
+    
+
+    <!-- Title -->
+    <h1>
+        <i class="fa fa-circle-o-notch fa-spin"></i>
+        <a href="." >Introduction</a>
+    </h1>
+</div>
+
+
+
+
+                    <div class="page-wrapper" tabindex="-1" role="main">
+                        <div class="page-inner">
+                            
+<div id="book-search-results">
+    <div class="search-noresults">
+    
+                                <section class="normal markdown-section">
+                                
+                                <h1 id="introduction">Introduction</h1>
+
+                                
+                                </section>
+                            
+    </div>
+    <div class="search-results">
+        <div class="has-results">
+            
+            <h1 class="search-results-title"><span class='search-results-count'></span> results matching "<span class='search-query'></span>"</h1>
+            <ul class="search-results-list"></ul>
+            
+        </div>
+        <div class="no-results">
+            
+            <h1 class="search-results-title">No results matching "<span class='search-query'></span>"</h1>
+            
+        </div>
+    </div>
+</div>
+
+                        </div>
+                    </div>
+                
+            </div>
+
+            
+                
+                
+                <a href="chapter-1/" class="navigation navigation-next navigation-unique" aria-label="Next page: Chapter 1">
+                    <i class="fa fa-angle-right"></i>
+                </a>
+                
+            
+        
+    </div>
+
+    <script>
+        var gitbook = gitbook || [];
+        gitbook.push(function() {
+            
+        });
+    </script>
+</div>
+
+        
+    <noscript>
+        <style>
+            .honkit-cloak {
+                display: block !important;
+            }
+        </style>
+    </noscript>
+    <script>
+        // Restore sidebar state as critical path for prevent layout shift
+        function __init__getSidebarState(defaultValue){
+            var baseKey = "";
+            var key = baseKey + ":sidebar";
+            try {
+                var value = localStorage[key];
+                if (value === undefined) {
+                    return defaultValue;
+                }
+                var parsed = JSON.parse(value);
+                return parsed == null ? defaultValue : parsed;
+            } catch (e) {
+                return defaultValue;
+            }
+        }
+        function __init__restoreLastSidebarState() {
+            var isMobile = window.matchMedia("(max-width: 600px)").matches;
+            if (isMobile) {
+                // Init last state if not mobile
+                return;
+            }
+            var sidebarState = __init__getSidebarState(true);
+            var book = document.querySelector(".book");
+            // Show sidebar if it enabled
+            if (sidebarState && book) {
+                book.classList.add("without-animation", "with-summary");
+            }
+        }
+
+        try {
+            __init__restoreLastSidebarState();
+        } finally {
+            var book = document.querySelector(".book");
+            book.classList.remove("honkit-cloak");
+        }
+    </script>
+    <script src="gitbook/gitbook.js"></script>
+    <script src="gitbook/theme.js"></script>
+    
+        
+        <script src="gitbook/gitbook-plugin-search/search-engine.js"></script>
+        
+    
+        
+        <script src="gitbook/gitbook-plugin-search/search.js"></script>
+        
+    
+        
+        <script src="gitbook/gitbook-plugin-lunr/lunr.min.js"></script>
+        
+    
+        
+        <script src="gitbook/gitbook-plugin-lunr/search-lunr.js"></script>
+        
+    
+        
+        <script src="gitbook/gitbook-plugin-fontsettings/fontsettings.js"></script>
+        
+    
+
+    </body>
+</html>
+
+",
+  "filePath": "index.html",
+  "stats": {
+    "isDirectory": false,
+    "isFile": true,
+    "isSocket": false,
+    "isSymbolicLink": false,
+  },
+}
+`;

--- a/packages/honkit/src/__tests__/__snapshots__/snapshot-honkit.ts.snap
+++ b/packages/honkit/src/__tests__/__snapshots__/snapshot-honkit.ts.snap
@@ -10,50 +10,50 @@ exports[`HonKit snapshots: GLOSSARY.html 1`] = `
         <title> · HonKit Documentation</title>
         <meta http-equiv="X-UA-Compatible" content="IE=edge" />
         <meta name="description" content="">
-
-
-
-
-
+        
+        
+        
+        
+    
     <link rel="stylesheet" href="gitbook/style.css">
 
-
-
-
+    
+            
+                
                 <link rel="stylesheet" href="gitbook/@honkit/honkit-plugin-highlight/website.css">
-
-
-
+                
+            
+                
                 <link rel="stylesheet" href="gitbook/gitbook-plugin-search/search.css">
-
-
-
+                
+            
+                
                 <link rel="stylesheet" href="gitbook/gitbook-plugin-fontsettings/website.css">
+                
+            
+        
 
+    
 
-
-
-
-
-
-
+    
+        
         <link rel="stylesheet" href="styles/website.css">
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
+        
+    
+    
     <meta name="HandheldFriendly" content="true"/>
     <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no">
     <meta name="apple-mobile-web-app-capable" content="yes">
@@ -61,553 +61,553 @@ exports[`HonKit snapshots: GLOSSARY.html 1`] = `
     <link rel="apple-touch-icon-precomposed" sizes="152x152" href="gitbook/images/apple-touch-icon-precomposed-152.png">
     <link rel="shortcut icon" href="gitbook/images/favicon.ico" type="image/x-icon">
 
-
-
+    
+    
 
     </head>
     <body>
-
+        
 <div class="book honkit-cloak">
     <div class="book-summary">
-
-
+        
+            
 <div id="book-search-input" role="search">
     <input type="text" placeholder="Type to search" />
 </div>
 
-
+            
                 <nav role="navigation">
-
+                
 
 
 <ul class="summary">
+    
+    
 
+    
 
-
-
-
-
-
+    
+        
         <li class="header">Getting Started</li>
-
-
-
+        
+        
+    
         <li class="chapter " data-level="1.1" data-path="./">
-
+            
                 <a href="./">
-
-
+            
+                    
                     About this documentation
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="1.2" data-path="setup.html">
-
+            
                 <a href="setup.html">
-
-
+            
+                    
                     Installation and Setup
-
+            
                 </a>
+            
 
-
-
+            
         </li>
+    
 
-
-
-
+    
+        
         <li class="header">Your Content</li>
-
-
-
+        
+        
+    
         <li class="chapter " data-level="2.1" data-path="structure.html">
-
+            
                 <a href="structure.html">
-
-
+            
+                    
                     Directory structure
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.2" data-path="pages.html">
-
+            
                 <a href="pages.html">
-
-
+            
+                    
                     Pages and Summary
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.3" data-path="config.html">
-
+            
                 <a href="config.html">
-
-
+            
+                    
                     Configuration
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.4" data-path="lexicon.html">
-
+            
                 <a href="lexicon.html">
-
-
+            
+                    
                     Glossary
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.5" data-path="languages.html">
-
+            
                 <a href="languages.html">
-
-
+            
+                    
                     Multi-Lingual
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.6" data-path="syntax/markdown.html">
-
+            
                 <a href="syntax/markdown.html">
-
-
+            
+                    
                     Markdown
-
+            
                 </a>
+            
 
-
-
+            
             <ul class="articles">
-
-
+                
+    
         <li class="chapter " data-level="2.6.1" data-path="syntax/markdown.html">
-
+            
                 <a href="syntax/markdown.html#headings">
-
-
+            
+                    
                     Headings
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.6.2" data-path="syntax/markdown.html">
-
+            
                 <a href="syntax/markdown.html#paragraphs">
-
-
+            
+                    
                     Paragraphs
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.6.3" data-path="syntax/markdown.html">
-
+            
                 <a href="syntax/markdown.html#lists">
-
-
+            
+                    
                     Lists
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.6.4" data-path="syntax/markdown.html">
-
+            
                 <a href="syntax/markdown.html#links">
-
-
+            
+                    
                     Links
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.6.5" data-path="syntax/markdown.html">
-
+            
                 <a href="syntax/markdown.html#images">
-
-
+            
+                    
                     Images
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.6.6" data-path="syntax/markdown.html">
-
+            
                 <a href="syntax/markdown.html#blockquotes">
-
-
+            
+                    
                     Blockquotes
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.6.7" data-path="syntax/markdown.html">
-
+            
                 <a href="syntax/markdown.html#tables">
-
-
+            
+                    
                     Tables
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.6.8" data-path="syntax/markdown.html">
-
+            
                 <a href="syntax/markdown.html#code">
-
-
+            
+                    
                     Code
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.6.9" data-path="syntax/markdown.html">
-
+            
                 <a href="syntax/markdown.html#html">
-
-
+            
+                    
                     HTML
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.6.10" data-path="syntax/markdown.html">
-
+            
                 <a href="syntax/markdown.html#footnotes">
-
-
+            
+                    
                     Footnotes
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
 
             </ul>
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.7" data-path="syntax/asciidoc.html">
-
+            
                 <a href="syntax/asciidoc.html">
-
-
+            
+                    
                     AsciiDoc
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.8" data-path="ebook.html">
-
+            
                 <a href="ebook.html">
-
-
+            
+                    
                     eBook and PDF
-
+            
                 </a>
+            
 
-
-
+            
         </li>
+    
 
-
-
-
+    
+        
         <li class="header">Customization</li>
-
-
-
+        
+        
+    
         <li class="chapter " data-level="3.1" data-path="templating/">
-
+            
                 <a href="templating/">
-
-
+            
+                    
                     Templating
-
+            
                 </a>
+            
 
-
-
+            
             <ul class="articles">
-
-
+                
+    
         <li class="chapter " data-level="3.1.1" data-path="templating/conrefs.html">
-
+            
                 <a href="templating/conrefs.html">
-
-
+            
+                    
                     Content References
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="3.1.2" data-path="templating/variables.html">
-
+            
                 <a href="templating/variables.html">
-
-
+            
+                    
                     Variables
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="3.1.3" data-path="templating/builtin.html">
-
+            
                 <a href="templating/builtin.html">
-
-
+            
+                    
                     Builtin
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
 
             </ul>
-
+            
         </li>
-
+    
         <li class="chapter " data-level="3.2" data-path="plugins/">
-
+            
                 <a href="plugins/">
-
-
+            
+                    
                     Plugins
-
+            
                 </a>
+            
 
-
-
+            
             <ul class="articles">
-
-
+                
+    
         <li class="chapter " data-level="3.2.1" data-path="plugins/create.html">
-
+            
                 <a href="plugins/create.html">
-
-
+            
+                    
                     Create a plugin
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="3.2.2" data-path="plugins/hooks.html">
-
+            
                 <a href="plugins/hooks.html">
-
-
+            
+                    
                     Hooks
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="3.2.3" data-path="plugins/blocks.html">
-
+            
                 <a href="plugins/blocks.html">
-
-
+            
+                    
                     Blocks
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="3.2.4" data-path="plugins/filters.html">
-
+            
                 <a href="plugins/filters.html">
-
-
+            
+                    
                     Filters
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="3.2.5" data-path="plugins/api.html">
-
+            
                 <a href="plugins/api.html">
-
-
+            
+                    
                     API & Context
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="3.2.6" data-path="plugins/testing.html">
-
+            
                 <a href="plugins/testing.html">
-
-
+            
+                    
                     Test your plugin
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
 
             </ul>
-
+            
         </li>
-
+    
         <li class="chapter " data-level="3.3" data-path="themes/">
-
+            
                 <a href="themes/">
-
-
+            
+                    
                     Theming
-
+            
                 </a>
+            
 
-
-
+            
         </li>
+    
 
-
-
-
+    
+        
         <li class="divider"></li>
-
-
-
+        
+        
+    
         <li class="chapter " data-level="4.1" data-path="faq.html">
-
+            
                 <a href="faq.html">
-
-
+            
+                    
                     FAQ
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="4.2" data-path="examples.md">
-
+            
                 <span>
-
-
+            
+                    
                     Examples
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="4.3" >
-
+            
                 <a target="_blank" href="https://github.com/honkit/honkit/blob/master/CHANGELOG.md">
-
-
+            
+                    
                     Release notes
-
+            
                 </a>
+            
 
-
-
+            
         </li>
+    
 
-
-
-
+    
+        
         <li class="divider"></li>
-
-
-
+        
+        
+    
         <li class="chapter " data-level="5.1" data-path="encoding.html">
-
+            
                 <a href="encoding.html">
-
-
+            
+                    
                     Encoding
-
+            
                 </a>
+            
 
-
-
+            
         </li>
+    
 
-
-
+    
 
     <li class="divider"></li>
 
@@ -620,18 +620,18 @@ exports[`HonKit snapshots: GLOSSARY.html 1`] = `
 
 
                 </nav>
-
-
+            
+        
     </div>
 
     <div class="book-body">
-
+        
             <div class="body-inner">
-
-
+                
+                    
 
 <div class="book-header" role="navigation">
-
+    
 
     <!-- Title -->
     <h1>
@@ -645,12 +645,12 @@ exports[`HonKit snapshots: GLOSSARY.html 1`] = `
 
                     <div class="page-wrapper" tabindex="-1" role="main">
                         <div class="page-inner">
-
+                            
 <div id="book-search-results">
     <div class="search-noresults">
-
+    
                                 <section class="normal markdown-section">
-
+                                
 
                                 <h2 id="honkit">HonKit</h2>
 <p><a href="GLOSSARY.html#honkit" class="glossary-term" title="Honkit is a command line tool for building beautiful books using GitHub/Git and Markdown (or AsciiDoc).">Honkit</a> is a command line tool for building beautiful books using GitHub/Git and Markdown (or AsciiDoc).</p>
@@ -661,52 +661,52 @@ exports[`HonKit snapshots: GLOSSARY.html 1`] = `
 <p><a href="GLOSSARY.html#honkit" class="glossary-term" title="Honkit is a command line tool for building beautiful books using GitHub/Git and Markdown (or AsciiDoc).">HonKit</a> uses the <a href="https://mozilla.github.io/nunjucks/" target="_blank">Nunjucks templating language</a> to process pages and theme&apos;s templates.</p>
 <p>For more details, see <a href="templating/">Templating</a>.</p>
 
-
+                                
 <hr>
 <div class="btn-group btn-group-justified">
-
-
+    
+    
 </div>
 
                                 </section>
-
+                            
     </div>
     <div class="search-results">
         <div class="has-results">
-
+            
             <h1 class="search-results-title"><span class='search-results-count'></span> results matching "<span class='search-query'></span>"</h1>
             <ul class="search-results-list"></ul>
-
+            
         </div>
         <div class="no-results">
-
+            
             <h1 class="search-results-title">No results matching "<span class='search-query'></span>"</h1>
-
+            
         </div>
     </div>
 </div>
 
                         </div>
                     </div>
-
+                
             </div>
 
-
-
-
-
-
+            
+                
+                
+            
+        
     </div>
 
     <script>
         var gitbook = gitbook || [];
         gitbook.push(function() {
-
+            
         });
     </script>
 </div>
 
-
+        
     <noscript>
         <style>
             .honkit-cloak {
@@ -753,27 +753,27 @@ exports[`HonKit snapshots: GLOSSARY.html 1`] = `
     </script>
     <script src="gitbook/gitbook.js"></script>
     <script src="gitbook/theme.js"></script>
-
-
+    
+        
         <script src="gitbook/gitbook-plugin-search/search-engine.js"></script>
-
-
-
+        
+    
+        
         <script src="gitbook/gitbook-plugin-search/search.js"></script>
-
-
-
+        
+    
+        
         <script src="gitbook/gitbook-plugin-lunr/lunr.min.js"></script>
-
-
-
+        
+    
+        
         <script src="gitbook/gitbook-plugin-lunr/search-lunr.js"></script>
-
-
-
+        
+    
+        
         <script src="gitbook/gitbook-plugin-fontsettings/fontsettings.js"></script>
-
-
+        
+    
 
     </body>
 </html>
@@ -799,50 +799,50 @@ exports[`HonKit snapshots: config.html 1`] = `
         <title>Configuration · HonKit Documentation</title>
         <meta http-equiv="X-UA-Compatible" content="IE=edge" />
         <meta name="description" content="">
-
-
-
-
-
+        
+        
+        
+        
+    
     <link rel="stylesheet" href="gitbook/style.css">
 
-
-
-
+    
+            
+                
                 <link rel="stylesheet" href="gitbook/@honkit/honkit-plugin-highlight/website.css">
-
-
-
+                
+            
+                
                 <link rel="stylesheet" href="gitbook/gitbook-plugin-search/search.css">
-
-
-
+                
+            
+                
                 <link rel="stylesheet" href="gitbook/gitbook-plugin-fontsettings/website.css">
+                
+            
+        
 
+    
 
-
-
-
-
-
-
+    
+        
         <link rel="stylesheet" href="styles/website.css">
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
+        
+    
+    
     <meta name="HandheldFriendly" content="true"/>
     <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no">
     <meta name="apple-mobile-web-app-capable" content="yes">
@@ -850,557 +850,557 @@ exports[`HonKit snapshots: config.html 1`] = `
     <link rel="apple-touch-icon-precomposed" sizes="152x152" href="gitbook/images/apple-touch-icon-precomposed-152.png">
     <link rel="shortcut icon" href="gitbook/images/favicon.ico" type="image/x-icon">
 
-
+    
     <link rel="next" href="lexicon.html" />
-
-
+    
+    
     <link rel="prev" href="pages.html" />
-
+    
 
     </head>
     <body>
-
+        
 <div class="book honkit-cloak">
     <div class="book-summary">
-
-
+        
+            
 <div id="book-search-input" role="search">
     <input type="text" placeholder="Type to search" />
 </div>
 
-
+            
                 <nav role="navigation">
-
+                
 
 
 <ul class="summary">
+    
+    
 
+    
 
-
-
-
-
-
+    
+        
         <li class="header">Getting Started</li>
-
-
-
+        
+        
+    
         <li class="chapter " data-level="1.1" data-path="./">
-
+            
                 <a href="./">
-
-
+            
+                    
                     About this documentation
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="1.2" data-path="setup.html">
-
+            
                 <a href="setup.html">
-
-
+            
+                    
                     Installation and Setup
-
+            
                 </a>
+            
 
-
-
+            
         </li>
+    
 
-
-
-
+    
+        
         <li class="header">Your Content</li>
-
-
-
+        
+        
+    
         <li class="chapter " data-level="2.1" data-path="structure.html">
-
+            
                 <a href="structure.html">
-
-
+            
+                    
                     Directory structure
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.2" data-path="pages.html">
-
+            
                 <a href="pages.html">
-
-
+            
+                    
                     Pages and Summary
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter active" data-level="2.3" data-path="config.html">
-
+            
                 <a href="config.html">
-
-
+            
+                    
                     Configuration
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.4" data-path="lexicon.html">
-
+            
                 <a href="lexicon.html">
-
-
+            
+                    
                     Glossary
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.5" data-path="languages.html">
-
+            
                 <a href="languages.html">
-
-
+            
+                    
                     Multi-Lingual
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.6" data-path="syntax/markdown.html">
-
+            
                 <a href="syntax/markdown.html">
-
-
+            
+                    
                     Markdown
-
+            
                 </a>
+            
 
-
-
+            
             <ul class="articles">
-
-
+                
+    
         <li class="chapter " data-level="2.6.1" data-path="syntax/markdown.html">
-
+            
                 <a href="syntax/markdown.html#headings">
-
-
+            
+                    
                     Headings
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.6.2" data-path="syntax/markdown.html">
-
+            
                 <a href="syntax/markdown.html#paragraphs">
-
-
+            
+                    
                     Paragraphs
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.6.3" data-path="syntax/markdown.html">
-
+            
                 <a href="syntax/markdown.html#lists">
-
-
+            
+                    
                     Lists
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.6.4" data-path="syntax/markdown.html">
-
+            
                 <a href="syntax/markdown.html#links">
-
-
+            
+                    
                     Links
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.6.5" data-path="syntax/markdown.html">
-
+            
                 <a href="syntax/markdown.html#images">
-
-
+            
+                    
                     Images
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.6.6" data-path="syntax/markdown.html">
-
+            
                 <a href="syntax/markdown.html#blockquotes">
-
-
+            
+                    
                     Blockquotes
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.6.7" data-path="syntax/markdown.html">
-
+            
                 <a href="syntax/markdown.html#tables">
-
-
+            
+                    
                     Tables
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.6.8" data-path="syntax/markdown.html">
-
+            
                 <a href="syntax/markdown.html#code">
-
-
+            
+                    
                     Code
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.6.9" data-path="syntax/markdown.html">
-
+            
                 <a href="syntax/markdown.html#html">
-
-
+            
+                    
                     HTML
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.6.10" data-path="syntax/markdown.html">
-
+            
                 <a href="syntax/markdown.html#footnotes">
-
-
+            
+                    
                     Footnotes
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
 
             </ul>
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.7" data-path="syntax/asciidoc.html">
-
+            
                 <a href="syntax/asciidoc.html">
-
-
+            
+                    
                     AsciiDoc
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.8" data-path="ebook.html">
-
+            
                 <a href="ebook.html">
-
-
+            
+                    
                     eBook and PDF
-
+            
                 </a>
+            
 
-
-
+            
         </li>
+    
 
-
-
-
+    
+        
         <li class="header">Customization</li>
-
-
-
+        
+        
+    
         <li class="chapter " data-level="3.1" data-path="templating/">
-
+            
                 <a href="templating/">
-
-
+            
+                    
                     Templating
-
+            
                 </a>
+            
 
-
-
+            
             <ul class="articles">
-
-
+                
+    
         <li class="chapter " data-level="3.1.1" data-path="templating/conrefs.html">
-
+            
                 <a href="templating/conrefs.html">
-
-
+            
+                    
                     Content References
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="3.1.2" data-path="templating/variables.html">
-
+            
                 <a href="templating/variables.html">
-
-
+            
+                    
                     Variables
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="3.1.3" data-path="templating/builtin.html">
-
+            
                 <a href="templating/builtin.html">
-
-
+            
+                    
                     Builtin
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
 
             </ul>
-
+            
         </li>
-
+    
         <li class="chapter " data-level="3.2" data-path="plugins/">
-
+            
                 <a href="plugins/">
-
-
+            
+                    
                     Plugins
-
+            
                 </a>
+            
 
-
-
+            
             <ul class="articles">
-
-
+                
+    
         <li class="chapter " data-level="3.2.1" data-path="plugins/create.html">
-
+            
                 <a href="plugins/create.html">
-
-
+            
+                    
                     Create a plugin
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="3.2.2" data-path="plugins/hooks.html">
-
+            
                 <a href="plugins/hooks.html">
-
-
+            
+                    
                     Hooks
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="3.2.3" data-path="plugins/blocks.html">
-
+            
                 <a href="plugins/blocks.html">
-
-
+            
+                    
                     Blocks
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="3.2.4" data-path="plugins/filters.html">
-
+            
                 <a href="plugins/filters.html">
-
-
+            
+                    
                     Filters
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="3.2.5" data-path="plugins/api.html">
-
+            
                 <a href="plugins/api.html">
-
-
+            
+                    
                     API & Context
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="3.2.6" data-path="plugins/testing.html">
-
+            
                 <a href="plugins/testing.html">
-
-
+            
+                    
                     Test your plugin
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
 
             </ul>
-
+            
         </li>
-
+    
         <li class="chapter " data-level="3.3" data-path="themes/">
-
+            
                 <a href="themes/">
-
-
+            
+                    
                     Theming
-
+            
                 </a>
+            
 
-
-
+            
         </li>
+    
 
-
-
-
+    
+        
         <li class="divider"></li>
-
-
-
+        
+        
+    
         <li class="chapter " data-level="4.1" data-path="faq.html">
-
+            
                 <a href="faq.html">
-
-
+            
+                    
                     FAQ
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="4.2" data-path="examples.md">
-
+            
                 <span>
-
-
+            
+                    
                     Examples
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="4.3" >
-
+            
                 <a target="_blank" href="https://github.com/honkit/honkit/blob/master/CHANGELOG.md">
-
-
+            
+                    
                     Release notes
-
+            
                 </a>
+            
 
-
-
+            
         </li>
+    
 
-
-
-
+    
+        
         <li class="divider"></li>
-
-
-
+        
+        
+    
         <li class="chapter " data-level="5.1" data-path="encoding.html">
-
+            
                 <a href="encoding.html">
-
-
+            
+                    
                     Encoding
-
+            
                 </a>
+            
 
-
-
+            
         </li>
+    
 
-
-
+    
 
     <li class="divider"></li>
 
@@ -1413,18 +1413,18 @@ exports[`HonKit snapshots: config.html 1`] = `
 
 
                 </nav>
-
-
+            
+        
     </div>
 
     <div class="book-body">
-
+        
             <div class="body-inner">
-
-
+                
+                    
 
 <div class="book-header" role="navigation">
-
+    
 
     <!-- Title -->
     <h1>
@@ -1438,12 +1438,12 @@ exports[`HonKit snapshots: config.html 1`] = `
 
                     <div class="page-wrapper" tabindex="-1" role="main">
                         <div class="page-inner">
-
+                            
 <div id="book-search-results">
     <div class="search-noresults">
-
+    
                                 <section class="normal markdown-section">
-
+                                
 
                                 <h1 id="configuration">Configuration</h1>
 <p><a href="GLOSSARY.html#honkit" class="glossary-term" title="Honkit is a command line tool for building beautiful books using GitHub/Git and Markdown (or AsciiDoc).">HonKit</a> allows you to customize your book using a flexible configuration. These options are specified in a <code>book.json</code> file. For authors unfamiliar with the JSON syntax, you can validate the syntax using tools such as <a href="http://jsonlint.com" target="_blank">JSONlint</a>.</p>
@@ -1597,64 +1597,64 @@ These files must be at the root of your book (or the root of every language book
 </tbody>
 </table>
 
-
+                                
 <hr>
 <div class="btn-group btn-group-justified">
-
+    
     <a class="btn" href="pages.html"><b>Previous:</b> Pages and Summary</a>
-
-
+    
+    
     <a class="btn" href="lexicon.html"><b>Next:</b> Glossary</a>
-
+    
 </div>
 
                                 </section>
-
+                            
     </div>
     <div class="search-results">
         <div class="has-results">
-
+            
             <h1 class="search-results-title"><span class='search-results-count'></span> results matching "<span class='search-query'></span>"</h1>
             <ul class="search-results-list"></ul>
-
+            
         </div>
         <div class="no-results">
-
+            
             <h1 class="search-results-title">No results matching "<span class='search-query'></span>"</h1>
-
+            
         </div>
     </div>
 </div>
 
                         </div>
                     </div>
-
+                
             </div>
 
-
-
+            
+                
                 <a href="pages.html" class="navigation navigation-prev " aria-label="Previous page: Pages and Summary">
                     <i class="fa fa-angle-left"></i>
                 </a>
-
-
+                
+                
                 <a href="lexicon.html" class="navigation navigation-next " aria-label="Next page: Glossary">
                     <i class="fa fa-angle-right"></i>
                 </a>
-
-
-
+                
+            
+        
     </div>
 
     <script>
         var gitbook = gitbook || [];
         gitbook.push(function() {
-
+            
         });
     </script>
 </div>
 
-
+        
     <noscript>
         <style>
             .honkit-cloak {
@@ -1701,27 +1701,27 @@ These files must be at the root of your book (or the root of every language book
     </script>
     <script src="gitbook/gitbook.js"></script>
     <script src="gitbook/theme.js"></script>
-
-
+    
+        
         <script src="gitbook/gitbook-plugin-search/search-engine.js"></script>
-
-
-
+        
+    
+        
         <script src="gitbook/gitbook-plugin-search/search.js"></script>
-
-
-
+        
+    
+        
         <script src="gitbook/gitbook-plugin-lunr/lunr.min.js"></script>
-
-
-
+        
+    
+        
         <script src="gitbook/gitbook-plugin-lunr/search-lunr.js"></script>
-
-
-
+        
+    
+        
         <script src="gitbook/gitbook-plugin-fontsettings/fontsettings.js"></script>
-
-
+        
+    
 
     </body>
 </html>
@@ -1747,50 +1747,50 @@ exports[`HonKit snapshots: ebook.html 1`] = `
         <title>eBook and PDF · HonKit Documentation</title>
         <meta http-equiv="X-UA-Compatible" content="IE=edge" />
         <meta name="description" content="">
-
-
-
-
-
+        
+        
+        
+        
+    
     <link rel="stylesheet" href="gitbook/style.css">
 
-
-
-
+    
+            
+                
                 <link rel="stylesheet" href="gitbook/@honkit/honkit-plugin-highlight/website.css">
-
-
-
+                
+            
+                
                 <link rel="stylesheet" href="gitbook/gitbook-plugin-search/search.css">
-
-
-
+                
+            
+                
                 <link rel="stylesheet" href="gitbook/gitbook-plugin-fontsettings/website.css">
+                
+            
+        
 
+    
 
-
-
-
-
-
-
+    
+        
         <link rel="stylesheet" href="styles/website.css">
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
+        
+    
+    
     <meta name="HandheldFriendly" content="true"/>
     <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no">
     <meta name="apple-mobile-web-app-capable" content="yes">
@@ -1798,557 +1798,557 @@ exports[`HonKit snapshots: ebook.html 1`] = `
     <link rel="apple-touch-icon-precomposed" sizes="152x152" href="gitbook/images/apple-touch-icon-precomposed-152.png">
     <link rel="shortcut icon" href="gitbook/images/favicon.ico" type="image/x-icon">
 
-
+    
     <link rel="next" href="templating/" />
-
-
+    
+    
     <link rel="prev" href="syntax/asciidoc.html" />
-
+    
 
     </head>
     <body>
-
+        
 <div class="book honkit-cloak">
     <div class="book-summary">
-
-
+        
+            
 <div id="book-search-input" role="search">
     <input type="text" placeholder="Type to search" />
 </div>
 
-
+            
                 <nav role="navigation">
-
+                
 
 
 <ul class="summary">
+    
+    
 
+    
 
-
-
-
-
-
+    
+        
         <li class="header">Getting Started</li>
-
-
-
+        
+        
+    
         <li class="chapter " data-level="1.1" data-path="./">
-
+            
                 <a href="./">
-
-
+            
+                    
                     About this documentation
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="1.2" data-path="setup.html">
-
+            
                 <a href="setup.html">
-
-
+            
+                    
                     Installation and Setup
-
+            
                 </a>
+            
 
-
-
+            
         </li>
+    
 
-
-
-
+    
+        
         <li class="header">Your Content</li>
-
-
-
+        
+        
+    
         <li class="chapter " data-level="2.1" data-path="structure.html">
-
+            
                 <a href="structure.html">
-
-
+            
+                    
                     Directory structure
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.2" data-path="pages.html">
-
+            
                 <a href="pages.html">
-
-
+            
+                    
                     Pages and Summary
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.3" data-path="config.html">
-
+            
                 <a href="config.html">
-
-
+            
+                    
                     Configuration
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.4" data-path="lexicon.html">
-
+            
                 <a href="lexicon.html">
-
-
+            
+                    
                     Glossary
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.5" data-path="languages.html">
-
+            
                 <a href="languages.html">
-
-
+            
+                    
                     Multi-Lingual
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.6" data-path="syntax/markdown.html">
-
+            
                 <a href="syntax/markdown.html">
-
-
+            
+                    
                     Markdown
-
+            
                 </a>
+            
 
-
-
+            
             <ul class="articles">
-
-
+                
+    
         <li class="chapter " data-level="2.6.1" data-path="syntax/markdown.html">
-
+            
                 <a href="syntax/markdown.html#headings">
-
-
+            
+                    
                     Headings
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.6.2" data-path="syntax/markdown.html">
-
+            
                 <a href="syntax/markdown.html#paragraphs">
-
-
+            
+                    
                     Paragraphs
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.6.3" data-path="syntax/markdown.html">
-
+            
                 <a href="syntax/markdown.html#lists">
-
-
+            
+                    
                     Lists
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.6.4" data-path="syntax/markdown.html">
-
+            
                 <a href="syntax/markdown.html#links">
-
-
+            
+                    
                     Links
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.6.5" data-path="syntax/markdown.html">
-
+            
                 <a href="syntax/markdown.html#images">
-
-
+            
+                    
                     Images
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.6.6" data-path="syntax/markdown.html">
-
+            
                 <a href="syntax/markdown.html#blockquotes">
-
-
+            
+                    
                     Blockquotes
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.6.7" data-path="syntax/markdown.html">
-
+            
                 <a href="syntax/markdown.html#tables">
-
-
+            
+                    
                     Tables
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.6.8" data-path="syntax/markdown.html">
-
+            
                 <a href="syntax/markdown.html#code">
-
-
+            
+                    
                     Code
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.6.9" data-path="syntax/markdown.html">
-
+            
                 <a href="syntax/markdown.html#html">
-
-
+            
+                    
                     HTML
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.6.10" data-path="syntax/markdown.html">
-
+            
                 <a href="syntax/markdown.html#footnotes">
-
-
+            
+                    
                     Footnotes
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
 
             </ul>
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.7" data-path="syntax/asciidoc.html">
-
+            
                 <a href="syntax/asciidoc.html">
-
-
+            
+                    
                     AsciiDoc
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter active" data-level="2.8" data-path="ebook.html">
-
+            
                 <a href="ebook.html">
-
-
+            
+                    
                     eBook and PDF
-
+            
                 </a>
+            
 
-
-
+            
         </li>
+    
 
-
-
-
+    
+        
         <li class="header">Customization</li>
-
-
-
+        
+        
+    
         <li class="chapter " data-level="3.1" data-path="templating/">
-
+            
                 <a href="templating/">
-
-
+            
+                    
                     Templating
-
+            
                 </a>
+            
 
-
-
+            
             <ul class="articles">
-
-
+                
+    
         <li class="chapter " data-level="3.1.1" data-path="templating/conrefs.html">
-
+            
                 <a href="templating/conrefs.html">
-
-
+            
+                    
                     Content References
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="3.1.2" data-path="templating/variables.html">
-
+            
                 <a href="templating/variables.html">
-
-
+            
+                    
                     Variables
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="3.1.3" data-path="templating/builtin.html">
-
+            
                 <a href="templating/builtin.html">
-
-
+            
+                    
                     Builtin
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
 
             </ul>
-
+            
         </li>
-
+    
         <li class="chapter " data-level="3.2" data-path="plugins/">
-
+            
                 <a href="plugins/">
-
-
+            
+                    
                     Plugins
-
+            
                 </a>
+            
 
-
-
+            
             <ul class="articles">
-
-
+                
+    
         <li class="chapter " data-level="3.2.1" data-path="plugins/create.html">
-
+            
                 <a href="plugins/create.html">
-
-
+            
+                    
                     Create a plugin
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="3.2.2" data-path="plugins/hooks.html">
-
+            
                 <a href="plugins/hooks.html">
-
-
+            
+                    
                     Hooks
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="3.2.3" data-path="plugins/blocks.html">
-
+            
                 <a href="plugins/blocks.html">
-
-
+            
+                    
                     Blocks
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="3.2.4" data-path="plugins/filters.html">
-
+            
                 <a href="plugins/filters.html">
-
-
+            
+                    
                     Filters
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="3.2.5" data-path="plugins/api.html">
-
+            
                 <a href="plugins/api.html">
-
-
+            
+                    
                     API & Context
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="3.2.6" data-path="plugins/testing.html">
-
+            
                 <a href="plugins/testing.html">
-
-
+            
+                    
                     Test your plugin
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
 
             </ul>
-
+            
         </li>
-
+    
         <li class="chapter " data-level="3.3" data-path="themes/">
-
+            
                 <a href="themes/">
-
-
+            
+                    
                     Theming
-
+            
                 </a>
+            
 
-
-
+            
         </li>
+    
 
-
-
-
+    
+        
         <li class="divider"></li>
-
-
-
+        
+        
+    
         <li class="chapter " data-level="4.1" data-path="faq.html">
-
+            
                 <a href="faq.html">
-
-
+            
+                    
                     FAQ
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="4.2" data-path="examples.md">
-
+            
                 <span>
-
-
+            
+                    
                     Examples
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="4.3" >
-
+            
                 <a target="_blank" href="https://github.com/honkit/honkit/blob/master/CHANGELOG.md">
-
-
+            
+                    
                     Release notes
-
+            
                 </a>
+            
 
-
-
+            
         </li>
+    
 
-
-
-
+    
+        
         <li class="divider"></li>
-
-
-
+        
+        
+    
         <li class="chapter " data-level="5.1" data-path="encoding.html">
-
+            
                 <a href="encoding.html">
-
-
+            
+                    
                     Encoding
-
+            
                 </a>
+            
 
-
-
+            
         </li>
+    
 
-
-
+    
 
     <li class="divider"></li>
 
@@ -2361,18 +2361,18 @@ exports[`HonKit snapshots: ebook.html 1`] = `
 
 
                 </nav>
-
-
+            
+        
     </div>
 
     <div class="book-body">
-
+        
             <div class="body-inner">
-
-
+                
+                    
 
 <div class="book-header" role="navigation">
-
+    
 
     <!-- Title -->
     <h1>
@@ -2386,12 +2386,12 @@ exports[`HonKit snapshots: ebook.html 1`] = `
 
                     <div class="page-wrapper" tabindex="-1" role="main">
                         <div class="page-inner">
-
+                            
 <div id="book-search-results">
     <div class="search-noresults">
-
+    
                                 <section class="normal markdown-section">
-
+                                
 
                                 <h1 id="generating-ebooks-and-pdfs">Generating eBooks and PDFs</h1>
 <p><a href="GLOSSARY.html#honkit" class="glossary-term" title="Honkit is a command line tool for building beautiful books using GitHub/Git and Markdown (or AsciiDoc).">HonKit</a> can generates a website, but can also output content as ebook (ePub, Mobi, PDF).</p>
@@ -2420,64 +2420,64 @@ $ honkit mobi ./ ./mybook.mobi
 <li>Any important text should be visible in the small version</li>
 </ul>
 
-
+                                
 <hr>
 <div class="btn-group btn-group-justified">
-
+    
     <a class="btn" href="syntax/asciidoc.html"><b>Previous:</b> AsciiDoc</a>
-
-
+    
+    
     <a class="btn" href="templating/"><b>Next:</b> Templating</a>
-
+    
 </div>
 
                                 </section>
-
+                            
     </div>
     <div class="search-results">
         <div class="has-results">
-
+            
             <h1 class="search-results-title"><span class='search-results-count'></span> results matching "<span class='search-query'></span>"</h1>
             <ul class="search-results-list"></ul>
-
+            
         </div>
         <div class="no-results">
-
+            
             <h1 class="search-results-title">No results matching "<span class='search-query'></span>"</h1>
-
+            
         </div>
     </div>
 </div>
 
                         </div>
                     </div>
-
+                
             </div>
 
-
-
+            
+                
                 <a href="syntax/asciidoc.html" class="navigation navigation-prev " aria-label="Previous page: AsciiDoc">
                     <i class="fa fa-angle-left"></i>
                 </a>
-
-
+                
+                
                 <a href="templating/" class="navigation navigation-next " aria-label="Next page: Templating">
                     <i class="fa fa-angle-right"></i>
                 </a>
-
-
-
+                
+            
+        
     </div>
 
     <script>
         var gitbook = gitbook || [];
         gitbook.push(function() {
-
+            
         });
     </script>
 </div>
 
-
+        
     <noscript>
         <style>
             .honkit-cloak {
@@ -2524,27 +2524,27 @@ $ honkit mobi ./ ./mybook.mobi
     </script>
     <script src="gitbook/gitbook.js"></script>
     <script src="gitbook/theme.js"></script>
-
-
+    
+        
         <script src="gitbook/gitbook-plugin-search/search-engine.js"></script>
-
-
-
+        
+    
+        
         <script src="gitbook/gitbook-plugin-search/search.js"></script>
-
-
-
+        
+    
+        
         <script src="gitbook/gitbook-plugin-lunr/lunr.min.js"></script>
-
-
-
+        
+    
+        
         <script src="gitbook/gitbook-plugin-lunr/search-lunr.js"></script>
-
-
-
+        
+    
+        
         <script src="gitbook/gitbook-plugin-fontsettings/fontsettings.js"></script>
-
-
+        
+    
 
     </body>
 </html>
@@ -2570,50 +2570,50 @@ exports[`HonKit snapshots: encoding.html 1`] = `
         <title>Encoding · HonKit Documentation</title>
         <meta http-equiv="X-UA-Compatible" content="IE=edge" />
         <meta name="description" content="">
-
-
-
-
-
+        
+        
+        
+        
+    
     <link rel="stylesheet" href="gitbook/style.css">
 
-
-
-
+    
+            
+                
                 <link rel="stylesheet" href="gitbook/@honkit/honkit-plugin-highlight/website.css">
-
-
-
+                
+            
+                
                 <link rel="stylesheet" href="gitbook/gitbook-plugin-search/search.css">
-
-
-
+                
+            
+                
                 <link rel="stylesheet" href="gitbook/gitbook-plugin-fontsettings/website.css">
+                
+            
+        
 
+    
 
-
-
-
-
-
-
+    
+        
         <link rel="stylesheet" href="styles/website.css">
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
+        
+    
+    
     <meta name="HandheldFriendly" content="true"/>
     <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no">
     <meta name="apple-mobile-web-app-capable" content="yes">
@@ -2621,553 +2621,553 @@ exports[`HonKit snapshots: encoding.html 1`] = `
     <link rel="apple-touch-icon-precomposed" sizes="152x152" href="gitbook/images/apple-touch-icon-precomposed-152.png">
     <link rel="shortcut icon" href="gitbook/images/favicon.ico" type="image/x-icon">
 
-
-
+    
+    
 
     </head>
     <body>
-
+        
 <div class="book honkit-cloak">
     <div class="book-summary">
-
-
+        
+            
 <div id="book-search-input" role="search">
     <input type="text" placeholder="Type to search" />
 </div>
 
-
+            
                 <nav role="navigation">
-
+                
 
 
 <ul class="summary">
+    
+    
 
+    
 
-
-
-
-
-
+    
+        
         <li class="header">Getting Started</li>
-
-
-
+        
+        
+    
         <li class="chapter " data-level="1.1" data-path="./">
-
+            
                 <a href="./">
-
-
+            
+                    
                     About this documentation
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="1.2" data-path="setup.html">
-
+            
                 <a href="setup.html">
-
-
+            
+                    
                     Installation and Setup
-
+            
                 </a>
+            
 
-
-
+            
         </li>
+    
 
-
-
-
+    
+        
         <li class="header">Your Content</li>
-
-
-
+        
+        
+    
         <li class="chapter " data-level="2.1" data-path="structure.html">
-
+            
                 <a href="structure.html">
-
-
+            
+                    
                     Directory structure
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.2" data-path="pages.html">
-
+            
                 <a href="pages.html">
-
-
+            
+                    
                     Pages and Summary
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.3" data-path="config.html">
-
+            
                 <a href="config.html">
-
-
+            
+                    
                     Configuration
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.4" data-path="lexicon.html">
-
+            
                 <a href="lexicon.html">
-
-
+            
+                    
                     Glossary
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.5" data-path="languages.html">
-
+            
                 <a href="languages.html">
-
-
+            
+                    
                     Multi-Lingual
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.6" data-path="syntax/markdown.html">
-
+            
                 <a href="syntax/markdown.html">
-
-
+            
+                    
                     Markdown
-
+            
                 </a>
+            
 
-
-
+            
             <ul class="articles">
-
-
+                
+    
         <li class="chapter " data-level="2.6.1" data-path="syntax/markdown.html">
-
+            
                 <a href="syntax/markdown.html#headings">
-
-
+            
+                    
                     Headings
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.6.2" data-path="syntax/markdown.html">
-
+            
                 <a href="syntax/markdown.html#paragraphs">
-
-
+            
+                    
                     Paragraphs
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.6.3" data-path="syntax/markdown.html">
-
+            
                 <a href="syntax/markdown.html#lists">
-
-
+            
+                    
                     Lists
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.6.4" data-path="syntax/markdown.html">
-
+            
                 <a href="syntax/markdown.html#links">
-
-
+            
+                    
                     Links
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.6.5" data-path="syntax/markdown.html">
-
+            
                 <a href="syntax/markdown.html#images">
-
-
+            
+                    
                     Images
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.6.6" data-path="syntax/markdown.html">
-
+            
                 <a href="syntax/markdown.html#blockquotes">
-
-
+            
+                    
                     Blockquotes
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.6.7" data-path="syntax/markdown.html">
-
+            
                 <a href="syntax/markdown.html#tables">
-
-
+            
+                    
                     Tables
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.6.8" data-path="syntax/markdown.html">
-
+            
                 <a href="syntax/markdown.html#code">
-
-
+            
+                    
                     Code
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.6.9" data-path="syntax/markdown.html">
-
+            
                 <a href="syntax/markdown.html#html">
-
-
+            
+                    
                     HTML
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.6.10" data-path="syntax/markdown.html">
-
+            
                 <a href="syntax/markdown.html#footnotes">
-
-
+            
+                    
                     Footnotes
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
 
             </ul>
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.7" data-path="syntax/asciidoc.html">
-
+            
                 <a href="syntax/asciidoc.html">
-
-
+            
+                    
                     AsciiDoc
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.8" data-path="ebook.html">
-
+            
                 <a href="ebook.html">
-
-
+            
+                    
                     eBook and PDF
-
+            
                 </a>
+            
 
-
-
+            
         </li>
+    
 
-
-
-
+    
+        
         <li class="header">Customization</li>
-
-
-
+        
+        
+    
         <li class="chapter " data-level="3.1" data-path="templating/">
-
+            
                 <a href="templating/">
-
-
+            
+                    
                     Templating
-
+            
                 </a>
+            
 
-
-
+            
             <ul class="articles">
-
-
+                
+    
         <li class="chapter " data-level="3.1.1" data-path="templating/conrefs.html">
-
+            
                 <a href="templating/conrefs.html">
-
-
+            
+                    
                     Content References
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="3.1.2" data-path="templating/variables.html">
-
+            
                 <a href="templating/variables.html">
-
-
+            
+                    
                     Variables
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="3.1.3" data-path="templating/builtin.html">
-
+            
                 <a href="templating/builtin.html">
-
-
+            
+                    
                     Builtin
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
 
             </ul>
-
+            
         </li>
-
+    
         <li class="chapter " data-level="3.2" data-path="plugins/">
-
+            
                 <a href="plugins/">
-
-
+            
+                    
                     Plugins
-
+            
                 </a>
+            
 
-
-
+            
             <ul class="articles">
-
-
+                
+    
         <li class="chapter " data-level="3.2.1" data-path="plugins/create.html">
-
+            
                 <a href="plugins/create.html">
-
-
+            
+                    
                     Create a plugin
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="3.2.2" data-path="plugins/hooks.html">
-
+            
                 <a href="plugins/hooks.html">
-
-
+            
+                    
                     Hooks
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="3.2.3" data-path="plugins/blocks.html">
-
+            
                 <a href="plugins/blocks.html">
-
-
+            
+                    
                     Blocks
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="3.2.4" data-path="plugins/filters.html">
-
+            
                 <a href="plugins/filters.html">
-
-
+            
+                    
                     Filters
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="3.2.5" data-path="plugins/api.html">
-
+            
                 <a href="plugins/api.html">
-
-
+            
+                    
                     API & Context
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="3.2.6" data-path="plugins/testing.html">
-
+            
                 <a href="plugins/testing.html">
-
-
+            
+                    
                     Test your plugin
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
 
             </ul>
-
+            
         </li>
-
+    
         <li class="chapter " data-level="3.3" data-path="themes/">
-
+            
                 <a href="themes/">
-
-
+            
+                    
                     Theming
-
+            
                 </a>
+            
 
-
-
+            
         </li>
+    
 
-
-
-
+    
+        
         <li class="divider"></li>
-
-
-
+        
+        
+    
         <li class="chapter " data-level="4.1" data-path="faq.html">
-
+            
                 <a href="faq.html">
-
-
+            
+                    
                     FAQ
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="4.2" data-path="examples.md">
-
+            
                 <span>
-
-
+            
+                    
                     Examples
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="4.3" >
-
+            
                 <a target="_blank" href="https://github.com/honkit/honkit/blob/master/CHANGELOG.md">
-
-
+            
+                    
                     Release notes
-
+            
                 </a>
+            
 
-
-
+            
         </li>
+    
 
-
-
-
+    
+        
         <li class="divider"></li>
-
-
-
+        
+        
+    
         <li class="chapter active" data-level="5.1" data-path="encoding.html">
-
+            
                 <a href="encoding.html">
-
-
+            
+                    
                     Encoding
-
+            
                 </a>
+            
 
-
-
+            
         </li>
+    
 
-
-
+    
 
     <li class="divider"></li>
 
@@ -3180,18 +3180,18 @@ exports[`HonKit snapshots: encoding.html 1`] = `
 
 
                 </nav>
-
-
+            
+        
     </div>
 
     <div class="book-body">
-
+        
             <div class="body-inner">
-
-
+                
+                    
 
 <div class="book-header" role="navigation">
-
+    
 
     <!-- Title -->
     <h1>
@@ -3205,12 +3205,12 @@ exports[`HonKit snapshots: encoding.html 1`] = `
 
                     <div class="page-wrapper" tabindex="-1" role="main">
                         <div class="page-inner">
-
+                            
 <div id="book-search-results">
     <div class="search-noresults">
-
+    
                                 <section class="normal markdown-section">
-
+                                
 
                                 <h1 id="encoding">Encoding</h1>
 <table>
@@ -3248,52 +3248,52 @@ exports[`HonKit snapshots: encoding.html 1`] = `
 </tbody>
 </table>
 
-
+                                
 <hr>
 <div class="btn-group btn-group-justified">
-
-
+    
+    
 </div>
 
                                 </section>
-
+                            
     </div>
     <div class="search-results">
         <div class="has-results">
-
+            
             <h1 class="search-results-title"><span class='search-results-count'></span> results matching "<span class='search-query'></span>"</h1>
             <ul class="search-results-list"></ul>
-
+            
         </div>
         <div class="no-results">
-
+            
             <h1 class="search-results-title">No results matching "<span class='search-query'></span>"</h1>
-
+            
         </div>
     </div>
 </div>
 
                         </div>
                     </div>
-
+                
             </div>
 
-
-
-
-
-
+            
+                
+                
+            
+        
     </div>
 
     <script>
         var gitbook = gitbook || [];
         gitbook.push(function() {
-
+            
         });
     </script>
 </div>
 
-
+        
     <noscript>
         <style>
             .honkit-cloak {
@@ -3340,27 +3340,27 @@ exports[`HonKit snapshots: encoding.html 1`] = `
     </script>
     <script src="gitbook/gitbook.js"></script>
     <script src="gitbook/theme.js"></script>
-
-
+    
+        
         <script src="gitbook/gitbook-plugin-search/search-engine.js"></script>
-
-
-
+        
+    
+        
         <script src="gitbook/gitbook-plugin-search/search.js"></script>
-
-
-
+        
+    
+        
         <script src="gitbook/gitbook-plugin-lunr/lunr.min.js"></script>
-
-
-
+        
+    
+        
         <script src="gitbook/gitbook-plugin-lunr/search-lunr.js"></script>
-
-
-
+        
+    
+        
         <script src="gitbook/gitbook-plugin-fontsettings/fontsettings.js"></script>
-
-
+        
+    
 
     </body>
 </html>
@@ -3386,50 +3386,50 @@ exports[`HonKit snapshots: faq.html 1`] = `
         <title>FAQ · HonKit Documentation</title>
         <meta http-equiv="X-UA-Compatible" content="IE=edge" />
         <meta name="description" content="">
-
-
-
-
-
+        
+        
+        
+        
+    
     <link rel="stylesheet" href="gitbook/style.css">
 
-
-
-
+    
+            
+                
                 <link rel="stylesheet" href="gitbook/@honkit/honkit-plugin-highlight/website.css">
-
-
-
+                
+            
+                
                 <link rel="stylesheet" href="gitbook/gitbook-plugin-search/search.css">
-
-
-
+                
+            
+                
                 <link rel="stylesheet" href="gitbook/gitbook-plugin-fontsettings/website.css">
+                
+            
+        
 
+    
 
-
-
-
-
-
-
+    
+        
         <link rel="stylesheet" href="styles/website.css">
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
+        
+    
+    
     <meta name="HandheldFriendly" content="true"/>
     <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no">
     <meta name="apple-mobile-web-app-capable" content="yes">
@@ -3437,557 +3437,557 @@ exports[`HonKit snapshots: faq.html 1`] = `
     <link rel="apple-touch-icon-precomposed" sizes="152x152" href="gitbook/images/apple-touch-icon-precomposed-152.png">
     <link rel="shortcut icon" href="gitbook/images/favicon.ico" type="image/x-icon">
 
-
+    
     <link rel="next" href="examples.md" />
-
-
+    
+    
     <link rel="prev" href="themes/" />
-
+    
 
     </head>
     <body>
-
+        
 <div class="book honkit-cloak">
     <div class="book-summary">
-
-
+        
+            
 <div id="book-search-input" role="search">
     <input type="text" placeholder="Type to search" />
 </div>
 
-
+            
                 <nav role="navigation">
-
+                
 
 
 <ul class="summary">
+    
+    
 
+    
 
-
-
-
-
-
+    
+        
         <li class="header">Getting Started</li>
-
-
-
+        
+        
+    
         <li class="chapter " data-level="1.1" data-path="./">
-
+            
                 <a href="./">
-
-
+            
+                    
                     About this documentation
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="1.2" data-path="setup.html">
-
+            
                 <a href="setup.html">
-
-
+            
+                    
                     Installation and Setup
-
+            
                 </a>
+            
 
-
-
+            
         </li>
+    
 
-
-
-
+    
+        
         <li class="header">Your Content</li>
-
-
-
+        
+        
+    
         <li class="chapter " data-level="2.1" data-path="structure.html">
-
+            
                 <a href="structure.html">
-
-
+            
+                    
                     Directory structure
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.2" data-path="pages.html">
-
+            
                 <a href="pages.html">
-
-
+            
+                    
                     Pages and Summary
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.3" data-path="config.html">
-
+            
                 <a href="config.html">
-
-
+            
+                    
                     Configuration
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.4" data-path="lexicon.html">
-
+            
                 <a href="lexicon.html">
-
-
+            
+                    
                     Glossary
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.5" data-path="languages.html">
-
+            
                 <a href="languages.html">
-
-
+            
+                    
                     Multi-Lingual
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.6" data-path="syntax/markdown.html">
-
+            
                 <a href="syntax/markdown.html">
-
-
+            
+                    
                     Markdown
-
+            
                 </a>
+            
 
-
-
+            
             <ul class="articles">
-
-
+                
+    
         <li class="chapter " data-level="2.6.1" data-path="syntax/markdown.html">
-
+            
                 <a href="syntax/markdown.html#headings">
-
-
+            
+                    
                     Headings
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.6.2" data-path="syntax/markdown.html">
-
+            
                 <a href="syntax/markdown.html#paragraphs">
-
-
+            
+                    
                     Paragraphs
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.6.3" data-path="syntax/markdown.html">
-
+            
                 <a href="syntax/markdown.html#lists">
-
-
+            
+                    
                     Lists
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.6.4" data-path="syntax/markdown.html">
-
+            
                 <a href="syntax/markdown.html#links">
-
-
+            
+                    
                     Links
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.6.5" data-path="syntax/markdown.html">
-
+            
                 <a href="syntax/markdown.html#images">
-
-
+            
+                    
                     Images
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.6.6" data-path="syntax/markdown.html">
-
+            
                 <a href="syntax/markdown.html#blockquotes">
-
-
+            
+                    
                     Blockquotes
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.6.7" data-path="syntax/markdown.html">
-
+            
                 <a href="syntax/markdown.html#tables">
-
-
+            
+                    
                     Tables
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.6.8" data-path="syntax/markdown.html">
-
+            
                 <a href="syntax/markdown.html#code">
-
-
+            
+                    
                     Code
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.6.9" data-path="syntax/markdown.html">
-
+            
                 <a href="syntax/markdown.html#html">
-
-
+            
+                    
                     HTML
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.6.10" data-path="syntax/markdown.html">
-
+            
                 <a href="syntax/markdown.html#footnotes">
-
-
+            
+                    
                     Footnotes
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
 
             </ul>
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.7" data-path="syntax/asciidoc.html">
-
+            
                 <a href="syntax/asciidoc.html">
-
-
+            
+                    
                     AsciiDoc
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.8" data-path="ebook.html">
-
+            
                 <a href="ebook.html">
-
-
+            
+                    
                     eBook and PDF
-
+            
                 </a>
+            
 
-
-
+            
         </li>
+    
 
-
-
-
+    
+        
         <li class="header">Customization</li>
-
-
-
+        
+        
+    
         <li class="chapter " data-level="3.1" data-path="templating/">
-
+            
                 <a href="templating/">
-
-
+            
+                    
                     Templating
-
+            
                 </a>
+            
 
-
-
+            
             <ul class="articles">
-
-
+                
+    
         <li class="chapter " data-level="3.1.1" data-path="templating/conrefs.html">
-
+            
                 <a href="templating/conrefs.html">
-
-
+            
+                    
                     Content References
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="3.1.2" data-path="templating/variables.html">
-
+            
                 <a href="templating/variables.html">
-
-
+            
+                    
                     Variables
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="3.1.3" data-path="templating/builtin.html">
-
+            
                 <a href="templating/builtin.html">
-
-
+            
+                    
                     Builtin
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
 
             </ul>
-
+            
         </li>
-
+    
         <li class="chapter " data-level="3.2" data-path="plugins/">
-
+            
                 <a href="plugins/">
-
-
+            
+                    
                     Plugins
-
+            
                 </a>
+            
 
-
-
+            
             <ul class="articles">
-
-
+                
+    
         <li class="chapter " data-level="3.2.1" data-path="plugins/create.html">
-
+            
                 <a href="plugins/create.html">
-
-
+            
+                    
                     Create a plugin
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="3.2.2" data-path="plugins/hooks.html">
-
+            
                 <a href="plugins/hooks.html">
-
-
+            
+                    
                     Hooks
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="3.2.3" data-path="plugins/blocks.html">
-
+            
                 <a href="plugins/blocks.html">
-
-
+            
+                    
                     Blocks
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="3.2.4" data-path="plugins/filters.html">
-
+            
                 <a href="plugins/filters.html">
-
-
+            
+                    
                     Filters
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="3.2.5" data-path="plugins/api.html">
-
+            
                 <a href="plugins/api.html">
-
-
+            
+                    
                     API & Context
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="3.2.6" data-path="plugins/testing.html">
-
+            
                 <a href="plugins/testing.html">
-
-
+            
+                    
                     Test your plugin
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
 
             </ul>
-
+            
         </li>
-
+    
         <li class="chapter " data-level="3.3" data-path="themes/">
-
+            
                 <a href="themes/">
-
-
+            
+                    
                     Theming
-
+            
                 </a>
+            
 
-
-
+            
         </li>
+    
 
-
-
-
+    
+        
         <li class="divider"></li>
-
-
-
+        
+        
+    
         <li class="chapter active" data-level="4.1" data-path="faq.html">
-
+            
                 <a href="faq.html">
-
-
+            
+                    
                     FAQ
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="4.2" data-path="examples.md">
-
+            
                 <span>
-
-
+            
+                    
                     Examples
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="4.3" >
-
+            
                 <a target="_blank" href="https://github.com/honkit/honkit/blob/master/CHANGELOG.md">
-
-
+            
+                    
                     Release notes
-
+            
                 </a>
+            
 
-
-
+            
         </li>
+    
 
-
-
-
+    
+        
         <li class="divider"></li>
-
-
-
+        
+        
+    
         <li class="chapter " data-level="5.1" data-path="encoding.html">
-
+            
                 <a href="encoding.html">
-
-
+            
+                    
                     Encoding
-
+            
                 </a>
+            
 
-
-
+            
         </li>
+    
 
-
-
+    
 
     <li class="divider"></li>
 
@@ -4000,18 +4000,18 @@ exports[`HonKit snapshots: faq.html 1`] = `
 
 
                 </nav>
-
-
+            
+        
     </div>
 
     <div class="book-body">
-
+        
             <div class="body-inner">
-
-
+                
+                    
 
 <div class="book-header" role="navigation">
-
+    
 
     <!-- Title -->
     <h1>
@@ -4025,12 +4025,12 @@ exports[`HonKit snapshots: faq.html 1`] = `
 
                     <div class="page-wrapper" tabindex="-1" role="main">
                         <div class="page-inner">
-
+                            
 <div id="book-search-results">
     <div class="search-noresults">
-
+    
                                 <section class="normal markdown-section">
-
+                                
 
                                 <h1 id="honkit-faq">HonKit FAQ</h1>
 <p>This page gathers common questions and answers concerning the <a href="GLOSSARY.html#honkit" class="glossary-term" title="Honkit is a command line tool for building beautiful books using GitHub/Git and Markdown (or AsciiDoc).">HonKit</a> format and toolchain.</p>
@@ -4065,64 +4065,64 @@ In some case, <a href="GLOSSARY.html#honkit" class="glossary-term" title="Honkit
 <h4 id="can-i-add-interactive-content-videos-etc">Can I add interactive content (videos, etc)?</h4>
 <p><a href="GLOSSARY.html#honkit" class="glossary-term" title="Honkit is a command line tool for building beautiful books using GitHub/Git and Markdown (or AsciiDoc).">HonKit</a> is very <a href="plugins/">extensible</a>. You can use <a href="https://plugins.honkit.com" target="_blank">existing plugins</a> or create your own!</p>
 
-
+                                
 <hr>
 <div class="btn-group btn-group-justified">
-
+    
     <a class="btn" href="themes/"><b>Previous:</b> Theming</a>
-
-
+    
+    
     <a class="btn" href="examples.md"><b>Next:</b> Examples</a>
-
+    
 </div>
 
                                 </section>
-
+                            
     </div>
     <div class="search-results">
         <div class="has-results">
-
+            
             <h1 class="search-results-title"><span class='search-results-count'></span> results matching "<span class='search-query'></span>"</h1>
             <ul class="search-results-list"></ul>
-
+            
         </div>
         <div class="no-results">
-
+            
             <h1 class="search-results-title">No results matching "<span class='search-query'></span>"</h1>
-
+            
         </div>
     </div>
 </div>
 
                         </div>
                     </div>
-
+                
             </div>
 
-
-
+            
+                
                 <a href="themes/" class="navigation navigation-prev " aria-label="Previous page: Theming">
                     <i class="fa fa-angle-left"></i>
                 </a>
-
-
+                
+                
                 <a href="examples.md" class="navigation navigation-next " aria-label="Next page: Examples">
                     <i class="fa fa-angle-right"></i>
                 </a>
-
-
-
+                
+            
+        
     </div>
 
     <script>
         var gitbook = gitbook || [];
         gitbook.push(function() {
-
+            
         });
     </script>
 </div>
 
-
+        
     <noscript>
         <style>
             .honkit-cloak {
@@ -4169,27 +4169,27 @@ In some case, <a href="GLOSSARY.html#honkit" class="glossary-term" title="Honkit
     </script>
     <script src="gitbook/gitbook.js"></script>
     <script src="gitbook/theme.js"></script>
-
-
+    
+        
         <script src="gitbook/gitbook-plugin-search/search-engine.js"></script>
-
-
-
+        
+    
+        
         <script src="gitbook/gitbook-plugin-search/search.js"></script>
-
-
-
+        
+    
+        
         <script src="gitbook/gitbook-plugin-lunr/lunr.min.js"></script>
-
-
-
+        
+    
+        
         <script src="gitbook/gitbook-plugin-lunr/search-lunr.js"></script>
-
-
-
+        
+    
+        
         <script src="gitbook/gitbook-plugin-fontsettings/fontsettings.js"></script>
-
-
+        
+    
 
     </body>
 </html>
@@ -4215,50 +4215,50 @@ exports[`HonKit snapshots: index.html 1`] = `
         <title>About this documentation · HonKit Documentation</title>
         <meta http-equiv="X-UA-Compatible" content="IE=edge" />
         <meta name="description" content="">
-
-
-
-
-
+        
+        
+        
+        
+    
     <link rel="stylesheet" href="gitbook/style.css">
 
-
-
-
+    
+            
+                
                 <link rel="stylesheet" href="gitbook/@honkit/honkit-plugin-highlight/website.css">
-
-
-
+                
+            
+                
                 <link rel="stylesheet" href="gitbook/gitbook-plugin-search/search.css">
-
-
-
+                
+            
+                
                 <link rel="stylesheet" href="gitbook/gitbook-plugin-fontsettings/website.css">
+                
+            
+        
 
+    
 
-
-
-
-
-
-
+    
+        
         <link rel="stylesheet" href="styles/website.css">
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
+        
+    
+    
     <meta name="HandheldFriendly" content="true"/>
     <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no">
     <meta name="apple-mobile-web-app-capable" content="yes">
@@ -4266,555 +4266,555 @@ exports[`HonKit snapshots: index.html 1`] = `
     <link rel="apple-touch-icon-precomposed" sizes="152x152" href="gitbook/images/apple-touch-icon-precomposed-152.png">
     <link rel="shortcut icon" href="gitbook/images/favicon.ico" type="image/x-icon">
 
-
+    
     <link rel="next" href="setup.html" />
-
-
+    
+    
 
     </head>
     <body>
-
+        
 <div class="book honkit-cloak">
     <div class="book-summary">
-
-
+        
+            
 <div id="book-search-input" role="search">
     <input type="text" placeholder="Type to search" />
 </div>
 
-
+            
                 <nav role="navigation">
-
+                
 
 
 <ul class="summary">
+    
+    
 
+    
 
-
-
-
-
-
+    
+        
         <li class="header">Getting Started</li>
-
-
-
+        
+        
+    
         <li class="chapter active" data-level="1.1" data-path="./">
-
+            
                 <a href="./">
-
-
+            
+                    
                     About this documentation
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="1.2" data-path="setup.html">
-
+            
                 <a href="setup.html">
-
-
+            
+                    
                     Installation and Setup
-
+            
                 </a>
+            
 
-
-
+            
         </li>
+    
 
-
-
-
+    
+        
         <li class="header">Your Content</li>
-
-
-
+        
+        
+    
         <li class="chapter " data-level="2.1" data-path="structure.html">
-
+            
                 <a href="structure.html">
-
-
+            
+                    
                     Directory structure
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.2" data-path="pages.html">
-
+            
                 <a href="pages.html">
-
-
+            
+                    
                     Pages and Summary
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.3" data-path="config.html">
-
+            
                 <a href="config.html">
-
-
+            
+                    
                     Configuration
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.4" data-path="lexicon.html">
-
+            
                 <a href="lexicon.html">
-
-
+            
+                    
                     Glossary
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.5" data-path="languages.html">
-
+            
                 <a href="languages.html">
-
-
+            
+                    
                     Multi-Lingual
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.6" data-path="syntax/markdown.html">
-
+            
                 <a href="syntax/markdown.html">
-
-
+            
+                    
                     Markdown
-
+            
                 </a>
+            
 
-
-
+            
             <ul class="articles">
-
-
+                
+    
         <li class="chapter " data-level="2.6.1" data-path="syntax/markdown.html">
-
+            
                 <a href="syntax/markdown.html#headings">
-
-
+            
+                    
                     Headings
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.6.2" data-path="syntax/markdown.html">
-
+            
                 <a href="syntax/markdown.html#paragraphs">
-
-
+            
+                    
                     Paragraphs
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.6.3" data-path="syntax/markdown.html">
-
+            
                 <a href="syntax/markdown.html#lists">
-
-
+            
+                    
                     Lists
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.6.4" data-path="syntax/markdown.html">
-
+            
                 <a href="syntax/markdown.html#links">
-
-
+            
+                    
                     Links
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.6.5" data-path="syntax/markdown.html">
-
+            
                 <a href="syntax/markdown.html#images">
-
-
+            
+                    
                     Images
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.6.6" data-path="syntax/markdown.html">
-
+            
                 <a href="syntax/markdown.html#blockquotes">
-
-
+            
+                    
                     Blockquotes
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.6.7" data-path="syntax/markdown.html">
-
+            
                 <a href="syntax/markdown.html#tables">
-
-
+            
+                    
                     Tables
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.6.8" data-path="syntax/markdown.html">
-
+            
                 <a href="syntax/markdown.html#code">
-
-
+            
+                    
                     Code
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.6.9" data-path="syntax/markdown.html">
-
+            
                 <a href="syntax/markdown.html#html">
-
-
+            
+                    
                     HTML
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.6.10" data-path="syntax/markdown.html">
-
+            
                 <a href="syntax/markdown.html#footnotes">
-
-
+            
+                    
                     Footnotes
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
 
             </ul>
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.7" data-path="syntax/asciidoc.html">
-
+            
                 <a href="syntax/asciidoc.html">
-
-
+            
+                    
                     AsciiDoc
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.8" data-path="ebook.html">
-
+            
                 <a href="ebook.html">
-
-
+            
+                    
                     eBook and PDF
-
+            
                 </a>
+            
 
-
-
+            
         </li>
+    
 
-
-
-
+    
+        
         <li class="header">Customization</li>
-
-
-
+        
+        
+    
         <li class="chapter " data-level="3.1" data-path="templating/">
-
+            
                 <a href="templating/">
-
-
+            
+                    
                     Templating
-
+            
                 </a>
+            
 
-
-
+            
             <ul class="articles">
-
-
+                
+    
         <li class="chapter " data-level="3.1.1" data-path="templating/conrefs.html">
-
+            
                 <a href="templating/conrefs.html">
-
-
+            
+                    
                     Content References
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="3.1.2" data-path="templating/variables.html">
-
+            
                 <a href="templating/variables.html">
-
-
+            
+                    
                     Variables
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="3.1.3" data-path="templating/builtin.html">
-
+            
                 <a href="templating/builtin.html">
-
-
+            
+                    
                     Builtin
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
 
             </ul>
-
+            
         </li>
-
+    
         <li class="chapter " data-level="3.2" data-path="plugins/">
-
+            
                 <a href="plugins/">
-
-
+            
+                    
                     Plugins
-
+            
                 </a>
+            
 
-
-
+            
             <ul class="articles">
-
-
+                
+    
         <li class="chapter " data-level="3.2.1" data-path="plugins/create.html">
-
+            
                 <a href="plugins/create.html">
-
-
+            
+                    
                     Create a plugin
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="3.2.2" data-path="plugins/hooks.html">
-
+            
                 <a href="plugins/hooks.html">
-
-
+            
+                    
                     Hooks
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="3.2.3" data-path="plugins/blocks.html">
-
+            
                 <a href="plugins/blocks.html">
-
-
+            
+                    
                     Blocks
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="3.2.4" data-path="plugins/filters.html">
-
+            
                 <a href="plugins/filters.html">
-
-
+            
+                    
                     Filters
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="3.2.5" data-path="plugins/api.html">
-
+            
                 <a href="plugins/api.html">
-
-
+            
+                    
                     API & Context
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="3.2.6" data-path="plugins/testing.html">
-
+            
                 <a href="plugins/testing.html">
-
-
+            
+                    
                     Test your plugin
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
 
             </ul>
-
+            
         </li>
-
+    
         <li class="chapter " data-level="3.3" data-path="themes/">
-
+            
                 <a href="themes/">
-
-
+            
+                    
                     Theming
-
+            
                 </a>
+            
 
-
-
+            
         </li>
+    
 
-
-
-
+    
+        
         <li class="divider"></li>
-
-
-
+        
+        
+    
         <li class="chapter " data-level="4.1" data-path="faq.html">
-
+            
                 <a href="faq.html">
-
-
+            
+                    
                     FAQ
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="4.2" data-path="examples.md">
-
+            
                 <span>
-
-
+            
+                    
                     Examples
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="4.3" >
-
+            
                 <a target="_blank" href="https://github.com/honkit/honkit/blob/master/CHANGELOG.md">
-
-
+            
+                    
                     Release notes
-
+            
                 </a>
+            
 
-
-
+            
         </li>
+    
 
-
-
-
+    
+        
         <li class="divider"></li>
-
-
-
+        
+        
+    
         <li class="chapter " data-level="5.1" data-path="encoding.html">
-
+            
                 <a href="encoding.html">
-
-
+            
+                    
                     Encoding
-
+            
                 </a>
+            
 
-
-
+            
         </li>
+    
 
-
-
+    
 
     <li class="divider"></li>
 
@@ -4827,18 +4827,18 @@ exports[`HonKit snapshots: index.html 1`] = `
 
 
                 </nav>
-
-
+            
+        
     </div>
 
     <div class="book-body">
-
+        
             <div class="body-inner">
-
-
+                
+                    
 
 <div class="book-header" role="navigation">
-
+    
 
     <!-- Title -->
     <h1>
@@ -4852,12 +4852,12 @@ exports[`HonKit snapshots: index.html 1`] = `
 
                     <div class="page-wrapper" tabindex="-1" role="main">
                         <div class="page-inner">
-
+                            
 <div id="book-search-results">
     <div class="search-noresults">
-
+    
                                 <section class="normal markdown-section">
-
+                                
 
                                 <h1 id="honkit-toolchain-documentation">HonKit Toolchain Documentation</h1>
 <p>This document aims to be a comprehensive guide to the <a href="GLOSSARY.html#honkit" class="glossary-term" title="Honkit is a command line tool for building beautiful books using GitHub/Git and Markdown (or AsciiDoc).">HonKit</a> command line tool.</p>
@@ -4872,58 +4872,58 @@ exports[`HonKit snapshots: index.html 1`] = `
 <h3 id="contribute-to-this-documentation">Contribute to this documentation</h3>
 <p>You can contribute to improve this documentation on <a href="https://github.com/honkit/honkit" target="_blank">GitHub</a> by signaling issues or proposing changes.</p>
 
-
+                                
 <hr>
 <div class="btn-group btn-group-justified">
-
-
+    
+    
     <a class="btn" href="setup.html"><b>Next:</b> Installation and Setup</a>
-
+    
 </div>
 
                                 </section>
-
+                            
     </div>
     <div class="search-results">
         <div class="has-results">
-
+            
             <h1 class="search-results-title"><span class='search-results-count'></span> results matching "<span class='search-query'></span>"</h1>
             <ul class="search-results-list"></ul>
-
+            
         </div>
         <div class="no-results">
-
+            
             <h1 class="search-results-title">No results matching "<span class='search-query'></span>"</h1>
-
+            
         </div>
     </div>
 </div>
 
                         </div>
                     </div>
-
+                
             </div>
 
-
-
-
+            
+                
+                
                 <a href="setup.html" class="navigation navigation-next navigation-unique" aria-label="Next page: Installation and Setup">
                     <i class="fa fa-angle-right"></i>
                 </a>
-
-
-
+                
+            
+        
     </div>
 
     <script>
         var gitbook = gitbook || [];
         gitbook.push(function() {
-
+            
         });
     </script>
 </div>
 
-
+        
     <noscript>
         <style>
             .honkit-cloak {
@@ -4970,27 +4970,27 @@ exports[`HonKit snapshots: index.html 1`] = `
     </script>
     <script src="gitbook/gitbook.js"></script>
     <script src="gitbook/theme.js"></script>
-
-
+    
+        
         <script src="gitbook/gitbook-plugin-search/search-engine.js"></script>
-
-
-
+        
+    
+        
         <script src="gitbook/gitbook-plugin-search/search.js"></script>
-
-
-
+        
+    
+        
         <script src="gitbook/gitbook-plugin-lunr/lunr.min.js"></script>
-
-
-
+        
+    
+        
         <script src="gitbook/gitbook-plugin-lunr/search-lunr.js"></script>
-
-
-
+        
+    
+        
         <script src="gitbook/gitbook-plugin-fontsettings/fontsettings.js"></script>
-
-
+        
+    
 
     </body>
 </html>
@@ -5016,50 +5016,50 @@ exports[`HonKit snapshots: languages.html 1`] = `
         <title>Multi-Lingual · HonKit Documentation</title>
         <meta http-equiv="X-UA-Compatible" content="IE=edge" />
         <meta name="description" content="">
-
-
-
-
-
+        
+        
+        
+        
+    
     <link rel="stylesheet" href="gitbook/style.css">
 
-
-
-
+    
+            
+                
                 <link rel="stylesheet" href="gitbook/@honkit/honkit-plugin-highlight/website.css">
-
-
-
+                
+            
+                
                 <link rel="stylesheet" href="gitbook/gitbook-plugin-search/search.css">
-
-
-
+                
+            
+                
                 <link rel="stylesheet" href="gitbook/gitbook-plugin-fontsettings/website.css">
+                
+            
+        
 
+    
 
-
-
-
-
-
-
+    
+        
         <link rel="stylesheet" href="styles/website.css">
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
+        
+    
+    
     <meta name="HandheldFriendly" content="true"/>
     <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no">
     <meta name="apple-mobile-web-app-capable" content="yes">
@@ -5067,557 +5067,557 @@ exports[`HonKit snapshots: languages.html 1`] = `
     <link rel="apple-touch-icon-precomposed" sizes="152x152" href="gitbook/images/apple-touch-icon-precomposed-152.png">
     <link rel="shortcut icon" href="gitbook/images/favicon.ico" type="image/x-icon">
 
-
+    
     <link rel="next" href="syntax/markdown.html" />
-
-
+    
+    
     <link rel="prev" href="lexicon.html" />
-
+    
 
     </head>
     <body>
-
+        
 <div class="book honkit-cloak">
     <div class="book-summary">
-
-
+        
+            
 <div id="book-search-input" role="search">
     <input type="text" placeholder="Type to search" />
 </div>
 
-
+            
                 <nav role="navigation">
-
+                
 
 
 <ul class="summary">
+    
+    
 
+    
 
-
-
-
-
-
+    
+        
         <li class="header">Getting Started</li>
-
-
-
+        
+        
+    
         <li class="chapter " data-level="1.1" data-path="./">
-
+            
                 <a href="./">
-
-
+            
+                    
                     About this documentation
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="1.2" data-path="setup.html">
-
+            
                 <a href="setup.html">
-
-
+            
+                    
                     Installation and Setup
-
+            
                 </a>
+            
 
-
-
+            
         </li>
+    
 
-
-
-
+    
+        
         <li class="header">Your Content</li>
-
-
-
+        
+        
+    
         <li class="chapter " data-level="2.1" data-path="structure.html">
-
+            
                 <a href="structure.html">
-
-
+            
+                    
                     Directory structure
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.2" data-path="pages.html">
-
+            
                 <a href="pages.html">
-
-
+            
+                    
                     Pages and Summary
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.3" data-path="config.html">
-
+            
                 <a href="config.html">
-
-
+            
+                    
                     Configuration
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.4" data-path="lexicon.html">
-
+            
                 <a href="lexicon.html">
-
-
+            
+                    
                     Glossary
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter active" data-level="2.5" data-path="languages.html">
-
+            
                 <a href="languages.html">
-
-
+            
+                    
                     Multi-Lingual
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.6" data-path="syntax/markdown.html">
-
+            
                 <a href="syntax/markdown.html">
-
-
+            
+                    
                     Markdown
-
+            
                 </a>
+            
 
-
-
+            
             <ul class="articles">
-
-
+                
+    
         <li class="chapter " data-level="2.6.1" data-path="syntax/markdown.html">
-
+            
                 <a href="syntax/markdown.html#headings">
-
-
+            
+                    
                     Headings
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.6.2" data-path="syntax/markdown.html">
-
+            
                 <a href="syntax/markdown.html#paragraphs">
-
-
+            
+                    
                     Paragraphs
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.6.3" data-path="syntax/markdown.html">
-
+            
                 <a href="syntax/markdown.html#lists">
-
-
+            
+                    
                     Lists
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.6.4" data-path="syntax/markdown.html">
-
+            
                 <a href="syntax/markdown.html#links">
-
-
+            
+                    
                     Links
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.6.5" data-path="syntax/markdown.html">
-
+            
                 <a href="syntax/markdown.html#images">
-
-
+            
+                    
                     Images
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.6.6" data-path="syntax/markdown.html">
-
+            
                 <a href="syntax/markdown.html#blockquotes">
-
-
+            
+                    
                     Blockquotes
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.6.7" data-path="syntax/markdown.html">
-
+            
                 <a href="syntax/markdown.html#tables">
-
-
+            
+                    
                     Tables
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.6.8" data-path="syntax/markdown.html">
-
+            
                 <a href="syntax/markdown.html#code">
-
-
+            
+                    
                     Code
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.6.9" data-path="syntax/markdown.html">
-
+            
                 <a href="syntax/markdown.html#html">
-
-
+            
+                    
                     HTML
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.6.10" data-path="syntax/markdown.html">
-
+            
                 <a href="syntax/markdown.html#footnotes">
-
-
+            
+                    
                     Footnotes
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
 
             </ul>
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.7" data-path="syntax/asciidoc.html">
-
+            
                 <a href="syntax/asciidoc.html">
-
-
+            
+                    
                     AsciiDoc
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.8" data-path="ebook.html">
-
+            
                 <a href="ebook.html">
-
-
+            
+                    
                     eBook and PDF
-
+            
                 </a>
+            
 
-
-
+            
         </li>
+    
 
-
-
-
+    
+        
         <li class="header">Customization</li>
-
-
-
+        
+        
+    
         <li class="chapter " data-level="3.1" data-path="templating/">
-
+            
                 <a href="templating/">
-
-
+            
+                    
                     Templating
-
+            
                 </a>
+            
 
-
-
+            
             <ul class="articles">
-
-
+                
+    
         <li class="chapter " data-level="3.1.1" data-path="templating/conrefs.html">
-
+            
                 <a href="templating/conrefs.html">
-
-
+            
+                    
                     Content References
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="3.1.2" data-path="templating/variables.html">
-
+            
                 <a href="templating/variables.html">
-
-
+            
+                    
                     Variables
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="3.1.3" data-path="templating/builtin.html">
-
+            
                 <a href="templating/builtin.html">
-
-
+            
+                    
                     Builtin
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
 
             </ul>
-
+            
         </li>
-
+    
         <li class="chapter " data-level="3.2" data-path="plugins/">
-
+            
                 <a href="plugins/">
-
-
+            
+                    
                     Plugins
-
+            
                 </a>
+            
 
-
-
+            
             <ul class="articles">
-
-
+                
+    
         <li class="chapter " data-level="3.2.1" data-path="plugins/create.html">
-
+            
                 <a href="plugins/create.html">
-
-
+            
+                    
                     Create a plugin
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="3.2.2" data-path="plugins/hooks.html">
-
+            
                 <a href="plugins/hooks.html">
-
-
+            
+                    
                     Hooks
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="3.2.3" data-path="plugins/blocks.html">
-
+            
                 <a href="plugins/blocks.html">
-
-
+            
+                    
                     Blocks
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="3.2.4" data-path="plugins/filters.html">
-
+            
                 <a href="plugins/filters.html">
-
-
+            
+                    
                     Filters
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="3.2.5" data-path="plugins/api.html">
-
+            
                 <a href="plugins/api.html">
-
-
+            
+                    
                     API & Context
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="3.2.6" data-path="plugins/testing.html">
-
+            
                 <a href="plugins/testing.html">
-
-
+            
+                    
                     Test your plugin
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
 
             </ul>
-
+            
         </li>
-
+    
         <li class="chapter " data-level="3.3" data-path="themes/">
-
+            
                 <a href="themes/">
-
-
+            
+                    
                     Theming
-
+            
                 </a>
+            
 
-
-
+            
         </li>
+    
 
-
-
-
+    
+        
         <li class="divider"></li>
-
-
-
+        
+        
+    
         <li class="chapter " data-level="4.1" data-path="faq.html">
-
+            
                 <a href="faq.html">
-
-
+            
+                    
                     FAQ
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="4.2" data-path="examples.md">
-
+            
                 <span>
-
-
+            
+                    
                     Examples
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="4.3" >
-
+            
                 <a target="_blank" href="https://github.com/honkit/honkit/blob/master/CHANGELOG.md">
-
-
+            
+                    
                     Release notes
-
+            
                 </a>
+            
 
-
-
+            
         </li>
+    
 
-
-
-
+    
+        
         <li class="divider"></li>
-
-
-
+        
+        
+    
         <li class="chapter " data-level="5.1" data-path="encoding.html">
-
+            
                 <a href="encoding.html">
-
-
+            
+                    
                     Encoding
-
+            
                 </a>
+            
 
-
-
+            
         </li>
+    
 
-
-
+    
 
     <li class="divider"></li>
 
@@ -5630,18 +5630,18 @@ exports[`HonKit snapshots: languages.html 1`] = `
 
 
                 </nav>
-
-
+            
+        
     </div>
 
     <div class="book-body">
-
+        
             <div class="body-inner">
-
-
+                
+                    
 
 <div class="book-header" role="navigation">
-
+    
 
     <!-- Title -->
     <h1>
@@ -5655,12 +5655,12 @@ exports[`HonKit snapshots: languages.html 1`] = `
 
                     <div class="page-wrapper" tabindex="-1" role="main">
                         <div class="page-inner">
-
+                            
 <div id="book-search-results">
     <div class="search-noresults">
-
+    
                                 <section class="normal markdown-section">
-
+                                
 
                                 <h1 id="multi-languages">Multi-Languages</h1>
 <p><a href="GLOSSARY.html#honkit" class="glossary-term" title="Honkit is a command line tool for building beautiful books using GitHub/Git and Markdown (or AsciiDoc).">HonKit</a> supports building books written in multiple languages. Each language should be a sub-directory following the normal <a href="GLOSSARY.html#honkit" class="glossary-term" title="Honkit is a command line tool for building beautiful books using GitHub/Git and Markdown (or AsciiDoc).">HonKit</a> format, and a file named <code>LANGS.md</code> should be present at the root of the repository with the following format:</p>
@@ -5674,64 +5674,64 @@ exports[`HonKit snapshots: languages.html 1`] = `
 <p>When a language book (ex: <code>en</code>) has a <code>book.json</code>, its configuration will extend the main configuration.</p>
 <p>The only exception is <a href="GLOSSARY.html#plugins" class="glossary-term" title="Plugins are the best way to extend HonKit functionalities (ebook and website).">plugins</a>, <a href="GLOSSARY.html#plugins" class="glossary-term" title="Plugins are the best way to extend HonKit functionalities (ebook and website).">plugins</a> are specified globally, and language specific <a href="GLOSSARY.html#plugins" class="glossary-term" title="Plugins are the best way to extend HonKit functionalities (ebook and website).">plugins</a> cannot be specified.</p>
 
-
+                                
 <hr>
 <div class="btn-group btn-group-justified">
-
+    
     <a class="btn" href="lexicon.html"><b>Previous:</b> Glossary</a>
-
-
+    
+    
     <a class="btn" href="syntax/markdown.html"><b>Next:</b> Markdown</a>
-
+    
 </div>
 
                                 </section>
-
+                            
     </div>
     <div class="search-results">
         <div class="has-results">
-
+            
             <h1 class="search-results-title"><span class='search-results-count'></span> results matching "<span class='search-query'></span>"</h1>
             <ul class="search-results-list"></ul>
-
+            
         </div>
         <div class="no-results">
-
+            
             <h1 class="search-results-title">No results matching "<span class='search-query'></span>"</h1>
-
+            
         </div>
     </div>
 </div>
 
                         </div>
                     </div>
-
+                
             </div>
 
-
-
+            
+                
                 <a href="lexicon.html" class="navigation navigation-prev " aria-label="Previous page: Glossary">
                     <i class="fa fa-angle-left"></i>
                 </a>
-
-
+                
+                
                 <a href="syntax/markdown.html" class="navigation navigation-next " aria-label="Next page: Markdown">
                     <i class="fa fa-angle-right"></i>
                 </a>
-
-
-
+                
+            
+        
     </div>
 
     <script>
         var gitbook = gitbook || [];
         gitbook.push(function() {
-
+            
         });
     </script>
 </div>
 
-
+        
     <noscript>
         <style>
             .honkit-cloak {
@@ -5778,27 +5778,27 @@ exports[`HonKit snapshots: languages.html 1`] = `
     </script>
     <script src="gitbook/gitbook.js"></script>
     <script src="gitbook/theme.js"></script>
-
-
+    
+        
         <script src="gitbook/gitbook-plugin-search/search-engine.js"></script>
-
-
-
+        
+    
+        
         <script src="gitbook/gitbook-plugin-search/search.js"></script>
-
-
-
+        
+    
+        
         <script src="gitbook/gitbook-plugin-lunr/lunr.min.js"></script>
-
-
-
+        
+    
+        
         <script src="gitbook/gitbook-plugin-lunr/search-lunr.js"></script>
-
-
-
+        
+    
+        
         <script src="gitbook/gitbook-plugin-fontsettings/fontsettings.js"></script>
-
-
+        
+    
 
     </body>
 </html>
@@ -5824,50 +5824,50 @@ exports[`HonKit snapshots: lexicon.html 1`] = `
         <title>Glossary · HonKit Documentation</title>
         <meta http-equiv="X-UA-Compatible" content="IE=edge" />
         <meta name="description" content="">
-
-
-
-
-
+        
+        
+        
+        
+    
     <link rel="stylesheet" href="gitbook/style.css">
 
-
-
-
+    
+            
+                
                 <link rel="stylesheet" href="gitbook/@honkit/honkit-plugin-highlight/website.css">
-
-
-
+                
+            
+                
                 <link rel="stylesheet" href="gitbook/gitbook-plugin-search/search.css">
-
-
-
+                
+            
+                
                 <link rel="stylesheet" href="gitbook/gitbook-plugin-fontsettings/website.css">
+                
+            
+        
 
+    
 
-
-
-
-
-
-
+    
+        
         <link rel="stylesheet" href="styles/website.css">
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
+        
+    
+    
     <meta name="HandheldFriendly" content="true"/>
     <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no">
     <meta name="apple-mobile-web-app-capable" content="yes">
@@ -5875,557 +5875,557 @@ exports[`HonKit snapshots: lexicon.html 1`] = `
     <link rel="apple-touch-icon-precomposed" sizes="152x152" href="gitbook/images/apple-touch-icon-precomposed-152.png">
     <link rel="shortcut icon" href="gitbook/images/favicon.ico" type="image/x-icon">
 
-
+    
     <link rel="next" href="languages.html" />
-
-
+    
+    
     <link rel="prev" href="config.html" />
-
+    
 
     </head>
     <body>
-
+        
 <div class="book honkit-cloak">
     <div class="book-summary">
-
-
+        
+            
 <div id="book-search-input" role="search">
     <input type="text" placeholder="Type to search" />
 </div>
 
-
+            
                 <nav role="navigation">
-
+                
 
 
 <ul class="summary">
+    
+    
 
+    
 
-
-
-
-
-
+    
+        
         <li class="header">Getting Started</li>
-
-
-
+        
+        
+    
         <li class="chapter " data-level="1.1" data-path="./">
-
+            
                 <a href="./">
-
-
+            
+                    
                     About this documentation
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="1.2" data-path="setup.html">
-
+            
                 <a href="setup.html">
-
-
+            
+                    
                     Installation and Setup
-
+            
                 </a>
+            
 
-
-
+            
         </li>
+    
 
-
-
-
+    
+        
         <li class="header">Your Content</li>
-
-
-
+        
+        
+    
         <li class="chapter " data-level="2.1" data-path="structure.html">
-
+            
                 <a href="structure.html">
-
-
+            
+                    
                     Directory structure
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.2" data-path="pages.html">
-
+            
                 <a href="pages.html">
-
-
+            
+                    
                     Pages and Summary
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.3" data-path="config.html">
-
+            
                 <a href="config.html">
-
-
+            
+                    
                     Configuration
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter active" data-level="2.4" data-path="lexicon.html">
-
+            
                 <a href="lexicon.html">
-
-
+            
+                    
                     Glossary
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.5" data-path="languages.html">
-
+            
                 <a href="languages.html">
-
-
+            
+                    
                     Multi-Lingual
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.6" data-path="syntax/markdown.html">
-
+            
                 <a href="syntax/markdown.html">
-
-
+            
+                    
                     Markdown
-
+            
                 </a>
+            
 
-
-
+            
             <ul class="articles">
-
-
+                
+    
         <li class="chapter " data-level="2.6.1" data-path="syntax/markdown.html">
-
+            
                 <a href="syntax/markdown.html#headings">
-
-
+            
+                    
                     Headings
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.6.2" data-path="syntax/markdown.html">
-
+            
                 <a href="syntax/markdown.html#paragraphs">
-
-
+            
+                    
                     Paragraphs
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.6.3" data-path="syntax/markdown.html">
-
+            
                 <a href="syntax/markdown.html#lists">
-
-
+            
+                    
                     Lists
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.6.4" data-path="syntax/markdown.html">
-
+            
                 <a href="syntax/markdown.html#links">
-
-
+            
+                    
                     Links
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.6.5" data-path="syntax/markdown.html">
-
+            
                 <a href="syntax/markdown.html#images">
-
-
+            
+                    
                     Images
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.6.6" data-path="syntax/markdown.html">
-
+            
                 <a href="syntax/markdown.html#blockquotes">
-
-
+            
+                    
                     Blockquotes
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.6.7" data-path="syntax/markdown.html">
-
+            
                 <a href="syntax/markdown.html#tables">
-
-
+            
+                    
                     Tables
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.6.8" data-path="syntax/markdown.html">
-
+            
                 <a href="syntax/markdown.html#code">
-
-
+            
+                    
                     Code
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.6.9" data-path="syntax/markdown.html">
-
+            
                 <a href="syntax/markdown.html#html">
-
-
+            
+                    
                     HTML
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.6.10" data-path="syntax/markdown.html">
-
+            
                 <a href="syntax/markdown.html#footnotes">
-
-
+            
+                    
                     Footnotes
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
 
             </ul>
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.7" data-path="syntax/asciidoc.html">
-
+            
                 <a href="syntax/asciidoc.html">
-
-
+            
+                    
                     AsciiDoc
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.8" data-path="ebook.html">
-
+            
                 <a href="ebook.html">
-
-
+            
+                    
                     eBook and PDF
-
+            
                 </a>
+            
 
-
-
+            
         </li>
+    
 
-
-
-
+    
+        
         <li class="header">Customization</li>
-
-
-
+        
+        
+    
         <li class="chapter " data-level="3.1" data-path="templating/">
-
+            
                 <a href="templating/">
-
-
+            
+                    
                     Templating
-
+            
                 </a>
+            
 
-
-
+            
             <ul class="articles">
-
-
+                
+    
         <li class="chapter " data-level="3.1.1" data-path="templating/conrefs.html">
-
+            
                 <a href="templating/conrefs.html">
-
-
+            
+                    
                     Content References
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="3.1.2" data-path="templating/variables.html">
-
+            
                 <a href="templating/variables.html">
-
-
+            
+                    
                     Variables
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="3.1.3" data-path="templating/builtin.html">
-
+            
                 <a href="templating/builtin.html">
-
-
+            
+                    
                     Builtin
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
 
             </ul>
-
+            
         </li>
-
+    
         <li class="chapter " data-level="3.2" data-path="plugins/">
-
+            
                 <a href="plugins/">
-
-
+            
+                    
                     Plugins
-
+            
                 </a>
+            
 
-
-
+            
             <ul class="articles">
-
-
+                
+    
         <li class="chapter " data-level="3.2.1" data-path="plugins/create.html">
-
+            
                 <a href="plugins/create.html">
-
-
+            
+                    
                     Create a plugin
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="3.2.2" data-path="plugins/hooks.html">
-
+            
                 <a href="plugins/hooks.html">
-
-
+            
+                    
                     Hooks
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="3.2.3" data-path="plugins/blocks.html">
-
+            
                 <a href="plugins/blocks.html">
-
-
+            
+                    
                     Blocks
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="3.2.4" data-path="plugins/filters.html">
-
+            
                 <a href="plugins/filters.html">
-
-
+            
+                    
                     Filters
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="3.2.5" data-path="plugins/api.html">
-
+            
                 <a href="plugins/api.html">
-
-
+            
+                    
                     API & Context
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="3.2.6" data-path="plugins/testing.html">
-
+            
                 <a href="plugins/testing.html">
-
-
+            
+                    
                     Test your plugin
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
 
             </ul>
-
+            
         </li>
-
+    
         <li class="chapter " data-level="3.3" data-path="themes/">
-
+            
                 <a href="themes/">
-
-
+            
+                    
                     Theming
-
+            
                 </a>
+            
 
-
-
+            
         </li>
+    
 
-
-
-
+    
+        
         <li class="divider"></li>
-
-
-
+        
+        
+    
         <li class="chapter " data-level="4.1" data-path="faq.html">
-
+            
                 <a href="faq.html">
-
-
+            
+                    
                     FAQ
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="4.2" data-path="examples.md">
-
+            
                 <span>
-
-
+            
+                    
                     Examples
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="4.3" >
-
+            
                 <a target="_blank" href="https://github.com/honkit/honkit/blob/master/CHANGELOG.md">
-
-
+            
+                    
                     Release notes
-
+            
                 </a>
+            
 
-
-
+            
         </li>
+    
 
-
-
-
+    
+        
         <li class="divider"></li>
-
-
-
+        
+        
+    
         <li class="chapter " data-level="5.1" data-path="encoding.html">
-
+            
                 <a href="encoding.html">
-
-
+            
+                    
                     Encoding
-
+            
                 </a>
+            
 
-
-
+            
         </li>
+    
 
-
-
+    
 
     <li class="divider"></li>
 
@@ -6438,18 +6438,18 @@ exports[`HonKit snapshots: lexicon.html 1`] = `
 
 
                 </nav>
-
-
+            
+        
     </div>
 
     <div class="book-body">
-
+        
             <div class="body-inner">
-
-
+                
+                    
 
 <div class="book-header" role="navigation">
-
+    
 
     <!-- Title -->
     <h1>
@@ -6463,12 +6463,12 @@ exports[`HonKit snapshots: lexicon.html 1`] = `
 
                     <div class="page-wrapper" tabindex="-1" role="main">
                         <div class="page-inner">
-
+                            
 <div id="book-search-results">
     <div class="search-noresults">
-
+    
                                 <section class="normal markdown-section">
-
+                                
 
                                 <h1 id="glossary">Glossary</h1>
 <p>Allows you to specify terms and their respective definitions to be displayed as annotations. Based on those terms, <a href="GLOSSARY.html#honkit" class="glossary-term" title="Honkit is a command line tool for building beautiful books using GitHub/Git and Markdown (or AsciiDoc).">HonKit</a> will automatically build an index and highlight those terms in pages.</p>
@@ -6481,64 +6481,64 @@ With it&apos;s definition, this can contain bold text
 and all other kinds of inline markup ...
 </code></pre>
 
-
+                                
 <hr>
 <div class="btn-group btn-group-justified">
-
+    
     <a class="btn" href="config.html"><b>Previous:</b> Configuration</a>
-
-
+    
+    
     <a class="btn" href="languages.html"><b>Next:</b> Multi-Lingual</a>
-
+    
 </div>
 
                                 </section>
-
+                            
     </div>
     <div class="search-results">
         <div class="has-results">
-
+            
             <h1 class="search-results-title"><span class='search-results-count'></span> results matching "<span class='search-query'></span>"</h1>
             <ul class="search-results-list"></ul>
-
+            
         </div>
         <div class="no-results">
-
+            
             <h1 class="search-results-title">No results matching "<span class='search-query'></span>"</h1>
-
+            
         </div>
     </div>
 </div>
 
                         </div>
                     </div>
-
+                
             </div>
 
-
-
+            
+                
                 <a href="config.html" class="navigation navigation-prev " aria-label="Previous page: Configuration">
                     <i class="fa fa-angle-left"></i>
                 </a>
-
-
+                
+                
                 <a href="languages.html" class="navigation navigation-next " aria-label="Next page: Multi-Lingual">
                     <i class="fa fa-angle-right"></i>
                 </a>
-
-
-
+                
+            
+        
     </div>
 
     <script>
         var gitbook = gitbook || [];
         gitbook.push(function() {
-
+            
         });
     </script>
 </div>
 
-
+        
     <noscript>
         <style>
             .honkit-cloak {
@@ -6585,27 +6585,27 @@ and all other kinds of inline markup ...
     </script>
     <script src="gitbook/gitbook.js"></script>
     <script src="gitbook/theme.js"></script>
-
-
+    
+        
         <script src="gitbook/gitbook-plugin-search/search-engine.js"></script>
-
-
-
+        
+    
+        
         <script src="gitbook/gitbook-plugin-search/search.js"></script>
-
-
-
+        
+    
+        
         <script src="gitbook/gitbook-plugin-lunr/lunr.min.js"></script>
-
-
-
+        
+    
+        
         <script src="gitbook/gitbook-plugin-lunr/search-lunr.js"></script>
-
-
-
+        
+    
+        
         <script src="gitbook/gitbook-plugin-fontsettings/fontsettings.js"></script>
-
-
+        
+    
 
     </body>
 </html>
@@ -6631,50 +6631,50 @@ exports[`HonKit snapshots: pages.html 1`] = `
         <title>Pages and Summary · HonKit Documentation</title>
         <meta http-equiv="X-UA-Compatible" content="IE=edge" />
         <meta name="description" content="">
-
-
-
-
-
+        
+        
+        
+        
+    
     <link rel="stylesheet" href="gitbook/style.css">
 
-
-
-
+    
+            
+                
                 <link rel="stylesheet" href="gitbook/@honkit/honkit-plugin-highlight/website.css">
-
-
-
+                
+            
+                
                 <link rel="stylesheet" href="gitbook/gitbook-plugin-search/search.css">
-
-
-
+                
+            
+                
                 <link rel="stylesheet" href="gitbook/gitbook-plugin-fontsettings/website.css">
+                
+            
+        
 
+    
 
-
-
-
-
-
-
+    
+        
         <link rel="stylesheet" href="styles/website.css">
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
+        
+    
+    
     <meta name="HandheldFriendly" content="true"/>
     <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no">
     <meta name="apple-mobile-web-app-capable" content="yes">
@@ -6682,557 +6682,557 @@ exports[`HonKit snapshots: pages.html 1`] = `
     <link rel="apple-touch-icon-precomposed" sizes="152x152" href="gitbook/images/apple-touch-icon-precomposed-152.png">
     <link rel="shortcut icon" href="gitbook/images/favicon.ico" type="image/x-icon">
 
-
+    
     <link rel="next" href="config.html" />
-
-
+    
+    
     <link rel="prev" href="structure.html" />
-
+    
 
     </head>
     <body>
-
+        
 <div class="book honkit-cloak">
     <div class="book-summary">
-
-
+        
+            
 <div id="book-search-input" role="search">
     <input type="text" placeholder="Type to search" />
 </div>
 
-
+            
                 <nav role="navigation">
-
+                
 
 
 <ul class="summary">
+    
+    
 
+    
 
-
-
-
-
-
+    
+        
         <li class="header">Getting Started</li>
-
-
-
+        
+        
+    
         <li class="chapter " data-level="1.1" data-path="./">
-
+            
                 <a href="./">
-
-
+            
+                    
                     About this documentation
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="1.2" data-path="setup.html">
-
+            
                 <a href="setup.html">
-
-
+            
+                    
                     Installation and Setup
-
+            
                 </a>
+            
 
-
-
+            
         </li>
+    
 
-
-
-
+    
+        
         <li class="header">Your Content</li>
-
-
-
+        
+        
+    
         <li class="chapter " data-level="2.1" data-path="structure.html">
-
+            
                 <a href="structure.html">
-
-
+            
+                    
                     Directory structure
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter active" data-level="2.2" data-path="pages.html">
-
+            
                 <a href="pages.html">
-
-
+            
+                    
                     Pages and Summary
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.3" data-path="config.html">
-
+            
                 <a href="config.html">
-
-
+            
+                    
                     Configuration
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.4" data-path="lexicon.html">
-
+            
                 <a href="lexicon.html">
-
-
+            
+                    
                     Glossary
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.5" data-path="languages.html">
-
+            
                 <a href="languages.html">
-
-
+            
+                    
                     Multi-Lingual
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.6" data-path="syntax/markdown.html">
-
+            
                 <a href="syntax/markdown.html">
-
-
+            
+                    
                     Markdown
-
+            
                 </a>
+            
 
-
-
+            
             <ul class="articles">
-
-
+                
+    
         <li class="chapter " data-level="2.6.1" data-path="syntax/markdown.html">
-
+            
                 <a href="syntax/markdown.html#headings">
-
-
+            
+                    
                     Headings
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.6.2" data-path="syntax/markdown.html">
-
+            
                 <a href="syntax/markdown.html#paragraphs">
-
-
+            
+                    
                     Paragraphs
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.6.3" data-path="syntax/markdown.html">
-
+            
                 <a href="syntax/markdown.html#lists">
-
-
+            
+                    
                     Lists
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.6.4" data-path="syntax/markdown.html">
-
+            
                 <a href="syntax/markdown.html#links">
-
-
+            
+                    
                     Links
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.6.5" data-path="syntax/markdown.html">
-
+            
                 <a href="syntax/markdown.html#images">
-
-
+            
+                    
                     Images
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.6.6" data-path="syntax/markdown.html">
-
+            
                 <a href="syntax/markdown.html#blockquotes">
-
-
+            
+                    
                     Blockquotes
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.6.7" data-path="syntax/markdown.html">
-
+            
                 <a href="syntax/markdown.html#tables">
-
-
+            
+                    
                     Tables
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.6.8" data-path="syntax/markdown.html">
-
+            
                 <a href="syntax/markdown.html#code">
-
-
+            
+                    
                     Code
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.6.9" data-path="syntax/markdown.html">
-
+            
                 <a href="syntax/markdown.html#html">
-
-
+            
+                    
                     HTML
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.6.10" data-path="syntax/markdown.html">
-
+            
                 <a href="syntax/markdown.html#footnotes">
-
-
+            
+                    
                     Footnotes
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
 
             </ul>
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.7" data-path="syntax/asciidoc.html">
-
+            
                 <a href="syntax/asciidoc.html">
-
-
+            
+                    
                     AsciiDoc
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.8" data-path="ebook.html">
-
+            
                 <a href="ebook.html">
-
-
+            
+                    
                     eBook and PDF
-
+            
                 </a>
+            
 
-
-
+            
         </li>
+    
 
-
-
-
+    
+        
         <li class="header">Customization</li>
-
-
-
+        
+        
+    
         <li class="chapter " data-level="3.1" data-path="templating/">
-
+            
                 <a href="templating/">
-
-
+            
+                    
                     Templating
-
+            
                 </a>
+            
 
-
-
+            
             <ul class="articles">
-
-
+                
+    
         <li class="chapter " data-level="3.1.1" data-path="templating/conrefs.html">
-
+            
                 <a href="templating/conrefs.html">
-
-
+            
+                    
                     Content References
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="3.1.2" data-path="templating/variables.html">
-
+            
                 <a href="templating/variables.html">
-
-
+            
+                    
                     Variables
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="3.1.3" data-path="templating/builtin.html">
-
+            
                 <a href="templating/builtin.html">
-
-
+            
+                    
                     Builtin
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
 
             </ul>
-
+            
         </li>
-
+    
         <li class="chapter " data-level="3.2" data-path="plugins/">
-
+            
                 <a href="plugins/">
-
-
+            
+                    
                     Plugins
-
+            
                 </a>
+            
 
-
-
+            
             <ul class="articles">
-
-
+                
+    
         <li class="chapter " data-level="3.2.1" data-path="plugins/create.html">
-
+            
                 <a href="plugins/create.html">
-
-
+            
+                    
                     Create a plugin
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="3.2.2" data-path="plugins/hooks.html">
-
+            
                 <a href="plugins/hooks.html">
-
-
+            
+                    
                     Hooks
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="3.2.3" data-path="plugins/blocks.html">
-
+            
                 <a href="plugins/blocks.html">
-
-
+            
+                    
                     Blocks
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="3.2.4" data-path="plugins/filters.html">
-
+            
                 <a href="plugins/filters.html">
-
-
+            
+                    
                     Filters
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="3.2.5" data-path="plugins/api.html">
-
+            
                 <a href="plugins/api.html">
-
-
+            
+                    
                     API & Context
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="3.2.6" data-path="plugins/testing.html">
-
+            
                 <a href="plugins/testing.html">
-
-
+            
+                    
                     Test your plugin
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
 
             </ul>
-
+            
         </li>
-
+    
         <li class="chapter " data-level="3.3" data-path="themes/">
-
+            
                 <a href="themes/">
-
-
+            
+                    
                     Theming
-
+            
                 </a>
+            
 
-
-
+            
         </li>
+    
 
-
-
-
+    
+        
         <li class="divider"></li>
-
-
-
+        
+        
+    
         <li class="chapter " data-level="4.1" data-path="faq.html">
-
+            
                 <a href="faq.html">
-
-
+            
+                    
                     FAQ
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="4.2" data-path="examples.md">
-
+            
                 <span>
-
-
+            
+                    
                     Examples
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="4.3" >
-
+            
                 <a target="_blank" href="https://github.com/honkit/honkit/blob/master/CHANGELOG.md">
-
-
+            
+                    
                     Release notes
-
+            
                 </a>
+            
 
-
-
+            
         </li>
+    
 
-
-
-
+    
+        
         <li class="divider"></li>
-
-
-
+        
+        
+    
         <li class="chapter " data-level="5.1" data-path="encoding.html">
-
+            
                 <a href="encoding.html">
-
-
+            
+                    
                     Encoding
-
+            
                 </a>
+            
 
-
-
+            
         </li>
+    
 
-
-
+    
 
     <li class="divider"></li>
 
@@ -7245,18 +7245,18 @@ exports[`HonKit snapshots: pages.html 1`] = `
 
 
                 </nav>
-
-
+            
+        
     </div>
 
     <div class="book-body">
-
+        
             <div class="body-inner">
-
-
+                
+                    
 
 <div class="book-header" role="navigation">
-
+    
 
     <!-- Title -->
     <h1>
@@ -7270,12 +7270,12 @@ exports[`HonKit snapshots: pages.html 1`] = `
 
                     <div class="page-wrapper" tabindex="-1" role="main">
                         <div class="page-inner">
-
+                            
 <div id="book-search-results">
     <div class="search-noresults">
-
+    
                                 <section class="normal markdown-section">
-
+                                
 
                                 <h1 id="pages-and-summary">Pages and Summary</h1>
 <h3 id="summary">Summary</h3>
@@ -7352,64 +7352,64 @@ Markdown will dictates <span class="hljs-emphasis">_most_</span> of your <span c
 </code></pre>
 <p>The front matter can define variables of your own, they will be added to the <a href="templating/variables.html">page variable</a> so you can use them in your <a href="GLOSSARY.html#templating" class="glossary-term" title="HonKit uses the Nunjucks templating language to process pages and theme&apos;s templates.">templating</a>.</p>
 
-
+                                
 <hr>
 <div class="btn-group btn-group-justified">
-
+    
     <a class="btn" href="structure.html"><b>Previous:</b> Directory structure</a>
-
-
+    
+    
     <a class="btn" href="config.html"><b>Next:</b> Configuration</a>
-
+    
 </div>
 
                                 </section>
-
+                            
     </div>
     <div class="search-results">
         <div class="has-results">
-
+            
             <h1 class="search-results-title"><span class='search-results-count'></span> results matching "<span class='search-query'></span>"</h1>
             <ul class="search-results-list"></ul>
-
+            
         </div>
         <div class="no-results">
-
+            
             <h1 class="search-results-title">No results matching "<span class='search-query'></span>"</h1>
-
+            
         </div>
     </div>
 </div>
 
                         </div>
                     </div>
-
+                
             </div>
 
-
-
+            
+                
                 <a href="structure.html" class="navigation navigation-prev " aria-label="Previous page: Directory structure">
                     <i class="fa fa-angle-left"></i>
                 </a>
-
-
+                
+                
                 <a href="config.html" class="navigation navigation-next " aria-label="Next page: Configuration">
                     <i class="fa fa-angle-right"></i>
                 </a>
-
-
-
+                
+            
+        
     </div>
 
     <script>
         var gitbook = gitbook || [];
         gitbook.push(function() {
-
+            
         });
     </script>
 </div>
 
-
+        
     <noscript>
         <style>
             .honkit-cloak {
@@ -7456,27 +7456,27 @@ Markdown will dictates <span class="hljs-emphasis">_most_</span> of your <span c
     </script>
     <script src="gitbook/gitbook.js"></script>
     <script src="gitbook/theme.js"></script>
-
-
+    
+        
         <script src="gitbook/gitbook-plugin-search/search-engine.js"></script>
-
-
-
+        
+    
+        
         <script src="gitbook/gitbook-plugin-search/search.js"></script>
-
-
-
+        
+    
+        
         <script src="gitbook/gitbook-plugin-lunr/lunr.min.js"></script>
-
-
-
+        
+    
+        
         <script src="gitbook/gitbook-plugin-lunr/search-lunr.js"></script>
-
-
-
+        
+    
+        
         <script src="gitbook/gitbook-plugin-fontsettings/fontsettings.js"></script>
-
-
+        
+    
 
     </body>
 </html>
@@ -7502,50 +7502,50 @@ exports[`HonKit snapshots: plugins/api.html 1`] = `
         <title>API & Context · HonKit Documentation</title>
         <meta http-equiv="X-UA-Compatible" content="IE=edge" />
         <meta name="description" content="">
-
-
-
-
-
+        
+        
+        
+        
+    
     <link rel="stylesheet" href="../gitbook/style.css">
 
-
-
-
+    
+            
+                
                 <link rel="stylesheet" href="../gitbook/@honkit/honkit-plugin-highlight/website.css">
-
-
-
+                
+            
+                
                 <link rel="stylesheet" href="../gitbook/gitbook-plugin-search/search.css">
-
-
-
+                
+            
+                
                 <link rel="stylesheet" href="../gitbook/gitbook-plugin-fontsettings/website.css">
+                
+            
+        
 
+    
 
-
-
-
-
-
-
+    
+        
         <link rel="stylesheet" href="../styles/website.css">
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
+        
+    
+    
     <meta name="HandheldFriendly" content="true"/>
     <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no">
     <meta name="apple-mobile-web-app-capable" content="yes">
@@ -7553,557 +7553,557 @@ exports[`HonKit snapshots: plugins/api.html 1`] = `
     <link rel="apple-touch-icon-precomposed" sizes="152x152" href="../gitbook/images/apple-touch-icon-precomposed-152.png">
     <link rel="shortcut icon" href="../gitbook/images/favicon.ico" type="image/x-icon">
 
-
+    
     <link rel="next" href="testing.html" />
-
-
+    
+    
     <link rel="prev" href="filters.html" />
-
+    
 
     </head>
     <body>
-
+        
 <div class="book honkit-cloak">
     <div class="book-summary">
-
-
+        
+            
 <div id="book-search-input" role="search">
     <input type="text" placeholder="Type to search" />
 </div>
 
-
+            
                 <nav role="navigation">
-
+                
 
 
 <ul class="summary">
+    
+    
 
+    
 
-
-
-
-
-
+    
+        
         <li class="header">Getting Started</li>
-
-
-
+        
+        
+    
         <li class="chapter " data-level="1.1" data-path="../">
-
+            
                 <a href="../">
-
-
+            
+                    
                     About this documentation
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="1.2" data-path="../setup.html">
-
+            
                 <a href="../setup.html">
-
-
+            
+                    
                     Installation and Setup
-
+            
                 </a>
+            
 
-
-
+            
         </li>
+    
 
-
-
-
+    
+        
         <li class="header">Your Content</li>
-
-
-
+        
+        
+    
         <li class="chapter " data-level="2.1" data-path="../structure.html">
-
+            
                 <a href="../structure.html">
-
-
+            
+                    
                     Directory structure
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.2" data-path="../pages.html">
-
+            
                 <a href="../pages.html">
-
-
+            
+                    
                     Pages and Summary
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.3" data-path="../config.html">
-
+            
                 <a href="../config.html">
-
-
+            
+                    
                     Configuration
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.4" data-path="../lexicon.html">
-
+            
                 <a href="../lexicon.html">
-
-
+            
+                    
                     Glossary
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.5" data-path="../languages.html">
-
+            
                 <a href="../languages.html">
-
-
+            
+                    
                     Multi-Lingual
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.6" data-path="../syntax/markdown.html">
-
+            
                 <a href="../syntax/markdown.html">
-
-
+            
+                    
                     Markdown
-
+            
                 </a>
+            
 
-
-
+            
             <ul class="articles">
-
-
+                
+    
         <li class="chapter " data-level="2.6.1" data-path="../syntax/markdown.html">
-
+            
                 <a href="../syntax/markdown.html#headings">
-
-
+            
+                    
                     Headings
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.6.2" data-path="../syntax/markdown.html">
-
+            
                 <a href="../syntax/markdown.html#paragraphs">
-
-
+            
+                    
                     Paragraphs
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.6.3" data-path="../syntax/markdown.html">
-
+            
                 <a href="../syntax/markdown.html#lists">
-
-
+            
+                    
                     Lists
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.6.4" data-path="../syntax/markdown.html">
-
+            
                 <a href="../syntax/markdown.html#links">
-
-
+            
+                    
                     Links
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.6.5" data-path="../syntax/markdown.html">
-
+            
                 <a href="../syntax/markdown.html#images">
-
-
+            
+                    
                     Images
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.6.6" data-path="../syntax/markdown.html">
-
+            
                 <a href="../syntax/markdown.html#blockquotes">
-
-
+            
+                    
                     Blockquotes
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.6.7" data-path="../syntax/markdown.html">
-
+            
                 <a href="../syntax/markdown.html#tables">
-
-
+            
+                    
                     Tables
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.6.8" data-path="../syntax/markdown.html">
-
+            
                 <a href="../syntax/markdown.html#code">
-
-
+            
+                    
                     Code
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.6.9" data-path="../syntax/markdown.html">
-
+            
                 <a href="../syntax/markdown.html#html">
-
-
+            
+                    
                     HTML
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.6.10" data-path="../syntax/markdown.html">
-
+            
                 <a href="../syntax/markdown.html#footnotes">
-
-
+            
+                    
                     Footnotes
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
 
             </ul>
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.7" data-path="../syntax/asciidoc.html">
-
+            
                 <a href="../syntax/asciidoc.html">
-
-
+            
+                    
                     AsciiDoc
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.8" data-path="../ebook.html">
-
+            
                 <a href="../ebook.html">
-
-
+            
+                    
                     eBook and PDF
-
+            
                 </a>
+            
 
-
-
+            
         </li>
+    
 
-
-
-
+    
+        
         <li class="header">Customization</li>
-
-
-
+        
+        
+    
         <li class="chapter " data-level="3.1" data-path="../templating/">
-
+            
                 <a href="../templating/">
-
-
+            
+                    
                     Templating
-
+            
                 </a>
+            
 
-
-
+            
             <ul class="articles">
-
-
+                
+    
         <li class="chapter " data-level="3.1.1" data-path="../templating/conrefs.html">
-
+            
                 <a href="../templating/conrefs.html">
-
-
+            
+                    
                     Content References
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="3.1.2" data-path="../templating/variables.html">
-
+            
                 <a href="../templating/variables.html">
-
-
+            
+                    
                     Variables
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="3.1.3" data-path="../templating/builtin.html">
-
+            
                 <a href="../templating/builtin.html">
-
-
+            
+                    
                     Builtin
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
 
             </ul>
-
+            
         </li>
-
+    
         <li class="chapter " data-level="3.2" data-path="./">
-
+            
                 <a href="./">
-
-
+            
+                    
                     Plugins
-
+            
                 </a>
+            
 
-
-
+            
             <ul class="articles">
-
-
+                
+    
         <li class="chapter " data-level="3.2.1" data-path="create.html">
-
+            
                 <a href="create.html">
-
-
+            
+                    
                     Create a plugin
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="3.2.2" data-path="hooks.html">
-
+            
                 <a href="hooks.html">
-
-
+            
+                    
                     Hooks
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="3.2.3" data-path="blocks.html">
-
+            
                 <a href="blocks.html">
-
-
+            
+                    
                     Blocks
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="3.2.4" data-path="filters.html">
-
+            
                 <a href="filters.html">
-
-
+            
+                    
                     Filters
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter active" data-level="3.2.5" data-path="api.html">
-
+            
                 <a href="api.html">
-
-
+            
+                    
                     API & Context
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="3.2.6" data-path="testing.html">
-
+            
                 <a href="testing.html">
-
-
+            
+                    
                     Test your plugin
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
 
             </ul>
-
+            
         </li>
-
+    
         <li class="chapter " data-level="3.3" data-path="../themes/">
-
+            
                 <a href="../themes/">
-
-
+            
+                    
                     Theming
-
+            
                 </a>
+            
 
-
-
+            
         </li>
+    
 
-
-
-
+    
+        
         <li class="divider"></li>
-
-
-
+        
+        
+    
         <li class="chapter " data-level="4.1" data-path="../faq.html">
-
+            
                 <a href="../faq.html">
-
-
+            
+                    
                     FAQ
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="4.2" data-path="../examples.md">
-
+            
                 <span>
-
-
+            
+                    
                     Examples
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="4.3" >
-
+            
                 <a target="_blank" href="https://github.com/honkit/honkit/blob/master/CHANGELOG.md">
-
-
+            
+                    
                     Release notes
-
+            
                 </a>
+            
 
-
-
+            
         </li>
+    
 
-
-
-
+    
+        
         <li class="divider"></li>
-
-
-
+        
+        
+    
         <li class="chapter " data-level="5.1" data-path="../encoding.html">
-
+            
                 <a href="../encoding.html">
-
-
+            
+                    
                     Encoding
-
+            
                 </a>
+            
 
-
-
+            
         </li>
+    
 
-
-
+    
 
     <li class="divider"></li>
 
@@ -8116,18 +8116,18 @@ exports[`HonKit snapshots: plugins/api.html 1`] = `
 
 
                 </nav>
-
-
+            
+        
     </div>
 
     <div class="book-body">
-
+        
             <div class="body-inner">
-
-
+                
+                    
 
 <div class="book-header" role="navigation">
-
+    
 
     <!-- Title -->
     <h1>
@@ -8141,12 +8141,12 @@ exports[`HonKit snapshots: plugins/api.html 1`] = `
 
                     <div class="page-wrapper" tabindex="-1" role="main">
                         <div class="page-inner">
-
+                            
 <div id="book-search-results">
     <div class="search-noresults">
-
+    
                                 <section class="normal markdown-section">
-
+                                
 
                                 <h1 id="context-and-apis">Context and APIs</h1>
 <p>HonKits provides different APIs and contexts to <a href="../GLOSSARY.html#plugins" class="glossary-term" title="Plugins are the best way to extend HonKit functionalities (ebook and website).">plugins</a>. These APIs can vary according to the <a href="../GLOSSARY.html#honkit" class="glossary-term" title="Honkit is a command line tool for building beautiful books using GitHub/Git and Markdown (or AsciiDoc).">HonKit</a> version being used, your plugin should specify the <code>engines.gitbook</code> field in <code>package.json</code> accordingly.</p>
@@ -8226,64 +8226,64 @@ page.type (<span class="hljs-string">&apos;markdown&apos;</span> or <span class=
 <h4 id="context-for-hooks">Context for Hooks</h4>
 <p>Hooks only have access to the <code>&lt;Book&gt;</code> instance using <code>this.book</code>.</p>
 
-
+                                
 <hr>
 <div class="btn-group btn-group-justified">
-
+    
     <a class="btn" href="filters.html"><b>Previous:</b> Filters</a>
-
-
+    
+    
     <a class="btn" href="testing.html"><b>Next:</b> Test your plugin</a>
-
+    
 </div>
 
                                 </section>
-
+                            
     </div>
     <div class="search-results">
         <div class="has-results">
-
+            
             <h1 class="search-results-title"><span class='search-results-count'></span> results matching "<span class='search-query'></span>"</h1>
             <ul class="search-results-list"></ul>
-
+            
         </div>
         <div class="no-results">
-
+            
             <h1 class="search-results-title">No results matching "<span class='search-query'></span>"</h1>
-
+            
         </div>
     </div>
 </div>
 
                         </div>
                     </div>
-
+                
             </div>
 
-
-
+            
+                
                 <a href="filters.html" class="navigation navigation-prev " aria-label="Previous page: Filters">
                     <i class="fa fa-angle-left"></i>
                 </a>
-
-
+                
+                
                 <a href="testing.html" class="navigation navigation-next " aria-label="Next page: Test your plugin">
                     <i class="fa fa-angle-right"></i>
                 </a>
-
-
-
+                
+            
+        
     </div>
 
     <script>
         var gitbook = gitbook || [];
         gitbook.push(function() {
-
+            
         });
     </script>
 </div>
 
-
+        
     <noscript>
         <style>
             .honkit-cloak {
@@ -8330,27 +8330,27 @@ page.type (<span class="hljs-string">&apos;markdown&apos;</span> or <span class=
     </script>
     <script src="../gitbook/gitbook.js"></script>
     <script src="../gitbook/theme.js"></script>
-
-
+    
+        
         <script src="../gitbook/gitbook-plugin-search/search-engine.js"></script>
-
-
-
+        
+    
+        
         <script src="../gitbook/gitbook-plugin-search/search.js"></script>
-
-
-
+        
+    
+        
         <script src="../gitbook/gitbook-plugin-lunr/lunr.min.js"></script>
-
-
-
+        
+    
+        
         <script src="../gitbook/gitbook-plugin-lunr/search-lunr.js"></script>
-
-
-
+        
+    
+        
         <script src="../gitbook/gitbook-plugin-fontsettings/fontsettings.js"></script>
-
-
+        
+    
 
     </body>
 </html>
@@ -8376,50 +8376,50 @@ exports[`HonKit snapshots: plugins/blocks.html 1`] = `
         <title>Blocks · HonKit Documentation</title>
         <meta http-equiv="X-UA-Compatible" content="IE=edge" />
         <meta name="description" content="">
-
-
-
-
-
+        
+        
+        
+        
+    
     <link rel="stylesheet" href="../gitbook/style.css">
 
-
-
-
+    
+            
+                
                 <link rel="stylesheet" href="../gitbook/@honkit/honkit-plugin-highlight/website.css">
-
-
-
+                
+            
+                
                 <link rel="stylesheet" href="../gitbook/gitbook-plugin-search/search.css">
-
-
-
+                
+            
+                
                 <link rel="stylesheet" href="../gitbook/gitbook-plugin-fontsettings/website.css">
+                
+            
+        
 
+    
 
-
-
-
-
-
-
+    
+        
         <link rel="stylesheet" href="../styles/website.css">
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
+        
+    
+    
     <meta name="HandheldFriendly" content="true"/>
     <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no">
     <meta name="apple-mobile-web-app-capable" content="yes">
@@ -8427,557 +8427,557 @@ exports[`HonKit snapshots: plugins/blocks.html 1`] = `
     <link rel="apple-touch-icon-precomposed" sizes="152x152" href="../gitbook/images/apple-touch-icon-precomposed-152.png">
     <link rel="shortcut icon" href="../gitbook/images/favicon.ico" type="image/x-icon">
 
-
+    
     <link rel="next" href="filters.html" />
-
-
+    
+    
     <link rel="prev" href="hooks.html" />
-
+    
 
     </head>
     <body>
-
+        
 <div class="book honkit-cloak">
     <div class="book-summary">
-
-
+        
+            
 <div id="book-search-input" role="search">
     <input type="text" placeholder="Type to search" />
 </div>
 
-
+            
                 <nav role="navigation">
-
+                
 
 
 <ul class="summary">
+    
+    
 
+    
 
-
-
-
-
-
+    
+        
         <li class="header">Getting Started</li>
-
-
-
+        
+        
+    
         <li class="chapter " data-level="1.1" data-path="../">
-
+            
                 <a href="../">
-
-
+            
+                    
                     About this documentation
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="1.2" data-path="../setup.html">
-
+            
                 <a href="../setup.html">
-
-
+            
+                    
                     Installation and Setup
-
+            
                 </a>
+            
 
-
-
+            
         </li>
+    
 
-
-
-
+    
+        
         <li class="header">Your Content</li>
-
-
-
+        
+        
+    
         <li class="chapter " data-level="2.1" data-path="../structure.html">
-
+            
                 <a href="../structure.html">
-
-
+            
+                    
                     Directory structure
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.2" data-path="../pages.html">
-
+            
                 <a href="../pages.html">
-
-
+            
+                    
                     Pages and Summary
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.3" data-path="../config.html">
-
+            
                 <a href="../config.html">
-
-
+            
+                    
                     Configuration
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.4" data-path="../lexicon.html">
-
+            
                 <a href="../lexicon.html">
-
-
+            
+                    
                     Glossary
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.5" data-path="../languages.html">
-
+            
                 <a href="../languages.html">
-
-
+            
+                    
                     Multi-Lingual
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.6" data-path="../syntax/markdown.html">
-
+            
                 <a href="../syntax/markdown.html">
-
-
+            
+                    
                     Markdown
-
+            
                 </a>
+            
 
-
-
+            
             <ul class="articles">
-
-
+                
+    
         <li class="chapter " data-level="2.6.1" data-path="../syntax/markdown.html">
-
+            
                 <a href="../syntax/markdown.html#headings">
-
-
+            
+                    
                     Headings
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.6.2" data-path="../syntax/markdown.html">
-
+            
                 <a href="../syntax/markdown.html#paragraphs">
-
-
+            
+                    
                     Paragraphs
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.6.3" data-path="../syntax/markdown.html">
-
+            
                 <a href="../syntax/markdown.html#lists">
-
-
+            
+                    
                     Lists
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.6.4" data-path="../syntax/markdown.html">
-
+            
                 <a href="../syntax/markdown.html#links">
-
-
+            
+                    
                     Links
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.6.5" data-path="../syntax/markdown.html">
-
+            
                 <a href="../syntax/markdown.html#images">
-
-
+            
+                    
                     Images
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.6.6" data-path="../syntax/markdown.html">
-
+            
                 <a href="../syntax/markdown.html#blockquotes">
-
-
+            
+                    
                     Blockquotes
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.6.7" data-path="../syntax/markdown.html">
-
+            
                 <a href="../syntax/markdown.html#tables">
-
-
+            
+                    
                     Tables
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.6.8" data-path="../syntax/markdown.html">
-
+            
                 <a href="../syntax/markdown.html#code">
-
-
+            
+                    
                     Code
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.6.9" data-path="../syntax/markdown.html">
-
+            
                 <a href="../syntax/markdown.html#html">
-
-
+            
+                    
                     HTML
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.6.10" data-path="../syntax/markdown.html">
-
+            
                 <a href="../syntax/markdown.html#footnotes">
-
-
+            
+                    
                     Footnotes
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
 
             </ul>
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.7" data-path="../syntax/asciidoc.html">
-
+            
                 <a href="../syntax/asciidoc.html">
-
-
+            
+                    
                     AsciiDoc
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.8" data-path="../ebook.html">
-
+            
                 <a href="../ebook.html">
-
-
+            
+                    
                     eBook and PDF
-
+            
                 </a>
+            
 
-
-
+            
         </li>
+    
 
-
-
-
+    
+        
         <li class="header">Customization</li>
-
-
-
+        
+        
+    
         <li class="chapter " data-level="3.1" data-path="../templating/">
-
+            
                 <a href="../templating/">
-
-
+            
+                    
                     Templating
-
+            
                 </a>
+            
 
-
-
+            
             <ul class="articles">
-
-
+                
+    
         <li class="chapter " data-level="3.1.1" data-path="../templating/conrefs.html">
-
+            
                 <a href="../templating/conrefs.html">
-
-
+            
+                    
                     Content References
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="3.1.2" data-path="../templating/variables.html">
-
+            
                 <a href="../templating/variables.html">
-
-
+            
+                    
                     Variables
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="3.1.3" data-path="../templating/builtin.html">
-
+            
                 <a href="../templating/builtin.html">
-
-
+            
+                    
                     Builtin
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
 
             </ul>
-
+            
         </li>
-
+    
         <li class="chapter " data-level="3.2" data-path="./">
-
+            
                 <a href="./">
-
-
+            
+                    
                     Plugins
-
+            
                 </a>
+            
 
-
-
+            
             <ul class="articles">
-
-
+                
+    
         <li class="chapter " data-level="3.2.1" data-path="create.html">
-
+            
                 <a href="create.html">
-
-
+            
+                    
                     Create a plugin
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="3.2.2" data-path="hooks.html">
-
+            
                 <a href="hooks.html">
-
-
+            
+                    
                     Hooks
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter active" data-level="3.2.3" data-path="blocks.html">
-
+            
                 <a href="blocks.html">
-
-
+            
+                    
                     Blocks
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="3.2.4" data-path="filters.html">
-
+            
                 <a href="filters.html">
-
-
+            
+                    
                     Filters
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="3.2.5" data-path="api.html">
-
+            
                 <a href="api.html">
-
-
+            
+                    
                     API & Context
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="3.2.6" data-path="testing.html">
-
+            
                 <a href="testing.html">
-
-
+            
+                    
                     Test your plugin
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
 
             </ul>
-
+            
         </li>
-
+    
         <li class="chapter " data-level="3.3" data-path="../themes/">
-
+            
                 <a href="../themes/">
-
-
+            
+                    
                     Theming
-
+            
                 </a>
+            
 
-
-
+            
         </li>
+    
 
-
-
-
+    
+        
         <li class="divider"></li>
-
-
-
+        
+        
+    
         <li class="chapter " data-level="4.1" data-path="../faq.html">
-
+            
                 <a href="../faq.html">
-
-
+            
+                    
                     FAQ
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="4.2" data-path="../examples.md">
-
+            
                 <span>
-
-
+            
+                    
                     Examples
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="4.3" >
-
+            
                 <a target="_blank" href="https://github.com/honkit/honkit/blob/master/CHANGELOG.md">
-
-
+            
+                    
                     Release notes
-
+            
                 </a>
+            
 
-
-
+            
         </li>
+    
 
-
-
-
+    
+        
         <li class="divider"></li>
-
-
-
+        
+        
+    
         <li class="chapter " data-level="5.1" data-path="../encoding.html">
-
+            
                 <a href="../encoding.html">
-
-
+            
+                    
                     Encoding
-
+            
                 </a>
+            
 
-
-
+            
         </li>
+    
 
-
-
+    
 
     <li class="divider"></li>
 
@@ -8990,18 +8990,18 @@ exports[`HonKit snapshots: plugins/blocks.html 1`] = `
 
 
                 </nav>
-
-
+            
+        
     </div>
 
     <div class="book-body">
-
+        
             <div class="body-inner">
-
-
+                
+                    
 
 <div class="book-header" role="navigation">
-
+    
 
     <!-- Title -->
     <h1>
@@ -9015,12 +9015,12 @@ exports[`HonKit snapshots: plugins/blocks.html 1`] = `
 
                     <div class="page-wrapper" tabindex="-1" role="main">
                         <div class="page-inner">
-
+                            
 <div id="book-search-results">
     <div class="search-noresults">
-
+    
                                 <section class="normal markdown-section">
-
+                                
 
                                 <h1 id="extend-blocks">Extend Blocks</h1>
 <p>Extending <a href="../GLOSSARY.html#templating" class="glossary-term" title="HonKit uses the Nunjucks templating language to process pages and theme&apos;s templates.">templating</a> blocks is the best way to provide extra functionalities to authors.</p>
@@ -9065,64 +9065,64 @@ This is the body of the block.
     Body of sub-block 1
 {% endmyTag %}
 </code></pre>
-
+                                
 <hr>
 <div class="btn-group btn-group-justified">
-
+    
     <a class="btn" href="hooks.html"><b>Previous:</b> Hooks</a>
-
-
+    
+    
     <a class="btn" href="filters.html"><b>Next:</b> Filters</a>
-
+    
 </div>
 
                                 </section>
-
+                            
     </div>
     <div class="search-results">
         <div class="has-results">
-
+            
             <h1 class="search-results-title"><span class='search-results-count'></span> results matching "<span class='search-query'></span>"</h1>
             <ul class="search-results-list"></ul>
-
+            
         </div>
         <div class="no-results">
-
+            
             <h1 class="search-results-title">No results matching "<span class='search-query'></span>"</h1>
-
+            
         </div>
     </div>
 </div>
 
                         </div>
                     </div>
-
+                
             </div>
 
-
-
+            
+                
                 <a href="hooks.html" class="navigation navigation-prev " aria-label="Previous page: Hooks">
                     <i class="fa fa-angle-left"></i>
                 </a>
-
-
+                
+                
                 <a href="filters.html" class="navigation navigation-next " aria-label="Next page: Filters">
                     <i class="fa fa-angle-right"></i>
                 </a>
-
-
-
+                
+            
+        
     </div>
 
     <script>
         var gitbook = gitbook || [];
         gitbook.push(function() {
-
+            
         });
     </script>
 </div>
 
-
+        
     <noscript>
         <style>
             .honkit-cloak {
@@ -9169,27 +9169,27 @@ This is the body of the block.
     </script>
     <script src="../gitbook/gitbook.js"></script>
     <script src="../gitbook/theme.js"></script>
-
-
+    
+        
         <script src="../gitbook/gitbook-plugin-search/search-engine.js"></script>
-
-
-
+        
+    
+        
         <script src="../gitbook/gitbook-plugin-search/search.js"></script>
-
-
-
+        
+    
+        
         <script src="../gitbook/gitbook-plugin-lunr/lunr.min.js"></script>
-
-
-
+        
+    
+        
         <script src="../gitbook/gitbook-plugin-lunr/search-lunr.js"></script>
-
-
-
+        
+    
+        
         <script src="../gitbook/gitbook-plugin-fontsettings/fontsettings.js"></script>
-
-
+        
+    
 
     </body>
 </html>
@@ -9215,50 +9215,50 @@ exports[`HonKit snapshots: plugins/create.html 1`] = `
         <title>Create a plugin · HonKit Documentation</title>
         <meta http-equiv="X-UA-Compatible" content="IE=edge" />
         <meta name="description" content="">
-
-
-
-
-
+        
+        
+        
+        
+    
     <link rel="stylesheet" href="../gitbook/style.css">
 
-
-
-
+    
+            
+                
                 <link rel="stylesheet" href="../gitbook/@honkit/honkit-plugin-highlight/website.css">
-
-
-
+                
+            
+                
                 <link rel="stylesheet" href="../gitbook/gitbook-plugin-search/search.css">
-
-
-
+                
+            
+                
                 <link rel="stylesheet" href="../gitbook/gitbook-plugin-fontsettings/website.css">
+                
+            
+        
 
+    
 
-
-
-
-
-
-
+    
+        
         <link rel="stylesheet" href="../styles/website.css">
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
+        
+    
+    
     <meta name="HandheldFriendly" content="true"/>
     <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no">
     <meta name="apple-mobile-web-app-capable" content="yes">
@@ -9266,557 +9266,557 @@ exports[`HonKit snapshots: plugins/create.html 1`] = `
     <link rel="apple-touch-icon-precomposed" sizes="152x152" href="../gitbook/images/apple-touch-icon-precomposed-152.png">
     <link rel="shortcut icon" href="../gitbook/images/favicon.ico" type="image/x-icon">
 
-
+    
     <link rel="next" href="hooks.html" />
-
-
+    
+    
     <link rel="prev" href="./" />
-
+    
 
     </head>
     <body>
-
+        
 <div class="book honkit-cloak">
     <div class="book-summary">
-
-
+        
+            
 <div id="book-search-input" role="search">
     <input type="text" placeholder="Type to search" />
 </div>
 
-
+            
                 <nav role="navigation">
-
+                
 
 
 <ul class="summary">
+    
+    
 
+    
 
-
-
-
-
-
+    
+        
         <li class="header">Getting Started</li>
-
-
-
+        
+        
+    
         <li class="chapter " data-level="1.1" data-path="../">
-
+            
                 <a href="../">
-
-
+            
+                    
                     About this documentation
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="1.2" data-path="../setup.html">
-
+            
                 <a href="../setup.html">
-
-
+            
+                    
                     Installation and Setup
-
+            
                 </a>
+            
 
-
-
+            
         </li>
+    
 
-
-
-
+    
+        
         <li class="header">Your Content</li>
-
-
-
+        
+        
+    
         <li class="chapter " data-level="2.1" data-path="../structure.html">
-
+            
                 <a href="../structure.html">
-
-
+            
+                    
                     Directory structure
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.2" data-path="../pages.html">
-
+            
                 <a href="../pages.html">
-
-
+            
+                    
                     Pages and Summary
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.3" data-path="../config.html">
-
+            
                 <a href="../config.html">
-
-
+            
+                    
                     Configuration
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.4" data-path="../lexicon.html">
-
+            
                 <a href="../lexicon.html">
-
-
+            
+                    
                     Glossary
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.5" data-path="../languages.html">
-
+            
                 <a href="../languages.html">
-
-
+            
+                    
                     Multi-Lingual
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.6" data-path="../syntax/markdown.html">
-
+            
                 <a href="../syntax/markdown.html">
-
-
+            
+                    
                     Markdown
-
+            
                 </a>
+            
 
-
-
+            
             <ul class="articles">
-
-
+                
+    
         <li class="chapter " data-level="2.6.1" data-path="../syntax/markdown.html">
-
+            
                 <a href="../syntax/markdown.html#headings">
-
-
+            
+                    
                     Headings
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.6.2" data-path="../syntax/markdown.html">
-
+            
                 <a href="../syntax/markdown.html#paragraphs">
-
-
+            
+                    
                     Paragraphs
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.6.3" data-path="../syntax/markdown.html">
-
+            
                 <a href="../syntax/markdown.html#lists">
-
-
+            
+                    
                     Lists
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.6.4" data-path="../syntax/markdown.html">
-
+            
                 <a href="../syntax/markdown.html#links">
-
-
+            
+                    
                     Links
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.6.5" data-path="../syntax/markdown.html">
-
+            
                 <a href="../syntax/markdown.html#images">
-
-
+            
+                    
                     Images
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.6.6" data-path="../syntax/markdown.html">
-
+            
                 <a href="../syntax/markdown.html#blockquotes">
-
-
+            
+                    
                     Blockquotes
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.6.7" data-path="../syntax/markdown.html">
-
+            
                 <a href="../syntax/markdown.html#tables">
-
-
+            
+                    
                     Tables
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.6.8" data-path="../syntax/markdown.html">
-
+            
                 <a href="../syntax/markdown.html#code">
-
-
+            
+                    
                     Code
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.6.9" data-path="../syntax/markdown.html">
-
+            
                 <a href="../syntax/markdown.html#html">
-
-
+            
+                    
                     HTML
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.6.10" data-path="../syntax/markdown.html">
-
+            
                 <a href="../syntax/markdown.html#footnotes">
-
-
+            
+                    
                     Footnotes
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
 
             </ul>
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.7" data-path="../syntax/asciidoc.html">
-
+            
                 <a href="../syntax/asciidoc.html">
-
-
+            
+                    
                     AsciiDoc
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.8" data-path="../ebook.html">
-
+            
                 <a href="../ebook.html">
-
-
+            
+                    
                     eBook and PDF
-
+            
                 </a>
+            
 
-
-
+            
         </li>
+    
 
-
-
-
+    
+        
         <li class="header">Customization</li>
-
-
-
+        
+        
+    
         <li class="chapter " data-level="3.1" data-path="../templating/">
-
+            
                 <a href="../templating/">
-
-
+            
+                    
                     Templating
-
+            
                 </a>
+            
 
-
-
+            
             <ul class="articles">
-
-
+                
+    
         <li class="chapter " data-level="3.1.1" data-path="../templating/conrefs.html">
-
+            
                 <a href="../templating/conrefs.html">
-
-
+            
+                    
                     Content References
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="3.1.2" data-path="../templating/variables.html">
-
+            
                 <a href="../templating/variables.html">
-
-
+            
+                    
                     Variables
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="3.1.3" data-path="../templating/builtin.html">
-
+            
                 <a href="../templating/builtin.html">
-
-
+            
+                    
                     Builtin
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
 
             </ul>
-
+            
         </li>
-
+    
         <li class="chapter " data-level="3.2" data-path="./">
-
+            
                 <a href="./">
-
-
+            
+                    
                     Plugins
-
+            
                 </a>
+            
 
-
-
+            
             <ul class="articles">
-
-
+                
+    
         <li class="chapter active" data-level="3.2.1" data-path="create.html">
-
+            
                 <a href="create.html">
-
-
+            
+                    
                     Create a plugin
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="3.2.2" data-path="hooks.html">
-
+            
                 <a href="hooks.html">
-
-
+            
+                    
                     Hooks
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="3.2.3" data-path="blocks.html">
-
+            
                 <a href="blocks.html">
-
-
+            
+                    
                     Blocks
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="3.2.4" data-path="filters.html">
-
+            
                 <a href="filters.html">
-
-
+            
+                    
                     Filters
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="3.2.5" data-path="api.html">
-
+            
                 <a href="api.html">
-
-
+            
+                    
                     API & Context
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="3.2.6" data-path="testing.html">
-
+            
                 <a href="testing.html">
-
-
+            
+                    
                     Test your plugin
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
 
             </ul>
-
+            
         </li>
-
+    
         <li class="chapter " data-level="3.3" data-path="../themes/">
-
+            
                 <a href="../themes/">
-
-
+            
+                    
                     Theming
-
+            
                 </a>
+            
 
-
-
+            
         </li>
+    
 
-
-
-
+    
+        
         <li class="divider"></li>
-
-
-
+        
+        
+    
         <li class="chapter " data-level="4.1" data-path="../faq.html">
-
+            
                 <a href="../faq.html">
-
-
+            
+                    
                     FAQ
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="4.2" data-path="../examples.md">
-
+            
                 <span>
-
-
+            
+                    
                     Examples
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="4.3" >
-
+            
                 <a target="_blank" href="https://github.com/honkit/honkit/blob/master/CHANGELOG.md">
-
-
+            
+                    
                     Release notes
-
+            
                 </a>
+            
 
-
-
+            
         </li>
+    
 
-
-
-
+    
+        
         <li class="divider"></li>
-
-
-
+        
+        
+    
         <li class="chapter " data-level="5.1" data-path="../encoding.html">
-
+            
                 <a href="../encoding.html">
-
-
+            
+                    
                     Encoding
-
+            
                 </a>
+            
 
-
-
+            
         </li>
+    
 
-
-
+    
 
     <li class="divider"></li>
 
@@ -9829,18 +9829,18 @@ exports[`HonKit snapshots: plugins/create.html 1`] = `
 
 
                 </nav>
-
-
+            
+        
     </div>
 
     <div class="book-body">
-
+        
             <div class="body-inner">
-
-
+                
+                    
 
 <div class="book-header" role="navigation">
-
+    
 
     <!-- Title -->
     <h1>
@@ -9854,12 +9854,12 @@ exports[`HonKit snapshots: plugins/create.html 1`] = `
 
                     <div class="page-wrapper" tabindex="-1" role="main">
                         <div class="page-inner">
-
+                            
 <div id="book-search-results">
     <div class="search-noresults">
-
+    
                                 <section class="normal markdown-section">
-
+                                
 
                                 <h1 id="create-and-publish-a-plugin">Create and publish a plugin</h1>
 <p>A <a href="../GLOSSARY.html#honkit" class="glossary-term" title="Honkit is a command line tool for building beautiful books using GitHub/Git and Markdown (or AsciiDoc).">HonKit</a> plugin is a node package published on NPM that follow a defined convention.</p>
@@ -9919,64 +9919,64 @@ exports[`HonKit snapshots: plugins/create.html 1`] = `
     ]
 }
 </code></pre>
-
+                                
 <hr>
 <div class="btn-group btn-group-justified">
-
+    
     <a class="btn" href="./"><b>Previous:</b> Plugins</a>
-
-
+    
+    
     <a class="btn" href="hooks.html"><b>Next:</b> Hooks</a>
-
+    
 </div>
 
                                 </section>
-
+                            
     </div>
     <div class="search-results">
         <div class="has-results">
-
+            
             <h1 class="search-results-title"><span class='search-results-count'></span> results matching "<span class='search-query'></span>"</h1>
             <ul class="search-results-list"></ul>
-
+            
         </div>
         <div class="no-results">
-
+            
             <h1 class="search-results-title">No results matching "<span class='search-query'></span>"</h1>
-
+            
         </div>
     </div>
 </div>
 
                         </div>
                     </div>
-
+                
             </div>
 
-
-
+            
+                
                 <a href="./" class="navigation navigation-prev " aria-label="Previous page: Plugins">
                     <i class="fa fa-angle-left"></i>
                 </a>
-
-
+                
+                
                 <a href="hooks.html" class="navigation navigation-next " aria-label="Next page: Hooks">
                     <i class="fa fa-angle-right"></i>
                 </a>
-
-
-
+                
+            
+        
     </div>
 
     <script>
         var gitbook = gitbook || [];
         gitbook.push(function() {
-
+            
         });
     </script>
 </div>
 
-
+        
     <noscript>
         <style>
             .honkit-cloak {
@@ -10023,27 +10023,27 @@ exports[`HonKit snapshots: plugins/create.html 1`] = `
     </script>
     <script src="../gitbook/gitbook.js"></script>
     <script src="../gitbook/theme.js"></script>
-
-
+    
+        
         <script src="../gitbook/gitbook-plugin-search/search-engine.js"></script>
-
-
-
+        
+    
+        
         <script src="../gitbook/gitbook-plugin-search/search.js"></script>
-
-
-
+        
+    
+        
         <script src="../gitbook/gitbook-plugin-lunr/lunr.min.js"></script>
-
-
-
+        
+    
+        
         <script src="../gitbook/gitbook-plugin-lunr/search-lunr.js"></script>
-
-
-
+        
+    
+        
         <script src="../gitbook/gitbook-plugin-fontsettings/fontsettings.js"></script>
-
-
+        
+    
 
     </body>
 </html>
@@ -10069,50 +10069,50 @@ exports[`HonKit snapshots: plugins/filters.html 1`] = `
         <title>Filters · HonKit Documentation</title>
         <meta http-equiv="X-UA-Compatible" content="IE=edge" />
         <meta name="description" content="">
-
-
-
-
-
+        
+        
+        
+        
+    
     <link rel="stylesheet" href="../gitbook/style.css">
 
-
-
-
+    
+            
+                
                 <link rel="stylesheet" href="../gitbook/@honkit/honkit-plugin-highlight/website.css">
-
-
-
+                
+            
+                
                 <link rel="stylesheet" href="../gitbook/gitbook-plugin-search/search.css">
-
-
-
+                
+            
+                
                 <link rel="stylesheet" href="../gitbook/gitbook-plugin-fontsettings/website.css">
+                
+            
+        
 
+    
 
-
-
-
-
-
-
+    
+        
         <link rel="stylesheet" href="../styles/website.css">
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
+        
+    
+    
     <meta name="HandheldFriendly" content="true"/>
     <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no">
     <meta name="apple-mobile-web-app-capable" content="yes">
@@ -10120,557 +10120,557 @@ exports[`HonKit snapshots: plugins/filters.html 1`] = `
     <link rel="apple-touch-icon-precomposed" sizes="152x152" href="../gitbook/images/apple-touch-icon-precomposed-152.png">
     <link rel="shortcut icon" href="../gitbook/images/favicon.ico" type="image/x-icon">
 
-
+    
     <link rel="next" href="api.html" />
-
-
+    
+    
     <link rel="prev" href="blocks.html" />
-
+    
 
     </head>
     <body>
-
+        
 <div class="book honkit-cloak">
     <div class="book-summary">
-
-
+        
+            
 <div id="book-search-input" role="search">
     <input type="text" placeholder="Type to search" />
 </div>
 
-
+            
                 <nav role="navigation">
-
+                
 
 
 <ul class="summary">
+    
+    
 
+    
 
-
-
-
-
-
+    
+        
         <li class="header">Getting Started</li>
-
-
-
+        
+        
+    
         <li class="chapter " data-level="1.1" data-path="../">
-
+            
                 <a href="../">
-
-
+            
+                    
                     About this documentation
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="1.2" data-path="../setup.html">
-
+            
                 <a href="../setup.html">
-
-
+            
+                    
                     Installation and Setup
-
+            
                 </a>
+            
 
-
-
+            
         </li>
+    
 
-
-
-
+    
+        
         <li class="header">Your Content</li>
-
-
-
+        
+        
+    
         <li class="chapter " data-level="2.1" data-path="../structure.html">
-
+            
                 <a href="../structure.html">
-
-
+            
+                    
                     Directory structure
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.2" data-path="../pages.html">
-
+            
                 <a href="../pages.html">
-
-
+            
+                    
                     Pages and Summary
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.3" data-path="../config.html">
-
+            
                 <a href="../config.html">
-
-
+            
+                    
                     Configuration
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.4" data-path="../lexicon.html">
-
+            
                 <a href="../lexicon.html">
-
-
+            
+                    
                     Glossary
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.5" data-path="../languages.html">
-
+            
                 <a href="../languages.html">
-
-
+            
+                    
                     Multi-Lingual
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.6" data-path="../syntax/markdown.html">
-
+            
                 <a href="../syntax/markdown.html">
-
-
+            
+                    
                     Markdown
-
+            
                 </a>
+            
 
-
-
+            
             <ul class="articles">
-
-
+                
+    
         <li class="chapter " data-level="2.6.1" data-path="../syntax/markdown.html">
-
+            
                 <a href="../syntax/markdown.html#headings">
-
-
+            
+                    
                     Headings
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.6.2" data-path="../syntax/markdown.html">
-
+            
                 <a href="../syntax/markdown.html#paragraphs">
-
-
+            
+                    
                     Paragraphs
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.6.3" data-path="../syntax/markdown.html">
-
+            
                 <a href="../syntax/markdown.html#lists">
-
-
+            
+                    
                     Lists
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.6.4" data-path="../syntax/markdown.html">
-
+            
                 <a href="../syntax/markdown.html#links">
-
-
+            
+                    
                     Links
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.6.5" data-path="../syntax/markdown.html">
-
+            
                 <a href="../syntax/markdown.html#images">
-
-
+            
+                    
                     Images
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.6.6" data-path="../syntax/markdown.html">
-
+            
                 <a href="../syntax/markdown.html#blockquotes">
-
-
+            
+                    
                     Blockquotes
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.6.7" data-path="../syntax/markdown.html">
-
+            
                 <a href="../syntax/markdown.html#tables">
-
-
+            
+                    
                     Tables
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.6.8" data-path="../syntax/markdown.html">
-
+            
                 <a href="../syntax/markdown.html#code">
-
-
+            
+                    
                     Code
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.6.9" data-path="../syntax/markdown.html">
-
+            
                 <a href="../syntax/markdown.html#html">
-
-
+            
+                    
                     HTML
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.6.10" data-path="../syntax/markdown.html">
-
+            
                 <a href="../syntax/markdown.html#footnotes">
-
-
+            
+                    
                     Footnotes
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
 
             </ul>
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.7" data-path="../syntax/asciidoc.html">
-
+            
                 <a href="../syntax/asciidoc.html">
-
-
+            
+                    
                     AsciiDoc
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.8" data-path="../ebook.html">
-
+            
                 <a href="../ebook.html">
-
-
+            
+                    
                     eBook and PDF
-
+            
                 </a>
+            
 
-
-
+            
         </li>
+    
 
-
-
-
+    
+        
         <li class="header">Customization</li>
-
-
-
+        
+        
+    
         <li class="chapter " data-level="3.1" data-path="../templating/">
-
+            
                 <a href="../templating/">
-
-
+            
+                    
                     Templating
-
+            
                 </a>
+            
 
-
-
+            
             <ul class="articles">
-
-
+                
+    
         <li class="chapter " data-level="3.1.1" data-path="../templating/conrefs.html">
-
+            
                 <a href="../templating/conrefs.html">
-
-
+            
+                    
                     Content References
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="3.1.2" data-path="../templating/variables.html">
-
+            
                 <a href="../templating/variables.html">
-
-
+            
+                    
                     Variables
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="3.1.3" data-path="../templating/builtin.html">
-
+            
                 <a href="../templating/builtin.html">
-
-
+            
+                    
                     Builtin
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
 
             </ul>
-
+            
         </li>
-
+    
         <li class="chapter " data-level="3.2" data-path="./">
-
+            
                 <a href="./">
-
-
+            
+                    
                     Plugins
-
+            
                 </a>
+            
 
-
-
+            
             <ul class="articles">
-
-
+                
+    
         <li class="chapter " data-level="3.2.1" data-path="create.html">
-
+            
                 <a href="create.html">
-
-
+            
+                    
                     Create a plugin
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="3.2.2" data-path="hooks.html">
-
+            
                 <a href="hooks.html">
-
-
+            
+                    
                     Hooks
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="3.2.3" data-path="blocks.html">
-
+            
                 <a href="blocks.html">
-
-
+            
+                    
                     Blocks
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter active" data-level="3.2.4" data-path="filters.html">
-
+            
                 <a href="filters.html">
-
-
+            
+                    
                     Filters
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="3.2.5" data-path="api.html">
-
+            
                 <a href="api.html">
-
-
+            
+                    
                     API & Context
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="3.2.6" data-path="testing.html">
-
+            
                 <a href="testing.html">
-
-
+            
+                    
                     Test your plugin
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
 
             </ul>
-
+            
         </li>
-
+    
         <li class="chapter " data-level="3.3" data-path="../themes/">
-
+            
                 <a href="../themes/">
-
-
+            
+                    
                     Theming
-
+            
                 </a>
+            
 
-
-
+            
         </li>
+    
 
-
-
-
+    
+        
         <li class="divider"></li>
-
-
-
+        
+        
+    
         <li class="chapter " data-level="4.1" data-path="../faq.html">
-
+            
                 <a href="../faq.html">
-
-
+            
+                    
                     FAQ
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="4.2" data-path="../examples.md">
-
+            
                 <span>
-
-
+            
+                    
                     Examples
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="4.3" >
-
+            
                 <a target="_blank" href="https://github.com/honkit/honkit/blob/master/CHANGELOG.md">
-
-
+            
+                    
                     Release notes
-
+            
                 </a>
+            
 
-
-
+            
         </li>
+    
 
-
-
-
+    
+        
         <li class="divider"></li>
-
-
-
+        
+        
+    
         <li class="chapter " data-level="5.1" data-path="../encoding.html">
-
+            
                 <a href="../encoding.html">
-
-
+            
+                    
                     Encoding
-
+            
                 </a>
+            
 
-
-
+            
         </li>
+    
 
-
-
+    
 
     <li class="divider"></li>
 
@@ -10683,18 +10683,18 @@ exports[`HonKit snapshots: plugins/filters.html 1`] = `
 
 
                 </nav>
-
-
+            
+        
     </div>
 
     <div class="book-body">
-
+        
             <div class="body-inner">
-
-
+                
+                    
 
 <div class="book-header" role="navigation">
-
+    
 
     <!-- Title -->
     <h1>
@@ -10708,12 +10708,12 @@ exports[`HonKit snapshots: plugins/filters.html 1`] = `
 
                     <div class="page-wrapper" tabindex="-1" role="main">
                         <div class="page-inner">
-
+                            
 <div id="book-search-results">
     <div class="search-noresults">
-
+    
                                 <section class="normal markdown-section">
-
+                                
 
                                 <h1 id="extend-filters">Extend Filters</h1>
 <p>Filters are essentially functions that can be applied to variables. They are called with a pipe operator (<code>|</code>) and can take arguments.</p>
@@ -10752,64 +10752,64 @@ Refer to <a href="api.html">Context and APIs</a> to learn more about <code>this<
 };
 </code></pre>
 
-
+                                
 <hr>
 <div class="btn-group btn-group-justified">
-
+    
     <a class="btn" href="blocks.html"><b>Previous:</b> Blocks</a>
-
-
+    
+    
     <a class="btn" href="api.html"><b>Next:</b> API & Context</a>
-
+    
 </div>
 
                                 </section>
-
+                            
     </div>
     <div class="search-results">
         <div class="has-results">
-
+            
             <h1 class="search-results-title"><span class='search-results-count'></span> results matching "<span class='search-query'></span>"</h1>
             <ul class="search-results-list"></ul>
-
+            
         </div>
         <div class="no-results">
-
+            
             <h1 class="search-results-title">No results matching "<span class='search-query'></span>"</h1>
-
+            
         </div>
     </div>
 </div>
 
                         </div>
                     </div>
-
+                
             </div>
 
-
-
+            
+                
                 <a href="blocks.html" class="navigation navigation-prev " aria-label="Previous page: Blocks">
                     <i class="fa fa-angle-left"></i>
                 </a>
-
-
+                
+                
                 <a href="api.html" class="navigation navigation-next " aria-label="Next page: API & Context">
                     <i class="fa fa-angle-right"></i>
                 </a>
-
-
-
+                
+            
+        
     </div>
 
     <script>
         var gitbook = gitbook || [];
         gitbook.push(function() {
-
+            
         });
     </script>
 </div>
 
-
+        
     <noscript>
         <style>
             .honkit-cloak {
@@ -10856,27 +10856,27 @@ Refer to <a href="api.html">Context and APIs</a> to learn more about <code>this<
     </script>
     <script src="../gitbook/gitbook.js"></script>
     <script src="../gitbook/theme.js"></script>
-
-
+    
+        
         <script src="../gitbook/gitbook-plugin-search/search-engine.js"></script>
-
-
-
+        
+    
+        
         <script src="../gitbook/gitbook-plugin-search/search.js"></script>
-
-
-
+        
+    
+        
         <script src="../gitbook/gitbook-plugin-lunr/lunr.min.js"></script>
-
-
-
+        
+    
+        
         <script src="../gitbook/gitbook-plugin-lunr/search-lunr.js"></script>
-
-
-
+        
+    
+        
         <script src="../gitbook/gitbook-plugin-fontsettings/fontsettings.js"></script>
-
-
+        
+    
 
     </body>
 </html>
@@ -10902,50 +10902,50 @@ exports[`HonKit snapshots: plugins/hooks.html 1`] = `
         <title>Hooks · HonKit Documentation</title>
         <meta http-equiv="X-UA-Compatible" content="IE=edge" />
         <meta name="description" content="">
-
-
-
-
-
+        
+        
+        
+        
+    
     <link rel="stylesheet" href="../gitbook/style.css">
 
-
-
-
+    
+            
+                
                 <link rel="stylesheet" href="../gitbook/@honkit/honkit-plugin-highlight/website.css">
-
-
-
+                
+            
+                
                 <link rel="stylesheet" href="../gitbook/gitbook-plugin-search/search.css">
-
-
-
+                
+            
+                
                 <link rel="stylesheet" href="../gitbook/gitbook-plugin-fontsettings/website.css">
+                
+            
+        
 
+    
 
-
-
-
-
-
-
+    
+        
         <link rel="stylesheet" href="../styles/website.css">
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
+        
+    
+    
     <meta name="HandheldFriendly" content="true"/>
     <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no">
     <meta name="apple-mobile-web-app-capable" content="yes">
@@ -10953,557 +10953,557 @@ exports[`HonKit snapshots: plugins/hooks.html 1`] = `
     <link rel="apple-touch-icon-precomposed" sizes="152x152" href="../gitbook/images/apple-touch-icon-precomposed-152.png">
     <link rel="shortcut icon" href="../gitbook/images/favicon.ico" type="image/x-icon">
 
-
+    
     <link rel="next" href="blocks.html" />
-
-
+    
+    
     <link rel="prev" href="create.html" />
-
+    
 
     </head>
     <body>
-
+        
 <div class="book honkit-cloak">
     <div class="book-summary">
-
-
+        
+            
 <div id="book-search-input" role="search">
     <input type="text" placeholder="Type to search" />
 </div>
 
-
+            
                 <nav role="navigation">
-
+                
 
 
 <ul class="summary">
+    
+    
 
+    
 
-
-
-
-
-
+    
+        
         <li class="header">Getting Started</li>
-
-
-
+        
+        
+    
         <li class="chapter " data-level="1.1" data-path="../">
-
+            
                 <a href="../">
-
-
+            
+                    
                     About this documentation
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="1.2" data-path="../setup.html">
-
+            
                 <a href="../setup.html">
-
-
+            
+                    
                     Installation and Setup
-
+            
                 </a>
+            
 
-
-
+            
         </li>
+    
 
-
-
-
+    
+        
         <li class="header">Your Content</li>
-
-
-
+        
+        
+    
         <li class="chapter " data-level="2.1" data-path="../structure.html">
-
+            
                 <a href="../structure.html">
-
-
+            
+                    
                     Directory structure
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.2" data-path="../pages.html">
-
+            
                 <a href="../pages.html">
-
-
+            
+                    
                     Pages and Summary
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.3" data-path="../config.html">
-
+            
                 <a href="../config.html">
-
-
+            
+                    
                     Configuration
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.4" data-path="../lexicon.html">
-
+            
                 <a href="../lexicon.html">
-
-
+            
+                    
                     Glossary
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.5" data-path="../languages.html">
-
+            
                 <a href="../languages.html">
-
-
+            
+                    
                     Multi-Lingual
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.6" data-path="../syntax/markdown.html">
-
+            
                 <a href="../syntax/markdown.html">
-
-
+            
+                    
                     Markdown
-
+            
                 </a>
+            
 
-
-
+            
             <ul class="articles">
-
-
+                
+    
         <li class="chapter " data-level="2.6.1" data-path="../syntax/markdown.html">
-
+            
                 <a href="../syntax/markdown.html#headings">
-
-
+            
+                    
                     Headings
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.6.2" data-path="../syntax/markdown.html">
-
+            
                 <a href="../syntax/markdown.html#paragraphs">
-
-
+            
+                    
                     Paragraphs
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.6.3" data-path="../syntax/markdown.html">
-
+            
                 <a href="../syntax/markdown.html#lists">
-
-
+            
+                    
                     Lists
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.6.4" data-path="../syntax/markdown.html">
-
+            
                 <a href="../syntax/markdown.html#links">
-
-
+            
+                    
                     Links
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.6.5" data-path="../syntax/markdown.html">
-
+            
                 <a href="../syntax/markdown.html#images">
-
-
+            
+                    
                     Images
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.6.6" data-path="../syntax/markdown.html">
-
+            
                 <a href="../syntax/markdown.html#blockquotes">
-
-
+            
+                    
                     Blockquotes
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.6.7" data-path="../syntax/markdown.html">
-
+            
                 <a href="../syntax/markdown.html#tables">
-
-
+            
+                    
                     Tables
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.6.8" data-path="../syntax/markdown.html">
-
+            
                 <a href="../syntax/markdown.html#code">
-
-
+            
+                    
                     Code
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.6.9" data-path="../syntax/markdown.html">
-
+            
                 <a href="../syntax/markdown.html#html">
-
-
+            
+                    
                     HTML
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.6.10" data-path="../syntax/markdown.html">
-
+            
                 <a href="../syntax/markdown.html#footnotes">
-
-
+            
+                    
                     Footnotes
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
 
             </ul>
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.7" data-path="../syntax/asciidoc.html">
-
+            
                 <a href="../syntax/asciidoc.html">
-
-
+            
+                    
                     AsciiDoc
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.8" data-path="../ebook.html">
-
+            
                 <a href="../ebook.html">
-
-
+            
+                    
                     eBook and PDF
-
+            
                 </a>
+            
 
-
-
+            
         </li>
+    
 
-
-
-
+    
+        
         <li class="header">Customization</li>
-
-
-
+        
+        
+    
         <li class="chapter " data-level="3.1" data-path="../templating/">
-
+            
                 <a href="../templating/">
-
-
+            
+                    
                     Templating
-
+            
                 </a>
+            
 
-
-
+            
             <ul class="articles">
-
-
+                
+    
         <li class="chapter " data-level="3.1.1" data-path="../templating/conrefs.html">
-
+            
                 <a href="../templating/conrefs.html">
-
-
+            
+                    
                     Content References
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="3.1.2" data-path="../templating/variables.html">
-
+            
                 <a href="../templating/variables.html">
-
-
+            
+                    
                     Variables
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="3.1.3" data-path="../templating/builtin.html">
-
+            
                 <a href="../templating/builtin.html">
-
-
+            
+                    
                     Builtin
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
 
             </ul>
-
+            
         </li>
-
+    
         <li class="chapter " data-level="3.2" data-path="./">
-
+            
                 <a href="./">
-
-
+            
+                    
                     Plugins
-
+            
                 </a>
+            
 
-
-
+            
             <ul class="articles">
-
-
+                
+    
         <li class="chapter " data-level="3.2.1" data-path="create.html">
-
+            
                 <a href="create.html">
-
-
+            
+                    
                     Create a plugin
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter active" data-level="3.2.2" data-path="hooks.html">
-
+            
                 <a href="hooks.html">
-
-
+            
+                    
                     Hooks
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="3.2.3" data-path="blocks.html">
-
+            
                 <a href="blocks.html">
-
-
+            
+                    
                     Blocks
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="3.2.4" data-path="filters.html">
-
+            
                 <a href="filters.html">
-
-
+            
+                    
                     Filters
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="3.2.5" data-path="api.html">
-
+            
                 <a href="api.html">
-
-
+            
+                    
                     API & Context
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="3.2.6" data-path="testing.html">
-
+            
                 <a href="testing.html">
-
-
+            
+                    
                     Test your plugin
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
 
             </ul>
-
+            
         </li>
-
+    
         <li class="chapter " data-level="3.3" data-path="../themes/">
-
+            
                 <a href="../themes/">
-
-
+            
+                    
                     Theming
-
+            
                 </a>
+            
 
-
-
+            
         </li>
+    
 
-
-
-
+    
+        
         <li class="divider"></li>
-
-
-
+        
+        
+    
         <li class="chapter " data-level="4.1" data-path="../faq.html">
-
+            
                 <a href="../faq.html">
-
-
+            
+                    
                     FAQ
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="4.2" data-path="../examples.md">
-
+            
                 <span>
-
-
+            
+                    
                     Examples
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="4.3" >
-
+            
                 <a target="_blank" href="https://github.com/honkit/honkit/blob/master/CHANGELOG.md">
-
-
+            
+                    
                     Release notes
-
+            
                 </a>
+            
 
-
-
+            
         </li>
+    
 
-
-
-
+    
+        
         <li class="divider"></li>
-
-
-
+        
+        
+    
         <li class="chapter " data-level="5.1" data-path="../encoding.html">
-
+            
                 <a href="../encoding.html">
-
-
+            
+                    
                     Encoding
-
+            
                 </a>
+            
 
-
-
+            
         </li>
+    
 
-
-
+    
 
     <li class="divider"></li>
 
@@ -11516,18 +11516,18 @@ exports[`HonKit snapshots: plugins/hooks.html 1`] = `
 
 
                 </nav>
-
-
+            
+        
     </div>
 
     <div class="book-body">
-
+        
             <div class="body-inner">
-
-
+                
+                    
 
 <div class="book-header" role="navigation">
-
+    
 
     <!-- Title -->
     <h1>
@@ -11541,12 +11541,12 @@ exports[`HonKit snapshots: plugins/hooks.html 1`] = `
 
                     <div class="page-wrapper" tabindex="-1" role="main">
                         <div class="page-inner">
-
+                            
 <div id="book-search-results">
     <div class="search-noresults">
-
+    
                                 <section class="normal markdown-section">
-
+                                
 
                                 <h1 id="hooks">Hooks</h1>
 <p>Hooks is a method of augmenting or altering the behavior of the process, with custom callbacks.</p>
@@ -11655,64 +11655,64 @@ exports[`HonKit snapshots: plugins/hooks.html 1`] = `
 }
 </code></pre>
 
-
+                                
 <hr>
 <div class="btn-group btn-group-justified">
-
+    
     <a class="btn" href="create.html"><b>Previous:</b> Create a plugin</a>
-
-
+    
+    
     <a class="btn" href="blocks.html"><b>Next:</b> Blocks</a>
-
+    
 </div>
 
                                 </section>
-
+                            
     </div>
     <div class="search-results">
         <div class="has-results">
-
+            
             <h1 class="search-results-title"><span class='search-results-count'></span> results matching "<span class='search-query'></span>"</h1>
             <ul class="search-results-list"></ul>
-
+            
         </div>
         <div class="no-results">
-
+            
             <h1 class="search-results-title">No results matching "<span class='search-query'></span>"</h1>
-
+            
         </div>
     </div>
 </div>
 
                         </div>
                     </div>
-
+                
             </div>
 
-
-
+            
+                
                 <a href="create.html" class="navigation navigation-prev " aria-label="Previous page: Create a plugin">
                     <i class="fa fa-angle-left"></i>
                 </a>
-
-
+                
+                
                 <a href="blocks.html" class="navigation navigation-next " aria-label="Next page: Blocks">
                     <i class="fa fa-angle-right"></i>
                 </a>
-
-
-
+                
+            
+        
     </div>
 
     <script>
         var gitbook = gitbook || [];
         gitbook.push(function() {
-
+            
         });
     </script>
 </div>
 
-
+        
     <noscript>
         <style>
             .honkit-cloak {
@@ -11759,27 +11759,27 @@ exports[`HonKit snapshots: plugins/hooks.html 1`] = `
     </script>
     <script src="../gitbook/gitbook.js"></script>
     <script src="../gitbook/theme.js"></script>
-
-
+    
+        
         <script src="../gitbook/gitbook-plugin-search/search-engine.js"></script>
-
-
-
+        
+    
+        
         <script src="../gitbook/gitbook-plugin-search/search.js"></script>
-
-
-
+        
+    
+        
         <script src="../gitbook/gitbook-plugin-lunr/lunr.min.js"></script>
-
-
-
+        
+    
+        
         <script src="../gitbook/gitbook-plugin-lunr/search-lunr.js"></script>
-
-
-
+        
+    
+        
         <script src="../gitbook/gitbook-plugin-fontsettings/fontsettings.js"></script>
-
-
+        
+    
 
     </body>
 </html>
@@ -11805,50 +11805,50 @@ exports[`HonKit snapshots: plugins/index.html 1`] = `
         <title>Plugins · HonKit Documentation</title>
         <meta http-equiv="X-UA-Compatible" content="IE=edge" />
         <meta name="description" content="">
-
-
-
-
-
+        
+        
+        
+        
+    
     <link rel="stylesheet" href="../gitbook/style.css">
 
-
-
-
+    
+            
+                
                 <link rel="stylesheet" href="../gitbook/@honkit/honkit-plugin-highlight/website.css">
-
-
-
+                
+            
+                
                 <link rel="stylesheet" href="../gitbook/gitbook-plugin-search/search.css">
-
-
-
+                
+            
+                
                 <link rel="stylesheet" href="../gitbook/gitbook-plugin-fontsettings/website.css">
+                
+            
+        
 
+    
 
-
-
-
-
-
-
+    
+        
         <link rel="stylesheet" href="../styles/website.css">
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
+        
+    
+    
     <meta name="HandheldFriendly" content="true"/>
     <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no">
     <meta name="apple-mobile-web-app-capable" content="yes">
@@ -11856,557 +11856,557 @@ exports[`HonKit snapshots: plugins/index.html 1`] = `
     <link rel="apple-touch-icon-precomposed" sizes="152x152" href="../gitbook/images/apple-touch-icon-precomposed-152.png">
     <link rel="shortcut icon" href="../gitbook/images/favicon.ico" type="image/x-icon">
 
-
+    
     <link rel="next" href="create.html" />
-
-
+    
+    
     <link rel="prev" href="../templating/builtin.html" />
-
+    
 
     </head>
     <body>
-
+        
 <div class="book honkit-cloak">
     <div class="book-summary">
-
-
+        
+            
 <div id="book-search-input" role="search">
     <input type="text" placeholder="Type to search" />
 </div>
 
-
+            
                 <nav role="navigation">
-
+                
 
 
 <ul class="summary">
+    
+    
 
+    
 
-
-
-
-
-
+    
+        
         <li class="header">Getting Started</li>
-
-
-
+        
+        
+    
         <li class="chapter " data-level="1.1" data-path="../">
-
+            
                 <a href="../">
-
-
+            
+                    
                     About this documentation
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="1.2" data-path="../setup.html">
-
+            
                 <a href="../setup.html">
-
-
+            
+                    
                     Installation and Setup
-
+            
                 </a>
+            
 
-
-
+            
         </li>
+    
 
-
-
-
+    
+        
         <li class="header">Your Content</li>
-
-
-
+        
+        
+    
         <li class="chapter " data-level="2.1" data-path="../structure.html">
-
+            
                 <a href="../structure.html">
-
-
+            
+                    
                     Directory structure
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.2" data-path="../pages.html">
-
+            
                 <a href="../pages.html">
-
-
+            
+                    
                     Pages and Summary
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.3" data-path="../config.html">
-
+            
                 <a href="../config.html">
-
-
+            
+                    
                     Configuration
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.4" data-path="../lexicon.html">
-
+            
                 <a href="../lexicon.html">
-
-
+            
+                    
                     Glossary
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.5" data-path="../languages.html">
-
+            
                 <a href="../languages.html">
-
-
+            
+                    
                     Multi-Lingual
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.6" data-path="../syntax/markdown.html">
-
+            
                 <a href="../syntax/markdown.html">
-
-
+            
+                    
                     Markdown
-
+            
                 </a>
+            
 
-
-
+            
             <ul class="articles">
-
-
+                
+    
         <li class="chapter " data-level="2.6.1" data-path="../syntax/markdown.html">
-
+            
                 <a href="../syntax/markdown.html#headings">
-
-
+            
+                    
                     Headings
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.6.2" data-path="../syntax/markdown.html">
-
+            
                 <a href="../syntax/markdown.html#paragraphs">
-
-
+            
+                    
                     Paragraphs
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.6.3" data-path="../syntax/markdown.html">
-
+            
                 <a href="../syntax/markdown.html#lists">
-
-
+            
+                    
                     Lists
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.6.4" data-path="../syntax/markdown.html">
-
+            
                 <a href="../syntax/markdown.html#links">
-
-
+            
+                    
                     Links
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.6.5" data-path="../syntax/markdown.html">
-
+            
                 <a href="../syntax/markdown.html#images">
-
-
+            
+                    
                     Images
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.6.6" data-path="../syntax/markdown.html">
-
+            
                 <a href="../syntax/markdown.html#blockquotes">
-
-
+            
+                    
                     Blockquotes
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.6.7" data-path="../syntax/markdown.html">
-
+            
                 <a href="../syntax/markdown.html#tables">
-
-
+            
+                    
                     Tables
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.6.8" data-path="../syntax/markdown.html">
-
+            
                 <a href="../syntax/markdown.html#code">
-
-
+            
+                    
                     Code
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.6.9" data-path="../syntax/markdown.html">
-
+            
                 <a href="../syntax/markdown.html#html">
-
-
+            
+                    
                     HTML
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.6.10" data-path="../syntax/markdown.html">
-
+            
                 <a href="../syntax/markdown.html#footnotes">
-
-
+            
+                    
                     Footnotes
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
 
             </ul>
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.7" data-path="../syntax/asciidoc.html">
-
+            
                 <a href="../syntax/asciidoc.html">
-
-
+            
+                    
                     AsciiDoc
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.8" data-path="../ebook.html">
-
+            
                 <a href="../ebook.html">
-
-
+            
+                    
                     eBook and PDF
-
+            
                 </a>
+            
 
-
-
+            
         </li>
+    
 
-
-
-
+    
+        
         <li class="header">Customization</li>
-
-
-
+        
+        
+    
         <li class="chapter " data-level="3.1" data-path="../templating/">
-
+            
                 <a href="../templating/">
-
-
+            
+                    
                     Templating
-
+            
                 </a>
+            
 
-
-
+            
             <ul class="articles">
-
-
+                
+    
         <li class="chapter " data-level="3.1.1" data-path="../templating/conrefs.html">
-
+            
                 <a href="../templating/conrefs.html">
-
-
+            
+                    
                     Content References
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="3.1.2" data-path="../templating/variables.html">
-
+            
                 <a href="../templating/variables.html">
-
-
+            
+                    
                     Variables
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="3.1.3" data-path="../templating/builtin.html">
-
+            
                 <a href="../templating/builtin.html">
-
-
+            
+                    
                     Builtin
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
 
             </ul>
-
+            
         </li>
-
+    
         <li class="chapter active" data-level="3.2" data-path="./">
-
+            
                 <a href="./">
-
-
+            
+                    
                     Plugins
-
+            
                 </a>
+            
 
-
-
+            
             <ul class="articles">
-
-
+                
+    
         <li class="chapter " data-level="3.2.1" data-path="create.html">
-
+            
                 <a href="create.html">
-
-
+            
+                    
                     Create a plugin
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="3.2.2" data-path="hooks.html">
-
+            
                 <a href="hooks.html">
-
-
+            
+                    
                     Hooks
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="3.2.3" data-path="blocks.html">
-
+            
                 <a href="blocks.html">
-
-
+            
+                    
                     Blocks
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="3.2.4" data-path="filters.html">
-
+            
                 <a href="filters.html">
-
-
+            
+                    
                     Filters
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="3.2.5" data-path="api.html">
-
+            
                 <a href="api.html">
-
-
+            
+                    
                     API & Context
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="3.2.6" data-path="testing.html">
-
+            
                 <a href="testing.html">
-
-
+            
+                    
                     Test your plugin
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
 
             </ul>
-
+            
         </li>
-
+    
         <li class="chapter " data-level="3.3" data-path="../themes/">
-
+            
                 <a href="../themes/">
-
-
+            
+                    
                     Theming
-
+            
                 </a>
+            
 
-
-
+            
         </li>
+    
 
-
-
-
+    
+        
         <li class="divider"></li>
-
-
-
+        
+        
+    
         <li class="chapter " data-level="4.1" data-path="../faq.html">
-
+            
                 <a href="../faq.html">
-
-
+            
+                    
                     FAQ
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="4.2" data-path="../examples.md">
-
+            
                 <span>
-
-
+            
+                    
                     Examples
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="4.3" >
-
+            
                 <a target="_blank" href="https://github.com/honkit/honkit/blob/master/CHANGELOG.md">
-
-
+            
+                    
                     Release notes
-
+            
                 </a>
+            
 
-
-
+            
         </li>
+    
 
-
-
-
+    
+        
         <li class="divider"></li>
-
-
-
+        
+        
+    
         <li class="chapter " data-level="5.1" data-path="../encoding.html">
-
+            
                 <a href="../encoding.html">
-
-
+            
+                    
                     Encoding
-
+            
                 </a>
+            
 
-
-
+            
         </li>
+    
 
-
-
+    
 
     <li class="divider"></li>
 
@@ -12419,18 +12419,18 @@ exports[`HonKit snapshots: plugins/index.html 1`] = `
 
 
                 </nav>
-
-
+            
+        
     </div>
 
     <div class="book-body">
-
+        
             <div class="body-inner">
-
-
+                
+                    
 
 <div class="book-header" role="navigation">
-
+    
 
     <!-- Title -->
     <h1>
@@ -12444,12 +12444,12 @@ exports[`HonKit snapshots: plugins/index.html 1`] = `
 
                     <div class="page-wrapper" tabindex="-1" role="main">
                         <div class="page-inner">
-
+                            
 <div id="book-search-results">
     <div class="search-noresults">
-
+    
                                 <section class="normal markdown-section">
-
+                                
 
                                 <h1 id="plugins">Plugins</h1>
 <p><a href="../GLOSSARY.html#plugins" class="glossary-term" title="Plugins are the best way to extend HonKit functionalities (ebook and website).">Plugins</a> are the best way to extend <a href="../GLOSSARY.html#honkit" class="glossary-term" title="Honkit is a command line tool for building beautiful books using GitHub/Git and Markdown (or AsciiDoc).">HonKit</a> functionalities (ebook and website). There exist <a href="../GLOSSARY.html#plugins" class="glossary-term" title="Plugins are the best way to extend HonKit functionalities (ebook and website).">plugins</a> to do a lot of things: bring math formulas display support, track visits using Google Analytic, etc.</p>
@@ -12465,64 +12465,64 @@ exports[`HonKit snapshots: plugins/index.html 1`] = `
 <h3 id="configuring-plugins">Configuring plugins</h3>
 <p><a href="../GLOSSARY.html#plugins" class="glossary-term" title="Plugins are the best way to extend HonKit functionalities (ebook and website).">Plugins</a> specific configurations are stored in <code>pluginsConfig</code>. You have to refer to the documentation of the plugin itself for details about the available options.</p>
 
-
+                                
 <hr>
 <div class="btn-group btn-group-justified">
-
+    
     <a class="btn" href="../templating/builtin.html"><b>Previous:</b> Builtin</a>
-
-
+    
+    
     <a class="btn" href="create.html"><b>Next:</b> Create a plugin</a>
-
+    
 </div>
 
                                 </section>
-
+                            
     </div>
     <div class="search-results">
         <div class="has-results">
-
+            
             <h1 class="search-results-title"><span class='search-results-count'></span> results matching "<span class='search-query'></span>"</h1>
             <ul class="search-results-list"></ul>
-
+            
         </div>
         <div class="no-results">
-
+            
             <h1 class="search-results-title">No results matching "<span class='search-query'></span>"</h1>
-
+            
         </div>
     </div>
 </div>
 
                         </div>
                     </div>
-
+                
             </div>
 
-
-
+            
+                
                 <a href="../templating/builtin.html" class="navigation navigation-prev " aria-label="Previous page: Builtin">
                     <i class="fa fa-angle-left"></i>
                 </a>
-
-
+                
+                
                 <a href="create.html" class="navigation navigation-next " aria-label="Next page: Create a plugin">
                     <i class="fa fa-angle-right"></i>
                 </a>
-
-
-
+                
+            
+        
     </div>
 
     <script>
         var gitbook = gitbook || [];
         gitbook.push(function() {
-
+            
         });
     </script>
 </div>
 
-
+        
     <noscript>
         <style>
             .honkit-cloak {
@@ -12569,27 +12569,27 @@ exports[`HonKit snapshots: plugins/index.html 1`] = `
     </script>
     <script src="../gitbook/gitbook.js"></script>
     <script src="../gitbook/theme.js"></script>
-
-
+    
+        
         <script src="../gitbook/gitbook-plugin-search/search-engine.js"></script>
-
-
-
+        
+    
+        
         <script src="../gitbook/gitbook-plugin-search/search.js"></script>
-
-
-
+        
+    
+        
         <script src="../gitbook/gitbook-plugin-lunr/lunr.min.js"></script>
-
-
-
+        
+    
+        
         <script src="../gitbook/gitbook-plugin-lunr/search-lunr.js"></script>
-
-
-
+        
+    
+        
         <script src="../gitbook/gitbook-plugin-fontsettings/fontsettings.js"></script>
-
-
+        
+    
 
     </body>
 </html>
@@ -12615,50 +12615,50 @@ exports[`HonKit snapshots: plugins/testing.html 1`] = `
         <title>Test your plugin · HonKit Documentation</title>
         <meta http-equiv="X-UA-Compatible" content="IE=edge" />
         <meta name="description" content="">
-
-
-
-
-
+        
+        
+        
+        
+    
     <link rel="stylesheet" href="../gitbook/style.css">
 
-
-
-
+    
+            
+                
                 <link rel="stylesheet" href="../gitbook/@honkit/honkit-plugin-highlight/website.css">
-
-
-
+                
+            
+                
                 <link rel="stylesheet" href="../gitbook/gitbook-plugin-search/search.css">
-
-
-
+                
+            
+                
                 <link rel="stylesheet" href="../gitbook/gitbook-plugin-fontsettings/website.css">
+                
+            
+        
 
+    
 
-
-
-
-
-
-
+    
+        
         <link rel="stylesheet" href="../styles/website.css">
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
+        
+    
+    
     <meta name="HandheldFriendly" content="true"/>
     <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no">
     <meta name="apple-mobile-web-app-capable" content="yes">
@@ -12666,557 +12666,557 @@ exports[`HonKit snapshots: plugins/testing.html 1`] = `
     <link rel="apple-touch-icon-precomposed" sizes="152x152" href="../gitbook/images/apple-touch-icon-precomposed-152.png">
     <link rel="shortcut icon" href="../gitbook/images/favicon.ico" type="image/x-icon">
 
-
+    
     <link rel="next" href="../themes/" />
-
-
+    
+    
     <link rel="prev" href="api.html" />
-
+    
 
     </head>
     <body>
-
+        
 <div class="book honkit-cloak">
     <div class="book-summary">
-
-
+        
+            
 <div id="book-search-input" role="search">
     <input type="text" placeholder="Type to search" />
 </div>
 
-
+            
                 <nav role="navigation">
-
+                
 
 
 <ul class="summary">
+    
+    
 
+    
 
-
-
-
-
-
+    
+        
         <li class="header">Getting Started</li>
-
-
-
+        
+        
+    
         <li class="chapter " data-level="1.1" data-path="../">
-
+            
                 <a href="../">
-
-
+            
+                    
                     About this documentation
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="1.2" data-path="../setup.html">
-
+            
                 <a href="../setup.html">
-
-
+            
+                    
                     Installation and Setup
-
+            
                 </a>
+            
 
-
-
+            
         </li>
+    
 
-
-
-
+    
+        
         <li class="header">Your Content</li>
-
-
-
+        
+        
+    
         <li class="chapter " data-level="2.1" data-path="../structure.html">
-
+            
                 <a href="../structure.html">
-
-
+            
+                    
                     Directory structure
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.2" data-path="../pages.html">
-
+            
                 <a href="../pages.html">
-
-
+            
+                    
                     Pages and Summary
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.3" data-path="../config.html">
-
+            
                 <a href="../config.html">
-
-
+            
+                    
                     Configuration
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.4" data-path="../lexicon.html">
-
+            
                 <a href="../lexicon.html">
-
-
+            
+                    
                     Glossary
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.5" data-path="../languages.html">
-
+            
                 <a href="../languages.html">
-
-
+            
+                    
                     Multi-Lingual
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.6" data-path="../syntax/markdown.html">
-
+            
                 <a href="../syntax/markdown.html">
-
-
+            
+                    
                     Markdown
-
+            
                 </a>
+            
 
-
-
+            
             <ul class="articles">
-
-
+                
+    
         <li class="chapter " data-level="2.6.1" data-path="../syntax/markdown.html">
-
+            
                 <a href="../syntax/markdown.html#headings">
-
-
+            
+                    
                     Headings
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.6.2" data-path="../syntax/markdown.html">
-
+            
                 <a href="../syntax/markdown.html#paragraphs">
-
-
+            
+                    
                     Paragraphs
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.6.3" data-path="../syntax/markdown.html">
-
+            
                 <a href="../syntax/markdown.html#lists">
-
-
+            
+                    
                     Lists
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.6.4" data-path="../syntax/markdown.html">
-
+            
                 <a href="../syntax/markdown.html#links">
-
-
+            
+                    
                     Links
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.6.5" data-path="../syntax/markdown.html">
-
+            
                 <a href="../syntax/markdown.html#images">
-
-
+            
+                    
                     Images
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.6.6" data-path="../syntax/markdown.html">
-
+            
                 <a href="../syntax/markdown.html#blockquotes">
-
-
+            
+                    
                     Blockquotes
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.6.7" data-path="../syntax/markdown.html">
-
+            
                 <a href="../syntax/markdown.html#tables">
-
-
+            
+                    
                     Tables
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.6.8" data-path="../syntax/markdown.html">
-
+            
                 <a href="../syntax/markdown.html#code">
-
-
+            
+                    
                     Code
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.6.9" data-path="../syntax/markdown.html">
-
+            
                 <a href="../syntax/markdown.html#html">
-
-
+            
+                    
                     HTML
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.6.10" data-path="../syntax/markdown.html">
-
+            
                 <a href="../syntax/markdown.html#footnotes">
-
-
+            
+                    
                     Footnotes
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
 
             </ul>
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.7" data-path="../syntax/asciidoc.html">
-
+            
                 <a href="../syntax/asciidoc.html">
-
-
+            
+                    
                     AsciiDoc
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.8" data-path="../ebook.html">
-
+            
                 <a href="../ebook.html">
-
-
+            
+                    
                     eBook and PDF
-
+            
                 </a>
+            
 
-
-
+            
         </li>
+    
 
-
-
-
+    
+        
         <li class="header">Customization</li>
-
-
-
+        
+        
+    
         <li class="chapter " data-level="3.1" data-path="../templating/">
-
+            
                 <a href="../templating/">
-
-
+            
+                    
                     Templating
-
+            
                 </a>
+            
 
-
-
+            
             <ul class="articles">
-
-
+                
+    
         <li class="chapter " data-level="3.1.1" data-path="../templating/conrefs.html">
-
+            
                 <a href="../templating/conrefs.html">
-
-
+            
+                    
                     Content References
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="3.1.2" data-path="../templating/variables.html">
-
+            
                 <a href="../templating/variables.html">
-
-
+            
+                    
                     Variables
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="3.1.3" data-path="../templating/builtin.html">
-
+            
                 <a href="../templating/builtin.html">
-
-
+            
+                    
                     Builtin
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
 
             </ul>
-
+            
         </li>
-
+    
         <li class="chapter " data-level="3.2" data-path="./">
-
+            
                 <a href="./">
-
-
+            
+                    
                     Plugins
-
+            
                 </a>
+            
 
-
-
+            
             <ul class="articles">
-
-
+                
+    
         <li class="chapter " data-level="3.2.1" data-path="create.html">
-
+            
                 <a href="create.html">
-
-
+            
+                    
                     Create a plugin
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="3.2.2" data-path="hooks.html">
-
+            
                 <a href="hooks.html">
-
-
+            
+                    
                     Hooks
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="3.2.3" data-path="blocks.html">
-
+            
                 <a href="blocks.html">
-
-
+            
+                    
                     Blocks
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="3.2.4" data-path="filters.html">
-
+            
                 <a href="filters.html">
-
-
+            
+                    
                     Filters
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="3.2.5" data-path="api.html">
-
+            
                 <a href="api.html">
-
-
+            
+                    
                     API & Context
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter active" data-level="3.2.6" data-path="testing.html">
-
+            
                 <a href="testing.html">
-
-
+            
+                    
                     Test your plugin
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
 
             </ul>
-
+            
         </li>
-
+    
         <li class="chapter " data-level="3.3" data-path="../themes/">
-
+            
                 <a href="../themes/">
-
-
+            
+                    
                     Theming
-
+            
                 </a>
+            
 
-
-
+            
         </li>
+    
 
-
-
-
+    
+        
         <li class="divider"></li>
-
-
-
+        
+        
+    
         <li class="chapter " data-level="4.1" data-path="../faq.html">
-
+            
                 <a href="../faq.html">
-
-
+            
+                    
                     FAQ
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="4.2" data-path="../examples.md">
-
+            
                 <span>
-
-
+            
+                    
                     Examples
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="4.3" >
-
+            
                 <a target="_blank" href="https://github.com/honkit/honkit/blob/master/CHANGELOG.md">
-
-
+            
+                    
                     Release notes
-
+            
                 </a>
+            
 
-
-
+            
         </li>
+    
 
-
-
-
+    
+        
         <li class="divider"></li>
-
-
-
+        
+        
+    
         <li class="chapter " data-level="5.1" data-path="../encoding.html">
-
+            
                 <a href="../encoding.html">
-
-
+            
+                    
                     Encoding
-
+            
                 </a>
+            
 
-
-
+            
         </li>
+    
 
-
-
+    
 
     <li class="divider"></li>
 
@@ -13229,18 +13229,18 @@ exports[`HonKit snapshots: plugins/testing.html 1`] = `
 
 
                 </nav>
-
-
+            
+        
     </div>
 
     <div class="book-body">
-
+        
             <div class="body-inner">
-
-
+                
+                    
 
 <div class="book-header" role="navigation">
-
+    
 
     <!-- Title -->
     <h1>
@@ -13254,12 +13254,12 @@ exports[`HonKit snapshots: plugins/testing.html 1`] = `
 
                     <div class="page-wrapper" tabindex="-1" role="main">
                         <div class="page-inner">
-
+                            
 <div id="book-search-results">
     <div class="search-noresults">
-
+    
                                 <section class="normal markdown-section">
-
+                                
 
                                 <h1 id="testing-your-plugin">Testing your plugin</h1>
 <h3 id="testing-your-plugin-locally">Testing your plugin locally</h3>
@@ -13271,64 +13271,64 @@ exports[`HonKit snapshots: plugins/testing.html 1`] = `
 </code></pre><h3 id="unit-testing-on-travis">Unit testing on Travis</h3>
 <p><a href="https://github.com/todvora/gitbook-tester" target="_blank">gitbook-tester</a> makes it easy to write <strong>Node.js/Mocha</strong> unit tests for your <a href="../GLOSSARY.html#plugins" class="glossary-term" title="Plugins are the best way to extend HonKit functionalities (ebook and website).">plugins</a>. Using <a href="https://travis.org" target="_blank">Travis.org</a>, tests can be run on each commits/tags.</p>
 
-
+                                
 <hr>
 <div class="btn-group btn-group-justified">
-
+    
     <a class="btn" href="api.html"><b>Previous:</b> API & Context</a>
-
-
+    
+    
     <a class="btn" href="../themes/"><b>Next:</b> Theming</a>
-
+    
 </div>
 
                                 </section>
-
+                            
     </div>
     <div class="search-results">
         <div class="has-results">
-
+            
             <h1 class="search-results-title"><span class='search-results-count'></span> results matching "<span class='search-query'></span>"</h1>
             <ul class="search-results-list"></ul>
-
+            
         </div>
         <div class="no-results">
-
+            
             <h1 class="search-results-title">No results matching "<span class='search-query'></span>"</h1>
-
+            
         </div>
     </div>
 </div>
 
                         </div>
                     </div>
-
+                
             </div>
 
-
-
+            
+                
                 <a href="api.html" class="navigation navigation-prev " aria-label="Previous page: API & Context">
                     <i class="fa fa-angle-left"></i>
                 </a>
-
-
+                
+                
                 <a href="../themes/" class="navigation navigation-next " aria-label="Next page: Theming">
                     <i class="fa fa-angle-right"></i>
                 </a>
-
-
-
+                
+            
+        
     </div>
 
     <script>
         var gitbook = gitbook || [];
         gitbook.push(function() {
-
+            
         });
     </script>
 </div>
 
-
+        
     <noscript>
         <style>
             .honkit-cloak {
@@ -13375,27 +13375,27 @@ exports[`HonKit snapshots: plugins/testing.html 1`] = `
     </script>
     <script src="../gitbook/gitbook.js"></script>
     <script src="../gitbook/theme.js"></script>
-
-
+    
+        
         <script src="../gitbook/gitbook-plugin-search/search-engine.js"></script>
-
-
-
+        
+    
+        
         <script src="../gitbook/gitbook-plugin-search/search.js"></script>
-
-
-
+        
+    
+        
         <script src="../gitbook/gitbook-plugin-lunr/lunr.min.js"></script>
-
-
-
+        
+    
+        
         <script src="../gitbook/gitbook-plugin-lunr/search-lunr.js"></script>
-
-
-
+        
+    
+        
         <script src="../gitbook/gitbook-plugin-fontsettings/fontsettings.js"></script>
-
-
+        
+    
 
     </body>
 </html>
@@ -13421,50 +13421,50 @@ exports[`HonKit snapshots: setup.html 1`] = `
         <title>Installation and Setup · HonKit Documentation</title>
         <meta http-equiv="X-UA-Compatible" content="IE=edge" />
         <meta name="description" content="">
-
-
-
-
-
+        
+        
+        
+        
+    
     <link rel="stylesheet" href="gitbook/style.css">
 
-
-
-
+    
+            
+                
                 <link rel="stylesheet" href="gitbook/@honkit/honkit-plugin-highlight/website.css">
-
-
-
+                
+            
+                
                 <link rel="stylesheet" href="gitbook/gitbook-plugin-search/search.css">
-
-
-
+                
+            
+                
                 <link rel="stylesheet" href="gitbook/gitbook-plugin-fontsettings/website.css">
+                
+            
+        
 
+    
 
-
-
-
-
-
-
+    
+        
         <link rel="stylesheet" href="styles/website.css">
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
+        
+    
+    
     <meta name="HandheldFriendly" content="true"/>
     <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no">
     <meta name="apple-mobile-web-app-capable" content="yes">
@@ -13472,557 +13472,557 @@ exports[`HonKit snapshots: setup.html 1`] = `
     <link rel="apple-touch-icon-precomposed" sizes="152x152" href="gitbook/images/apple-touch-icon-precomposed-152.png">
     <link rel="shortcut icon" href="gitbook/images/favicon.ico" type="image/x-icon">
 
-
+    
     <link rel="next" href="structure.html" />
-
-
+    
+    
     <link rel="prev" href="./" />
-
+    
 
     </head>
     <body>
-
+        
 <div class="book honkit-cloak">
     <div class="book-summary">
-
-
+        
+            
 <div id="book-search-input" role="search">
     <input type="text" placeholder="Type to search" />
 </div>
 
-
+            
                 <nav role="navigation">
-
+                
 
 
 <ul class="summary">
+    
+    
 
+    
 
-
-
-
-
-
+    
+        
         <li class="header">Getting Started</li>
-
-
-
+        
+        
+    
         <li class="chapter " data-level="1.1" data-path="./">
-
+            
                 <a href="./">
-
-
+            
+                    
                     About this documentation
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter active" data-level="1.2" data-path="setup.html">
-
+            
                 <a href="setup.html">
-
-
+            
+                    
                     Installation and Setup
-
+            
                 </a>
+            
 
-
-
+            
         </li>
+    
 
-
-
-
+    
+        
         <li class="header">Your Content</li>
-
-
-
+        
+        
+    
         <li class="chapter " data-level="2.1" data-path="structure.html">
-
+            
                 <a href="structure.html">
-
-
+            
+                    
                     Directory structure
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.2" data-path="pages.html">
-
+            
                 <a href="pages.html">
-
-
+            
+                    
                     Pages and Summary
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.3" data-path="config.html">
-
+            
                 <a href="config.html">
-
-
+            
+                    
                     Configuration
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.4" data-path="lexicon.html">
-
+            
                 <a href="lexicon.html">
-
-
+            
+                    
                     Glossary
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.5" data-path="languages.html">
-
+            
                 <a href="languages.html">
-
-
+            
+                    
                     Multi-Lingual
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.6" data-path="syntax/markdown.html">
-
+            
                 <a href="syntax/markdown.html">
-
-
+            
+                    
                     Markdown
-
+            
                 </a>
+            
 
-
-
+            
             <ul class="articles">
-
-
+                
+    
         <li class="chapter " data-level="2.6.1" data-path="syntax/markdown.html">
-
+            
                 <a href="syntax/markdown.html#headings">
-
-
+            
+                    
                     Headings
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.6.2" data-path="syntax/markdown.html">
-
+            
                 <a href="syntax/markdown.html#paragraphs">
-
-
+            
+                    
                     Paragraphs
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.6.3" data-path="syntax/markdown.html">
-
+            
                 <a href="syntax/markdown.html#lists">
-
-
+            
+                    
                     Lists
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.6.4" data-path="syntax/markdown.html">
-
+            
                 <a href="syntax/markdown.html#links">
-
-
+            
+                    
                     Links
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.6.5" data-path="syntax/markdown.html">
-
+            
                 <a href="syntax/markdown.html#images">
-
-
+            
+                    
                     Images
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.6.6" data-path="syntax/markdown.html">
-
+            
                 <a href="syntax/markdown.html#blockquotes">
-
-
+            
+                    
                     Blockquotes
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.6.7" data-path="syntax/markdown.html">
-
+            
                 <a href="syntax/markdown.html#tables">
-
-
+            
+                    
                     Tables
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.6.8" data-path="syntax/markdown.html">
-
+            
                 <a href="syntax/markdown.html#code">
-
-
+            
+                    
                     Code
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.6.9" data-path="syntax/markdown.html">
-
+            
                 <a href="syntax/markdown.html#html">
-
-
+            
+                    
                     HTML
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.6.10" data-path="syntax/markdown.html">
-
+            
                 <a href="syntax/markdown.html#footnotes">
-
-
+            
+                    
                     Footnotes
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
 
             </ul>
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.7" data-path="syntax/asciidoc.html">
-
+            
                 <a href="syntax/asciidoc.html">
-
-
+            
+                    
                     AsciiDoc
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.8" data-path="ebook.html">
-
+            
                 <a href="ebook.html">
-
-
+            
+                    
                     eBook and PDF
-
+            
                 </a>
+            
 
-
-
+            
         </li>
+    
 
-
-
-
+    
+        
         <li class="header">Customization</li>
-
-
-
+        
+        
+    
         <li class="chapter " data-level="3.1" data-path="templating/">
-
+            
                 <a href="templating/">
-
-
+            
+                    
                     Templating
-
+            
                 </a>
+            
 
-
-
+            
             <ul class="articles">
-
-
+                
+    
         <li class="chapter " data-level="3.1.1" data-path="templating/conrefs.html">
-
+            
                 <a href="templating/conrefs.html">
-
-
+            
+                    
                     Content References
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="3.1.2" data-path="templating/variables.html">
-
+            
                 <a href="templating/variables.html">
-
-
+            
+                    
                     Variables
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="3.1.3" data-path="templating/builtin.html">
-
+            
                 <a href="templating/builtin.html">
-
-
+            
+                    
                     Builtin
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
 
             </ul>
-
+            
         </li>
-
+    
         <li class="chapter " data-level="3.2" data-path="plugins/">
-
+            
                 <a href="plugins/">
-
-
+            
+                    
                     Plugins
-
+            
                 </a>
+            
 
-
-
+            
             <ul class="articles">
-
-
+                
+    
         <li class="chapter " data-level="3.2.1" data-path="plugins/create.html">
-
+            
                 <a href="plugins/create.html">
-
-
+            
+                    
                     Create a plugin
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="3.2.2" data-path="plugins/hooks.html">
-
+            
                 <a href="plugins/hooks.html">
-
-
+            
+                    
                     Hooks
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="3.2.3" data-path="plugins/blocks.html">
-
+            
                 <a href="plugins/blocks.html">
-
-
+            
+                    
                     Blocks
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="3.2.4" data-path="plugins/filters.html">
-
+            
                 <a href="plugins/filters.html">
-
-
+            
+                    
                     Filters
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="3.2.5" data-path="plugins/api.html">
-
+            
                 <a href="plugins/api.html">
-
-
+            
+                    
                     API & Context
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="3.2.6" data-path="plugins/testing.html">
-
+            
                 <a href="plugins/testing.html">
-
-
+            
+                    
                     Test your plugin
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
 
             </ul>
-
+            
         </li>
-
+    
         <li class="chapter " data-level="3.3" data-path="themes/">
-
+            
                 <a href="themes/">
-
-
+            
+                    
                     Theming
-
+            
                 </a>
+            
 
-
-
+            
         </li>
+    
 
-
-
-
+    
+        
         <li class="divider"></li>
-
-
-
+        
+        
+    
         <li class="chapter " data-level="4.1" data-path="faq.html">
-
+            
                 <a href="faq.html">
-
-
+            
+                    
                     FAQ
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="4.2" data-path="examples.md">
-
+            
                 <span>
-
-
+            
+                    
                     Examples
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="4.3" >
-
+            
                 <a target="_blank" href="https://github.com/honkit/honkit/blob/master/CHANGELOG.md">
-
-
+            
+                    
                     Release notes
-
+            
                 </a>
+            
 
-
-
+            
         </li>
+    
 
-
-
-
+    
+        
         <li class="divider"></li>
-
-
-
+        
+        
+    
         <li class="chapter " data-level="5.1" data-path="encoding.html">
-
+            
                 <a href="encoding.html">
-
-
+            
+                    
                     Encoding
-
+            
                 </a>
+            
 
-
-
+            
         </li>
+    
 
-
-
+    
 
     <li class="divider"></li>
 
@@ -14035,18 +14035,18 @@ exports[`HonKit snapshots: setup.html 1`] = `
 
 
                 </nav>
-
-
+            
+        
     </div>
 
     <div class="book-body">
-
+        
             <div class="body-inner">
-
-
+                
+                    
 
 <div class="book-header" role="navigation">
-
+    
 
     <!-- Title -->
     <h1>
@@ -14060,12 +14060,12 @@ exports[`HonKit snapshots: setup.html 1`] = `
 
                     <div class="page-wrapper" tabindex="-1" role="main">
                         <div class="page-inner">
-
+                            
 <div id="book-search-results">
     <div class="search-noresults">
-
+    
                                 <section class="normal markdown-section">
-
+                                
 
                                 <h1 id="setup-and-installation-of-honkit">Setup and Installation of HonKit</h1>
 <p>Getting <a href="GLOSSARY.html#honkit" class="glossary-term" title="Honkit is a command line tool for building beautiful books using GitHub/Git and Markdown (or AsciiDoc).">HonKit</a> installed and ready-to-go should only take a few minutes.</p>
@@ -14102,7 +14102,7 @@ $ yarn add honkit --dev
   },
 </code></pre>
 <p>After this configuration, you can use <code>npm run</code> command.</p>
-<pre><code># Build
+<pre><code># Build 
 npm run build
 # Start to server
 npm run serve
@@ -14110,64 +14110,64 @@ npm run serve
 <p>You can use the options <code>--log=debug</code> and <code>--debug</code> to get better error messages (with stack trace). For example:</p>
 <pre><code>$ honkit build ./ --log=debug --debug
 </code></pre>
-
+                                
 <hr>
 <div class="btn-group btn-group-justified">
-
+    
     <a class="btn" href="./"><b>Previous:</b> About this documentation</a>
-
-
+    
+    
     <a class="btn" href="structure.html"><b>Next:</b> Directory structure</a>
-
+    
 </div>
 
                                 </section>
-
+                            
     </div>
     <div class="search-results">
         <div class="has-results">
-
+            
             <h1 class="search-results-title"><span class='search-results-count'></span> results matching "<span class='search-query'></span>"</h1>
             <ul class="search-results-list"></ul>
-
+            
         </div>
         <div class="no-results">
-
+            
             <h1 class="search-results-title">No results matching "<span class='search-query'></span>"</h1>
-
+            
         </div>
     </div>
 </div>
 
                         </div>
                     </div>
-
+                
             </div>
 
-
-
+            
+                
                 <a href="./" class="navigation navigation-prev " aria-label="Previous page: About this documentation">
                     <i class="fa fa-angle-left"></i>
                 </a>
-
-
+                
+                
                 <a href="structure.html" class="navigation navigation-next " aria-label="Next page: Directory structure">
                     <i class="fa fa-angle-right"></i>
                 </a>
-
-
-
+                
+            
+        
     </div>
 
     <script>
         var gitbook = gitbook || [];
         gitbook.push(function() {
-
+            
         });
     </script>
 </div>
 
-
+        
     <noscript>
         <style>
             .honkit-cloak {
@@ -14214,27 +14214,27 @@ npm run serve
     </script>
     <script src="gitbook/gitbook.js"></script>
     <script src="gitbook/theme.js"></script>
-
-
+    
+        
         <script src="gitbook/gitbook-plugin-search/search-engine.js"></script>
-
-
-
+        
+    
+        
         <script src="gitbook/gitbook-plugin-search/search.js"></script>
-
-
-
+        
+    
+        
         <script src="gitbook/gitbook-plugin-lunr/lunr.min.js"></script>
-
-
-
+        
+    
+        
         <script src="gitbook/gitbook-plugin-lunr/search-lunr.js"></script>
-
-
-
+        
+    
+        
         <script src="gitbook/gitbook-plugin-fontsettings/fontsettings.js"></script>
-
-
+        
+    
 
     </body>
 </html>
@@ -14260,50 +14260,50 @@ exports[`HonKit snapshots: structure.html 1`] = `
         <title>Directory structure · HonKit Documentation</title>
         <meta http-equiv="X-UA-Compatible" content="IE=edge" />
         <meta name="description" content="">
-
-
-
-
-
+        
+        
+        
+        
+    
     <link rel="stylesheet" href="gitbook/style.css">
 
-
-
-
+    
+            
+                
                 <link rel="stylesheet" href="gitbook/@honkit/honkit-plugin-highlight/website.css">
-
-
-
+                
+            
+                
                 <link rel="stylesheet" href="gitbook/gitbook-plugin-search/search.css">
-
-
-
+                
+            
+                
                 <link rel="stylesheet" href="gitbook/gitbook-plugin-fontsettings/website.css">
+                
+            
+        
 
+    
 
-
-
-
-
-
-
+    
+        
         <link rel="stylesheet" href="styles/website.css">
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
+        
+    
+    
     <meta name="HandheldFriendly" content="true"/>
     <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no">
     <meta name="apple-mobile-web-app-capable" content="yes">
@@ -14311,557 +14311,557 @@ exports[`HonKit snapshots: structure.html 1`] = `
     <link rel="apple-touch-icon-precomposed" sizes="152x152" href="gitbook/images/apple-touch-icon-precomposed-152.png">
     <link rel="shortcut icon" href="gitbook/images/favicon.ico" type="image/x-icon">
 
-
+    
     <link rel="next" href="pages.html" />
-
-
+    
+    
     <link rel="prev" href="setup.html" />
-
+    
 
     </head>
     <body>
-
+        
 <div class="book honkit-cloak">
     <div class="book-summary">
-
-
+        
+            
 <div id="book-search-input" role="search">
     <input type="text" placeholder="Type to search" />
 </div>
 
-
+            
                 <nav role="navigation">
-
+                
 
 
 <ul class="summary">
+    
+    
 
+    
 
-
-
-
-
-
+    
+        
         <li class="header">Getting Started</li>
-
-
-
+        
+        
+    
         <li class="chapter " data-level="1.1" data-path="./">
-
+            
                 <a href="./">
-
-
+            
+                    
                     About this documentation
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="1.2" data-path="setup.html">
-
+            
                 <a href="setup.html">
-
-
+            
+                    
                     Installation and Setup
-
+            
                 </a>
+            
 
-
-
+            
         </li>
+    
 
-
-
-
+    
+        
         <li class="header">Your Content</li>
-
-
-
+        
+        
+    
         <li class="chapter active" data-level="2.1" data-path="structure.html">
-
+            
                 <a href="structure.html">
-
-
+            
+                    
                     Directory structure
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.2" data-path="pages.html">
-
+            
                 <a href="pages.html">
-
-
+            
+                    
                     Pages and Summary
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.3" data-path="config.html">
-
+            
                 <a href="config.html">
-
-
+            
+                    
                     Configuration
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.4" data-path="lexicon.html">
-
+            
                 <a href="lexicon.html">
-
-
+            
+                    
                     Glossary
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.5" data-path="languages.html">
-
+            
                 <a href="languages.html">
-
-
+            
+                    
                     Multi-Lingual
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.6" data-path="syntax/markdown.html">
-
+            
                 <a href="syntax/markdown.html">
-
-
+            
+                    
                     Markdown
-
+            
                 </a>
+            
 
-
-
+            
             <ul class="articles">
-
-
+                
+    
         <li class="chapter " data-level="2.6.1" data-path="syntax/markdown.html">
-
+            
                 <a href="syntax/markdown.html#headings">
-
-
+            
+                    
                     Headings
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.6.2" data-path="syntax/markdown.html">
-
+            
                 <a href="syntax/markdown.html#paragraphs">
-
-
+            
+                    
                     Paragraphs
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.6.3" data-path="syntax/markdown.html">
-
+            
                 <a href="syntax/markdown.html#lists">
-
-
+            
+                    
                     Lists
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.6.4" data-path="syntax/markdown.html">
-
+            
                 <a href="syntax/markdown.html#links">
-
-
+            
+                    
                     Links
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.6.5" data-path="syntax/markdown.html">
-
+            
                 <a href="syntax/markdown.html#images">
-
-
+            
+                    
                     Images
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.6.6" data-path="syntax/markdown.html">
-
+            
                 <a href="syntax/markdown.html#blockquotes">
-
-
+            
+                    
                     Blockquotes
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.6.7" data-path="syntax/markdown.html">
-
+            
                 <a href="syntax/markdown.html#tables">
-
-
+            
+                    
                     Tables
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.6.8" data-path="syntax/markdown.html">
-
+            
                 <a href="syntax/markdown.html#code">
-
-
+            
+                    
                     Code
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.6.9" data-path="syntax/markdown.html">
-
+            
                 <a href="syntax/markdown.html#html">
-
-
+            
+                    
                     HTML
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.6.10" data-path="syntax/markdown.html">
-
+            
                 <a href="syntax/markdown.html#footnotes">
-
-
+            
+                    
                     Footnotes
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
 
             </ul>
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.7" data-path="syntax/asciidoc.html">
-
+            
                 <a href="syntax/asciidoc.html">
-
-
+            
+                    
                     AsciiDoc
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.8" data-path="ebook.html">
-
+            
                 <a href="ebook.html">
-
-
+            
+                    
                     eBook and PDF
-
+            
                 </a>
+            
 
-
-
+            
         </li>
+    
 
-
-
-
+    
+        
         <li class="header">Customization</li>
-
-
-
+        
+        
+    
         <li class="chapter " data-level="3.1" data-path="templating/">
-
+            
                 <a href="templating/">
-
-
+            
+                    
                     Templating
-
+            
                 </a>
+            
 
-
-
+            
             <ul class="articles">
-
-
+                
+    
         <li class="chapter " data-level="3.1.1" data-path="templating/conrefs.html">
-
+            
                 <a href="templating/conrefs.html">
-
-
+            
+                    
                     Content References
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="3.1.2" data-path="templating/variables.html">
-
+            
                 <a href="templating/variables.html">
-
-
+            
+                    
                     Variables
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="3.1.3" data-path="templating/builtin.html">
-
+            
                 <a href="templating/builtin.html">
-
-
+            
+                    
                     Builtin
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
 
             </ul>
-
+            
         </li>
-
+    
         <li class="chapter " data-level="3.2" data-path="plugins/">
-
+            
                 <a href="plugins/">
-
-
+            
+                    
                     Plugins
-
+            
                 </a>
+            
 
-
-
+            
             <ul class="articles">
-
-
+                
+    
         <li class="chapter " data-level="3.2.1" data-path="plugins/create.html">
-
+            
                 <a href="plugins/create.html">
-
-
+            
+                    
                     Create a plugin
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="3.2.2" data-path="plugins/hooks.html">
-
+            
                 <a href="plugins/hooks.html">
-
-
+            
+                    
                     Hooks
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="3.2.3" data-path="plugins/blocks.html">
-
+            
                 <a href="plugins/blocks.html">
-
-
+            
+                    
                     Blocks
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="3.2.4" data-path="plugins/filters.html">
-
+            
                 <a href="plugins/filters.html">
-
-
+            
+                    
                     Filters
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="3.2.5" data-path="plugins/api.html">
-
+            
                 <a href="plugins/api.html">
-
-
+            
+                    
                     API & Context
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="3.2.6" data-path="plugins/testing.html">
-
+            
                 <a href="plugins/testing.html">
-
-
+            
+                    
                     Test your plugin
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
 
             </ul>
-
+            
         </li>
-
+    
         <li class="chapter " data-level="3.3" data-path="themes/">
-
+            
                 <a href="themes/">
-
-
+            
+                    
                     Theming
-
+            
                 </a>
+            
 
-
-
+            
         </li>
+    
 
-
-
-
+    
+        
         <li class="divider"></li>
-
-
-
+        
+        
+    
         <li class="chapter " data-level="4.1" data-path="faq.html">
-
+            
                 <a href="faq.html">
-
-
+            
+                    
                     FAQ
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="4.2" data-path="examples.md">
-
+            
                 <span>
-
-
+            
+                    
                     Examples
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="4.3" >
-
+            
                 <a target="_blank" href="https://github.com/honkit/honkit/blob/master/CHANGELOG.md">
-
-
+            
+                    
                     Release notes
-
+            
                 </a>
+            
 
-
-
+            
         </li>
+    
 
-
-
-
+    
+        
         <li class="divider"></li>
-
-
-
+        
+        
+    
         <li class="chapter " data-level="5.1" data-path="encoding.html">
-
+            
                 <a href="encoding.html">
-
-
+            
+                    
                     Encoding
-
+            
                 </a>
+            
 
-
-
+            
         </li>
+    
 
-
-
+    
 
     <li class="divider"></li>
 
@@ -14874,18 +14874,18 @@ exports[`HonKit snapshots: structure.html 1`] = `
 
 
                 </nav>
-
-
+            
+        
     </div>
 
     <div class="book-body">
-
+        
             <div class="body-inner">
-
-
+                
+                    
 
 <div class="book-header" role="navigation">
-
+    
 
     <!-- Title -->
     <h1>
@@ -14899,12 +14899,12 @@ exports[`HonKit snapshots: structure.html 1`] = `
 
                     <div class="page-wrapper" tabindex="-1" role="main">
                         <div class="page-inner">
-
+                            
 <div id="book-search-results">
     <div class="search-noresults">
-
+    
                                 <section class="normal markdown-section">
-
+                                
 
                                 <h1 id="directory-structure">Directory Structure</h1>
 <p><a href="GLOSSARY.html#honkit" class="glossary-term" title="Honkit is a command line tool for building beautiful books using GitHub/Git and Markdown (or AsciiDoc).">HonKit</a> uses a simple directory structure. All Markdown/Asciidoc files listed in the <a href="pages.html">SUMMARY</a> will be transformed as HTML. Multi-Lingual books have a slightly <a href="languages.html">different structure</a>.</p>
@@ -14970,64 +14970,64 @@ bin/*
     &quot;root&quot;: &quot;./docs&quot;
 }
 </code></pre>
-
+                                
 <hr>
 <div class="btn-group btn-group-justified">
-
+    
     <a class="btn" href="setup.html"><b>Previous:</b> Installation and Setup</a>
-
-
+    
+    
     <a class="btn" href="pages.html"><b>Next:</b> Pages and Summary</a>
-
+    
 </div>
 
                                 </section>
-
+                            
     </div>
     <div class="search-results">
         <div class="has-results">
-
+            
             <h1 class="search-results-title"><span class='search-results-count'></span> results matching "<span class='search-query'></span>"</h1>
             <ul class="search-results-list"></ul>
-
+            
         </div>
         <div class="no-results">
-
+            
             <h1 class="search-results-title">No results matching "<span class='search-query'></span>"</h1>
-
+            
         </div>
     </div>
 </div>
 
                         </div>
                     </div>
-
+                
             </div>
 
-
-
+            
+                
                 <a href="setup.html" class="navigation navigation-prev " aria-label="Previous page: Installation and Setup">
                     <i class="fa fa-angle-left"></i>
                 </a>
-
-
+                
+                
                 <a href="pages.html" class="navigation navigation-next " aria-label="Next page: Pages and Summary">
                     <i class="fa fa-angle-right"></i>
                 </a>
-
-
-
+                
+            
+        
     </div>
 
     <script>
         var gitbook = gitbook || [];
         gitbook.push(function() {
-
+            
         });
     </script>
 </div>
 
-
+        
     <noscript>
         <style>
             .honkit-cloak {
@@ -15074,27 +15074,27 @@ bin/*
     </script>
     <script src="gitbook/gitbook.js"></script>
     <script src="gitbook/theme.js"></script>
-
-
+    
+        
         <script src="gitbook/gitbook-plugin-search/search-engine.js"></script>
-
-
-
+        
+    
+        
         <script src="gitbook/gitbook-plugin-search/search.js"></script>
-
-
-
+        
+    
+        
         <script src="gitbook/gitbook-plugin-lunr/lunr.min.js"></script>
-
-
-
+        
+    
+        
         <script src="gitbook/gitbook-plugin-lunr/search-lunr.js"></script>
-
-
-
+        
+    
+        
         <script src="gitbook/gitbook-plugin-fontsettings/fontsettings.js"></script>
-
-
+        
+    
 
     </body>
 </html>
@@ -15120,50 +15120,50 @@ exports[`HonKit snapshots: syntax/asciidoc.html 1`] = `
         <title>AsciiDoc · HonKit Documentation</title>
         <meta http-equiv="X-UA-Compatible" content="IE=edge" />
         <meta name="description" content="">
-
-
-
-
-
+        
+        
+        
+        
+    
     <link rel="stylesheet" href="../gitbook/style.css">
 
-
-
-
+    
+            
+                
                 <link rel="stylesheet" href="../gitbook/@honkit/honkit-plugin-highlight/website.css">
-
-
-
+                
+            
+                
                 <link rel="stylesheet" href="../gitbook/gitbook-plugin-search/search.css">
-
-
-
+                
+            
+                
                 <link rel="stylesheet" href="../gitbook/gitbook-plugin-fontsettings/website.css">
+                
+            
+        
 
+    
 
-
-
-
-
-
-
+    
+        
         <link rel="stylesheet" href="../styles/website.css">
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
+        
+    
+    
     <meta name="HandheldFriendly" content="true"/>
     <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no">
     <meta name="apple-mobile-web-app-capable" content="yes">
@@ -15171,557 +15171,557 @@ exports[`HonKit snapshots: syntax/asciidoc.html 1`] = `
     <link rel="apple-touch-icon-precomposed" sizes="152x152" href="../gitbook/images/apple-touch-icon-precomposed-152.png">
     <link rel="shortcut icon" href="../gitbook/images/favicon.ico" type="image/x-icon">
 
-
+    
     <link rel="next" href="../ebook.html" />
-
-
+    
+    
     <link rel="prev" href="markdown.html" />
-
+    
 
     </head>
     <body>
-
+        
 <div class="book honkit-cloak">
     <div class="book-summary">
-
-
+        
+            
 <div id="book-search-input" role="search">
     <input type="text" placeholder="Type to search" />
 </div>
 
-
+            
                 <nav role="navigation">
-
+                
 
 
 <ul class="summary">
+    
+    
 
+    
 
-
-
-
-
-
+    
+        
         <li class="header">Getting Started</li>
-
-
-
+        
+        
+    
         <li class="chapter " data-level="1.1" data-path="../">
-
+            
                 <a href="../">
-
-
+            
+                    
                     About this documentation
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="1.2" data-path="../setup.html">
-
+            
                 <a href="../setup.html">
-
-
+            
+                    
                     Installation and Setup
-
+            
                 </a>
+            
 
-
-
+            
         </li>
+    
 
-
-
-
+    
+        
         <li class="header">Your Content</li>
-
-
-
+        
+        
+    
         <li class="chapter " data-level="2.1" data-path="../structure.html">
-
+            
                 <a href="../structure.html">
-
-
+            
+                    
                     Directory structure
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.2" data-path="../pages.html">
-
+            
                 <a href="../pages.html">
-
-
+            
+                    
                     Pages and Summary
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.3" data-path="../config.html">
-
+            
                 <a href="../config.html">
-
-
+            
+                    
                     Configuration
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.4" data-path="../lexicon.html">
-
+            
                 <a href="../lexicon.html">
-
-
+            
+                    
                     Glossary
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.5" data-path="../languages.html">
-
+            
                 <a href="../languages.html">
-
-
+            
+                    
                     Multi-Lingual
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.6" data-path="markdown.html">
-
+            
                 <a href="markdown.html">
-
-
+            
+                    
                     Markdown
-
+            
                 </a>
+            
 
-
-
+            
             <ul class="articles">
-
-
+                
+    
         <li class="chapter " data-level="2.6.1" data-path="markdown.html">
-
+            
                 <a href="markdown.html#headings">
-
-
+            
+                    
                     Headings
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.6.2" data-path="markdown.html">
-
+            
                 <a href="markdown.html#paragraphs">
-
-
+            
+                    
                     Paragraphs
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.6.3" data-path="markdown.html">
-
+            
                 <a href="markdown.html#lists">
-
-
+            
+                    
                     Lists
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.6.4" data-path="markdown.html">
-
+            
                 <a href="markdown.html#links">
-
-
+            
+                    
                     Links
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.6.5" data-path="markdown.html">
-
+            
                 <a href="markdown.html#images">
-
-
+            
+                    
                     Images
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.6.6" data-path="markdown.html">
-
+            
                 <a href="markdown.html#blockquotes">
-
-
+            
+                    
                     Blockquotes
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.6.7" data-path="markdown.html">
-
+            
                 <a href="markdown.html#tables">
-
-
+            
+                    
                     Tables
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.6.8" data-path="markdown.html">
-
+            
                 <a href="markdown.html#code">
-
-
+            
+                    
                     Code
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.6.9" data-path="markdown.html">
-
+            
                 <a href="markdown.html#html">
-
-
+            
+                    
                     HTML
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.6.10" data-path="markdown.html">
-
+            
                 <a href="markdown.html#footnotes">
-
-
+            
+                    
                     Footnotes
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
 
             </ul>
-
+            
         </li>
-
+    
         <li class="chapter active" data-level="2.7" data-path="asciidoc.html">
-
+            
                 <a href="asciidoc.html">
-
-
+            
+                    
                     AsciiDoc
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.8" data-path="../ebook.html">
-
+            
                 <a href="../ebook.html">
-
-
+            
+                    
                     eBook and PDF
-
+            
                 </a>
+            
 
-
-
+            
         </li>
+    
 
-
-
-
+    
+        
         <li class="header">Customization</li>
-
-
-
+        
+        
+    
         <li class="chapter " data-level="3.1" data-path="../templating/">
-
+            
                 <a href="../templating/">
-
-
+            
+                    
                     Templating
-
+            
                 </a>
+            
 
-
-
+            
             <ul class="articles">
-
-
+                
+    
         <li class="chapter " data-level="3.1.1" data-path="../templating/conrefs.html">
-
+            
                 <a href="../templating/conrefs.html">
-
-
+            
+                    
                     Content References
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="3.1.2" data-path="../templating/variables.html">
-
+            
                 <a href="../templating/variables.html">
-
-
+            
+                    
                     Variables
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="3.1.3" data-path="../templating/builtin.html">
-
+            
                 <a href="../templating/builtin.html">
-
-
+            
+                    
                     Builtin
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
 
             </ul>
-
+            
         </li>
-
+    
         <li class="chapter " data-level="3.2" data-path="../plugins/">
-
+            
                 <a href="../plugins/">
-
-
+            
+                    
                     Plugins
-
+            
                 </a>
+            
 
-
-
+            
             <ul class="articles">
-
-
+                
+    
         <li class="chapter " data-level="3.2.1" data-path="../plugins/create.html">
-
+            
                 <a href="../plugins/create.html">
-
-
+            
+                    
                     Create a plugin
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="3.2.2" data-path="../plugins/hooks.html">
-
+            
                 <a href="../plugins/hooks.html">
-
-
+            
+                    
                     Hooks
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="3.2.3" data-path="../plugins/blocks.html">
-
+            
                 <a href="../plugins/blocks.html">
-
-
+            
+                    
                     Blocks
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="3.2.4" data-path="../plugins/filters.html">
-
+            
                 <a href="../plugins/filters.html">
-
-
+            
+                    
                     Filters
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="3.2.5" data-path="../plugins/api.html">
-
+            
                 <a href="../plugins/api.html">
-
-
+            
+                    
                     API & Context
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="3.2.6" data-path="../plugins/testing.html">
-
+            
                 <a href="../plugins/testing.html">
-
-
+            
+                    
                     Test your plugin
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
 
             </ul>
-
+            
         </li>
-
+    
         <li class="chapter " data-level="3.3" data-path="../themes/">
-
+            
                 <a href="../themes/">
-
-
+            
+                    
                     Theming
-
+            
                 </a>
+            
 
-
-
+            
         </li>
+    
 
-
-
-
+    
+        
         <li class="divider"></li>
-
-
-
+        
+        
+    
         <li class="chapter " data-level="4.1" data-path="../faq.html">
-
+            
                 <a href="../faq.html">
-
-
+            
+                    
                     FAQ
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="4.2" data-path="../examples.md">
-
+            
                 <span>
-
-
+            
+                    
                     Examples
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="4.3" >
-
+            
                 <a target="_blank" href="https://github.com/honkit/honkit/blob/master/CHANGELOG.md">
-
-
+            
+                    
                     Release notes
-
+            
                 </a>
+            
 
-
-
+            
         </li>
+    
 
-
-
-
+    
+        
         <li class="divider"></li>
-
-
-
+        
+        
+    
         <li class="chapter " data-level="5.1" data-path="../encoding.html">
-
+            
                 <a href="../encoding.html">
-
-
+            
+                    
                     Encoding
-
+            
                 </a>
+            
 
-
-
+            
         </li>
+    
 
-
-
+    
 
     <li class="divider"></li>
 
@@ -15734,18 +15734,18 @@ exports[`HonKit snapshots: syntax/asciidoc.html 1`] = `
 
 
                 </nav>
-
-
+            
+        
     </div>
 
     <div class="book-body">
-
+        
             <div class="body-inner">
-
-
+                
+                    
 
 <div class="book-header" role="navigation">
-
+    
 
     <!-- Title -->
     <h1>
@@ -15759,12 +15759,12 @@ exports[`HonKit snapshots: syntax/asciidoc.html 1`] = `
 
                     <div class="page-wrapper" tabindex="-1" role="main">
                         <div class="page-inner">
-
+                            
 <div id="book-search-results">
     <div class="search-noresults">
-
+    
                                 <section class="normal markdown-section">
-
+                                
 
                                 <h1 id="asciidoc">AsciiDoc</h1>
 <p>Since version <code>2.0.0</code>, <a href="../GLOSSARY.html#honkit" class="glossary-term" title="Honkit is a command line tool for building beautiful books using GitHub/Git and Markdown (or AsciiDoc).">HonKit</a> can also accept AsciiDoc as an input format.</p>
@@ -15812,64 +15812,64 @@ his personal homepage (PHP originally stood for &quot;Personal Home Page&quot;
 but now stands for &quot;PHP: Hypertext Preprocessor&quot;).
 </code></pre>
 
-
+                                
 <hr>
 <div class="btn-group btn-group-justified">
-
+    
     <a class="btn" href="markdown.html"><b>Previous:</b> Markdown</a>
-
-
+    
+    
     <a class="btn" href="../ebook.html"><b>Next:</b> eBook and PDF</a>
-
+    
 </div>
 
                                 </section>
-
+                            
     </div>
     <div class="search-results">
         <div class="has-results">
-
+            
             <h1 class="search-results-title"><span class='search-results-count'></span> results matching "<span class='search-query'></span>"</h1>
             <ul class="search-results-list"></ul>
-
+            
         </div>
         <div class="no-results">
-
+            
             <h1 class="search-results-title">No results matching "<span class='search-query'></span>"</h1>
-
+            
         </div>
     </div>
 </div>
 
                         </div>
                     </div>
-
+                
             </div>
 
-
-
+            
+                
                 <a href="markdown.html" class="navigation navigation-prev " aria-label="Previous page: Markdown">
                     <i class="fa fa-angle-left"></i>
                 </a>
-
-
+                
+                
                 <a href="../ebook.html" class="navigation navigation-next " aria-label="Next page: eBook and PDF">
                     <i class="fa fa-angle-right"></i>
                 </a>
-
-
-
+                
+            
+        
     </div>
 
     <script>
         var gitbook = gitbook || [];
         gitbook.push(function() {
-
+            
         });
     </script>
 </div>
 
-
+        
     <noscript>
         <style>
             .honkit-cloak {
@@ -15916,27 +15916,27 @@ but now stands for &quot;PHP: Hypertext Preprocessor&quot;).
     </script>
     <script src="../gitbook/gitbook.js"></script>
     <script src="../gitbook/theme.js"></script>
-
-
+    
+        
         <script src="../gitbook/gitbook-plugin-search/search-engine.js"></script>
-
-
-
+        
+    
+        
         <script src="../gitbook/gitbook-plugin-search/search.js"></script>
-
-
-
+        
+    
+        
         <script src="../gitbook/gitbook-plugin-lunr/lunr.min.js"></script>
-
-
-
+        
+    
+        
         <script src="../gitbook/gitbook-plugin-lunr/search-lunr.js"></script>
-
-
-
+        
+    
+        
         <script src="../gitbook/gitbook-plugin-fontsettings/fontsettings.js"></script>
-
-
+        
+    
 
     </body>
 </html>
@@ -15962,50 +15962,50 @@ exports[`HonKit snapshots: syntax/markdown.html 1`] = `
         <title>Markdown · HonKit Documentation</title>
         <meta http-equiv="X-UA-Compatible" content="IE=edge" />
         <meta name="description" content="">
-
-
-
-
-
+        
+        
+        
+        
+    
     <link rel="stylesheet" href="../gitbook/style.css">
 
-
-
-
+    
+            
+                
                 <link rel="stylesheet" href="../gitbook/@honkit/honkit-plugin-highlight/website.css">
-
-
-
+                
+            
+                
                 <link rel="stylesheet" href="../gitbook/gitbook-plugin-search/search.css">
-
-
-
+                
+            
+                
                 <link rel="stylesheet" href="../gitbook/gitbook-plugin-fontsettings/website.css">
+                
+            
+        
 
+    
 
-
-
-
-
-
-
+    
+        
         <link rel="stylesheet" href="../styles/website.css">
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
+        
+    
+    
     <meta name="HandheldFriendly" content="true"/>
     <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no">
     <meta name="apple-mobile-web-app-capable" content="yes">
@@ -16013,557 +16013,557 @@ exports[`HonKit snapshots: syntax/markdown.html 1`] = `
     <link rel="apple-touch-icon-precomposed" sizes="152x152" href="../gitbook/images/apple-touch-icon-precomposed-152.png">
     <link rel="shortcut icon" href="../gitbook/images/favicon.ico" type="image/x-icon">
 
-
+    
     <link rel="next" href="asciidoc.html" />
-
-
+    
+    
     <link rel="prev" href="../languages.html" />
-
+    
 
     </head>
     <body>
-
+        
 <div class="book honkit-cloak">
     <div class="book-summary">
-
-
+        
+            
 <div id="book-search-input" role="search">
     <input type="text" placeholder="Type to search" />
 </div>
 
-
+            
                 <nav role="navigation">
-
+                
 
 
 <ul class="summary">
+    
+    
 
+    
 
-
-
-
-
-
+    
+        
         <li class="header">Getting Started</li>
-
-
-
+        
+        
+    
         <li class="chapter " data-level="1.1" data-path="../">
-
+            
                 <a href="../">
-
-
+            
+                    
                     About this documentation
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="1.2" data-path="../setup.html">
-
+            
                 <a href="../setup.html">
-
-
+            
+                    
                     Installation and Setup
-
+            
                 </a>
+            
 
-
-
+            
         </li>
+    
 
-
-
-
+    
+        
         <li class="header">Your Content</li>
-
-
-
+        
+        
+    
         <li class="chapter " data-level="2.1" data-path="../structure.html">
-
+            
                 <a href="../structure.html">
-
-
+            
+                    
                     Directory structure
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.2" data-path="../pages.html">
-
+            
                 <a href="../pages.html">
-
-
+            
+                    
                     Pages and Summary
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.3" data-path="../config.html">
-
+            
                 <a href="../config.html">
-
-
+            
+                    
                     Configuration
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.4" data-path="../lexicon.html">
-
+            
                 <a href="../lexicon.html">
-
-
+            
+                    
                     Glossary
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.5" data-path="../languages.html">
-
+            
                 <a href="../languages.html">
-
-
+            
+                    
                     Multi-Lingual
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter active" data-level="2.6" data-path="markdown.html">
-
+            
                 <a href="markdown.html">
-
-
+            
+                    
                     Markdown
-
+            
                 </a>
+            
 
-
-
+            
             <ul class="articles">
-
-
+                
+    
         <li class="chapter " data-level="2.6.1" data-path="markdown.html">
-
+            
                 <a href="markdown.html#headings">
-
-
+            
+                    
                     Headings
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.6.2" data-path="markdown.html">
-
+            
                 <a href="markdown.html#paragraphs">
-
-
+            
+                    
                     Paragraphs
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.6.3" data-path="markdown.html">
-
+            
                 <a href="markdown.html#lists">
-
-
+            
+                    
                     Lists
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.6.4" data-path="markdown.html">
-
+            
                 <a href="markdown.html#links">
-
-
+            
+                    
                     Links
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.6.5" data-path="markdown.html">
-
+            
                 <a href="markdown.html#images">
-
-
+            
+                    
                     Images
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.6.6" data-path="markdown.html">
-
+            
                 <a href="markdown.html#blockquotes">
-
-
+            
+                    
                     Blockquotes
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.6.7" data-path="markdown.html">
-
+            
                 <a href="markdown.html#tables">
-
-
+            
+                    
                     Tables
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.6.8" data-path="markdown.html">
-
+            
                 <a href="markdown.html#code">
-
-
+            
+                    
                     Code
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.6.9" data-path="markdown.html">
-
+            
                 <a href="markdown.html#html">
-
-
+            
+                    
                     HTML
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.6.10" data-path="markdown.html">
-
+            
                 <a href="markdown.html#footnotes">
-
-
+            
+                    
                     Footnotes
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
 
             </ul>
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.7" data-path="asciidoc.html">
-
+            
                 <a href="asciidoc.html">
-
-
+            
+                    
                     AsciiDoc
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.8" data-path="../ebook.html">
-
+            
                 <a href="../ebook.html">
-
-
+            
+                    
                     eBook and PDF
-
+            
                 </a>
+            
 
-
-
+            
         </li>
+    
 
-
-
-
+    
+        
         <li class="header">Customization</li>
-
-
-
+        
+        
+    
         <li class="chapter " data-level="3.1" data-path="../templating/">
-
+            
                 <a href="../templating/">
-
-
+            
+                    
                     Templating
-
+            
                 </a>
+            
 
-
-
+            
             <ul class="articles">
-
-
+                
+    
         <li class="chapter " data-level="3.1.1" data-path="../templating/conrefs.html">
-
+            
                 <a href="../templating/conrefs.html">
-
-
+            
+                    
                     Content References
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="3.1.2" data-path="../templating/variables.html">
-
+            
                 <a href="../templating/variables.html">
-
-
+            
+                    
                     Variables
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="3.1.3" data-path="../templating/builtin.html">
-
+            
                 <a href="../templating/builtin.html">
-
-
+            
+                    
                     Builtin
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
 
             </ul>
-
+            
         </li>
-
+    
         <li class="chapter " data-level="3.2" data-path="../plugins/">
-
+            
                 <a href="../plugins/">
-
-
+            
+                    
                     Plugins
-
+            
                 </a>
+            
 
-
-
+            
             <ul class="articles">
-
-
+                
+    
         <li class="chapter " data-level="3.2.1" data-path="../plugins/create.html">
-
+            
                 <a href="../plugins/create.html">
-
-
+            
+                    
                     Create a plugin
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="3.2.2" data-path="../plugins/hooks.html">
-
+            
                 <a href="../plugins/hooks.html">
-
-
+            
+                    
                     Hooks
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="3.2.3" data-path="../plugins/blocks.html">
-
+            
                 <a href="../plugins/blocks.html">
-
-
+            
+                    
                     Blocks
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="3.2.4" data-path="../plugins/filters.html">
-
+            
                 <a href="../plugins/filters.html">
-
-
+            
+                    
                     Filters
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="3.2.5" data-path="../plugins/api.html">
-
+            
                 <a href="../plugins/api.html">
-
-
+            
+                    
                     API & Context
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="3.2.6" data-path="../plugins/testing.html">
-
+            
                 <a href="../plugins/testing.html">
-
-
+            
+                    
                     Test your plugin
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
 
             </ul>
-
+            
         </li>
-
+    
         <li class="chapter " data-level="3.3" data-path="../themes/">
-
+            
                 <a href="../themes/">
-
-
+            
+                    
                     Theming
-
+            
                 </a>
+            
 
-
-
+            
         </li>
+    
 
-
-
-
+    
+        
         <li class="divider"></li>
-
-
-
+        
+        
+    
         <li class="chapter " data-level="4.1" data-path="../faq.html">
-
+            
                 <a href="../faq.html">
-
-
+            
+                    
                     FAQ
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="4.2" data-path="../examples.md">
-
+            
                 <span>
-
-
+            
+                    
                     Examples
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="4.3" >
-
+            
                 <a target="_blank" href="https://github.com/honkit/honkit/blob/master/CHANGELOG.md">
-
-
+            
+                    
                     Release notes
-
+            
                 </a>
+            
 
-
-
+            
         </li>
+    
 
-
-
-
+    
+        
         <li class="divider"></li>
-
-
-
+        
+        
+    
         <li class="chapter " data-level="5.1" data-path="../encoding.html">
-
+            
                 <a href="../encoding.html">
-
-
+            
+                    
                     Encoding
-
+            
                 </a>
+            
 
-
-
+            
         </li>
+    
 
-
-
+    
 
     <li class="divider"></li>
 
@@ -16576,18 +16576,18 @@ exports[`HonKit snapshots: syntax/markdown.html 1`] = `
 
 
                 </nav>
-
-
+            
+        
     </div>
 
     <div class="book-body">
-
+        
             <div class="body-inner">
-
-
+                
+                    
 
 <div class="book-header" role="navigation">
-
+    
 
     <!-- Title -->
     <h1>
@@ -16601,12 +16601,12 @@ exports[`HonKit snapshots: syntax/markdown.html 1`] = `
 
                     <div class="page-wrapper" tabindex="-1" role="main">
                         <div class="page-inner">
-
+                            
 <div id="book-search-results">
     <div class="search-noresults">
-
+    
                                 <section class="normal markdown-section">
-
+                                
 
                                 <h1 id="markdown">Markdown</h1>
 <p>Most of the examples from this documentation are in Markdown. Markdown is default parser for <a href="../GLOSSARY.html#honkit" class="glossary-term" title="Honkit is a command line tool for building beautiful books using GitHub/Git and Markdown (or AsciiDoc).">HonKit</a>, but one can also opt for the <a href="asciidoc.html">AsciiDoc syntax</a>.</p>
@@ -16744,64 +16744,64 @@ Asterisks
 <p>You can tell <a href="../GLOSSARY.html#honkit" class="glossary-term" title="Honkit is a command line tool for building beautiful books using GitHub/Git and Markdown (or AsciiDoc).">HonKit</a> to ignore (or escape) Markdown formatting by using <code>\\</code> before the Markdown character.</p>
 <pre><code>Let&apos;s rename \\*our-new-project\\* to \\*our-old-project\\*.
 </code></pre>
-
+                                
 <hr>
 <div class="btn-group btn-group-justified">
-
+    
     <a class="btn" href="../languages.html"><b>Previous:</b> Multi-Lingual</a>
-
-
+    
+    
     <a class="btn" href="asciidoc.html"><b>Next:</b> AsciiDoc</a>
-
+    
 </div>
 
                                 </section>
-
+                            
     </div>
     <div class="search-results">
         <div class="has-results">
-
+            
             <h1 class="search-results-title"><span class='search-results-count'></span> results matching "<span class='search-query'></span>"</h1>
             <ul class="search-results-list"></ul>
-
+            
         </div>
         <div class="no-results">
-
+            
             <h1 class="search-results-title">No results matching "<span class='search-query'></span>"</h1>
-
+            
         </div>
     </div>
 </div>
 
                         </div>
                     </div>
-
+                
             </div>
 
-
-
+            
+                
                 <a href="../languages.html" class="navigation navigation-prev " aria-label="Previous page: Multi-Lingual">
                     <i class="fa fa-angle-left"></i>
                 </a>
-
-
+                
+                
                 <a href="asciidoc.html" class="navigation navigation-next " aria-label="Next page: AsciiDoc">
                     <i class="fa fa-angle-right"></i>
                 </a>
-
-
-
+                
+            
+        
     </div>
 
     <script>
         var gitbook = gitbook || [];
         gitbook.push(function() {
-
+            
         });
     </script>
 </div>
 
-
+        
     <noscript>
         <style>
             .honkit-cloak {
@@ -16848,27 +16848,27 @@ Asterisks
     </script>
     <script src="../gitbook/gitbook.js"></script>
     <script src="../gitbook/theme.js"></script>
-
-
+    
+        
         <script src="../gitbook/gitbook-plugin-search/search-engine.js"></script>
-
-
-
+        
+    
+        
         <script src="../gitbook/gitbook-plugin-search/search.js"></script>
-
-
-
+        
+    
+        
         <script src="../gitbook/gitbook-plugin-lunr/lunr.min.js"></script>
-
-
-
+        
+    
+        
         <script src="../gitbook/gitbook-plugin-lunr/search-lunr.js"></script>
-
-
-
+        
+    
+        
         <script src="../gitbook/gitbook-plugin-fontsettings/fontsettings.js"></script>
-
-
+        
+    
 
     </body>
 </html>
@@ -16894,50 +16894,50 @@ exports[`HonKit snapshots: templating/builtin.html 1`] = `
         <title>Builtin · HonKit Documentation</title>
         <meta http-equiv="X-UA-Compatible" content="IE=edge" />
         <meta name="description" content="">
-
-
-
-
-
+        
+        
+        
+        
+    
     <link rel="stylesheet" href="../gitbook/style.css">
 
-
-
-
+    
+            
+                
                 <link rel="stylesheet" href="../gitbook/@honkit/honkit-plugin-highlight/website.css">
-
-
-
+                
+            
+                
                 <link rel="stylesheet" href="../gitbook/gitbook-plugin-search/search.css">
-
-
-
+                
+            
+                
                 <link rel="stylesheet" href="../gitbook/gitbook-plugin-fontsettings/website.css">
+                
+            
+        
 
+    
 
-
-
-
-
-
-
+    
+        
         <link rel="stylesheet" href="../styles/website.css">
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
+        
+    
+    
     <meta name="HandheldFriendly" content="true"/>
     <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no">
     <meta name="apple-mobile-web-app-capable" content="yes">
@@ -16945,557 +16945,557 @@ exports[`HonKit snapshots: templating/builtin.html 1`] = `
     <link rel="apple-touch-icon-precomposed" sizes="152x152" href="../gitbook/images/apple-touch-icon-precomposed-152.png">
     <link rel="shortcut icon" href="../gitbook/images/favicon.ico" type="image/x-icon">
 
-
+    
     <link rel="next" href="../plugins/" />
-
-
+    
+    
     <link rel="prev" href="variables.html" />
-
+    
 
     </head>
     <body>
-
+        
 <div class="book honkit-cloak">
     <div class="book-summary">
-
-
+        
+            
 <div id="book-search-input" role="search">
     <input type="text" placeholder="Type to search" />
 </div>
 
-
+            
                 <nav role="navigation">
-
+                
 
 
 <ul class="summary">
+    
+    
 
+    
 
-
-
-
-
-
+    
+        
         <li class="header">Getting Started</li>
-
-
-
+        
+        
+    
         <li class="chapter " data-level="1.1" data-path="../">
-
+            
                 <a href="../">
-
-
+            
+                    
                     About this documentation
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="1.2" data-path="../setup.html">
-
+            
                 <a href="../setup.html">
-
-
+            
+                    
                     Installation and Setup
-
+            
                 </a>
+            
 
-
-
+            
         </li>
+    
 
-
-
-
+    
+        
         <li class="header">Your Content</li>
-
-
-
+        
+        
+    
         <li class="chapter " data-level="2.1" data-path="../structure.html">
-
+            
                 <a href="../structure.html">
-
-
+            
+                    
                     Directory structure
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.2" data-path="../pages.html">
-
+            
                 <a href="../pages.html">
-
-
+            
+                    
                     Pages and Summary
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.3" data-path="../config.html">
-
+            
                 <a href="../config.html">
-
-
+            
+                    
                     Configuration
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.4" data-path="../lexicon.html">
-
+            
                 <a href="../lexicon.html">
-
-
+            
+                    
                     Glossary
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.5" data-path="../languages.html">
-
+            
                 <a href="../languages.html">
-
-
+            
+                    
                     Multi-Lingual
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.6" data-path="../syntax/markdown.html">
-
+            
                 <a href="../syntax/markdown.html">
-
-
+            
+                    
                     Markdown
-
+            
                 </a>
+            
 
-
-
+            
             <ul class="articles">
-
-
+                
+    
         <li class="chapter " data-level="2.6.1" data-path="../syntax/markdown.html">
-
+            
                 <a href="../syntax/markdown.html#headings">
-
-
+            
+                    
                     Headings
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.6.2" data-path="../syntax/markdown.html">
-
+            
                 <a href="../syntax/markdown.html#paragraphs">
-
-
+            
+                    
                     Paragraphs
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.6.3" data-path="../syntax/markdown.html">
-
+            
                 <a href="../syntax/markdown.html#lists">
-
-
+            
+                    
                     Lists
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.6.4" data-path="../syntax/markdown.html">
-
+            
                 <a href="../syntax/markdown.html#links">
-
-
+            
+                    
                     Links
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.6.5" data-path="../syntax/markdown.html">
-
+            
                 <a href="../syntax/markdown.html#images">
-
-
+            
+                    
                     Images
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.6.6" data-path="../syntax/markdown.html">
-
+            
                 <a href="../syntax/markdown.html#blockquotes">
-
-
+            
+                    
                     Blockquotes
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.6.7" data-path="../syntax/markdown.html">
-
+            
                 <a href="../syntax/markdown.html#tables">
-
-
+            
+                    
                     Tables
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.6.8" data-path="../syntax/markdown.html">
-
+            
                 <a href="../syntax/markdown.html#code">
-
-
+            
+                    
                     Code
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.6.9" data-path="../syntax/markdown.html">
-
+            
                 <a href="../syntax/markdown.html#html">
-
-
+            
+                    
                     HTML
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.6.10" data-path="../syntax/markdown.html">
-
+            
                 <a href="../syntax/markdown.html#footnotes">
-
-
+            
+                    
                     Footnotes
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
 
             </ul>
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.7" data-path="../syntax/asciidoc.html">
-
+            
                 <a href="../syntax/asciidoc.html">
-
-
+            
+                    
                     AsciiDoc
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.8" data-path="../ebook.html">
-
+            
                 <a href="../ebook.html">
-
-
+            
+                    
                     eBook and PDF
-
+            
                 </a>
+            
 
-
-
+            
         </li>
+    
 
-
-
-
+    
+        
         <li class="header">Customization</li>
-
-
-
+        
+        
+    
         <li class="chapter " data-level="3.1" data-path="./">
-
+            
                 <a href="./">
-
-
+            
+                    
                     Templating
-
+            
                 </a>
+            
 
-
-
+            
             <ul class="articles">
-
-
+                
+    
         <li class="chapter " data-level="3.1.1" data-path="conrefs.html">
-
+            
                 <a href="conrefs.html">
-
-
+            
+                    
                     Content References
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="3.1.2" data-path="variables.html">
-
+            
                 <a href="variables.html">
-
-
+            
+                    
                     Variables
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter active" data-level="3.1.3" data-path="builtin.html">
-
+            
                 <a href="builtin.html">
-
-
+            
+                    
                     Builtin
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
 
             </ul>
-
+            
         </li>
-
+    
         <li class="chapter " data-level="3.2" data-path="../plugins/">
-
+            
                 <a href="../plugins/">
-
-
+            
+                    
                     Plugins
-
+            
                 </a>
+            
 
-
-
+            
             <ul class="articles">
-
-
+                
+    
         <li class="chapter " data-level="3.2.1" data-path="../plugins/create.html">
-
+            
                 <a href="../plugins/create.html">
-
-
+            
+                    
                     Create a plugin
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="3.2.2" data-path="../plugins/hooks.html">
-
+            
                 <a href="../plugins/hooks.html">
-
-
+            
+                    
                     Hooks
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="3.2.3" data-path="../plugins/blocks.html">
-
+            
                 <a href="../plugins/blocks.html">
-
-
+            
+                    
                     Blocks
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="3.2.4" data-path="../plugins/filters.html">
-
+            
                 <a href="../plugins/filters.html">
-
-
+            
+                    
                     Filters
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="3.2.5" data-path="../plugins/api.html">
-
+            
                 <a href="../plugins/api.html">
-
-
+            
+                    
                     API & Context
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="3.2.6" data-path="../plugins/testing.html">
-
+            
                 <a href="../plugins/testing.html">
-
-
+            
+                    
                     Test your plugin
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
 
             </ul>
-
+            
         </li>
-
+    
         <li class="chapter " data-level="3.3" data-path="../themes/">
-
+            
                 <a href="../themes/">
-
-
+            
+                    
                     Theming
-
+            
                 </a>
+            
 
-
-
+            
         </li>
+    
 
-
-
-
+    
+        
         <li class="divider"></li>
-
-
-
+        
+        
+    
         <li class="chapter " data-level="4.1" data-path="../faq.html">
-
+            
                 <a href="../faq.html">
-
-
+            
+                    
                     FAQ
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="4.2" data-path="../examples.md">
-
+            
                 <span>
-
-
+            
+                    
                     Examples
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="4.3" >
-
+            
                 <a target="_blank" href="https://github.com/honkit/honkit/blob/master/CHANGELOG.md">
-
-
+            
+                    
                     Release notes
-
+            
                 </a>
+            
 
-
-
+            
         </li>
+    
 
-
-
-
+    
+        
         <li class="divider"></li>
-
-
-
+        
+        
+    
         <li class="chapter " data-level="5.1" data-path="../encoding.html">
-
+            
                 <a href="../encoding.html">
-
-
+            
+                    
                     Encoding
-
+            
                 </a>
+            
 
-
-
+            
         </li>
+    
 
-
-
+    
 
     <li class="divider"></li>
 
@@ -17508,18 +17508,18 @@ exports[`HonKit snapshots: templating/builtin.html 1`] = `
 
 
                 </nav>
-
-
+            
+        
     </div>
 
     <div class="book-body">
-
+        
             <div class="body-inner">
-
-
+                
+                    
 
 <div class="book-header" role="navigation">
-
+    
 
     <!-- Title -->
     <h1>
@@ -17533,12 +17533,12 @@ exports[`HonKit snapshots: templating/builtin.html 1`] = `
 
                     <div class="page-wrapper" tabindex="-1" role="main">
                         <div class="page-inner">
-
+                            
 <div id="book-search-results">
     <div class="search-noresults">
-
+    
                                 <section class="normal markdown-section">
-
+                                
 
                                 <h1 id="builtin-templating-helpers">Builtin Templating Helpers</h1>
 <p><a href="../GLOSSARY.html#honkit" class="glossary-term" title="Honkit is a command line tool for building beautiful books using GitHub/Git and Markdown (or AsciiDoc).">HonKit</a> provides a serie of builtin filters and blocks to help you write templates.</p>
@@ -17552,64 +17552,64 @@ Render inline markdown</p>
 <p><code>{% asciidoc %}AsciiDoc string{% endasciidoc %}</code>
 Render inline asciidoc</p>
 
-
+                                
 <hr>
 <div class="btn-group btn-group-justified">
-
+    
     <a class="btn" href="variables.html"><b>Previous:</b> Variables</a>
-
-
+    
+    
     <a class="btn" href="../plugins/"><b>Next:</b> Plugins</a>
-
+    
 </div>
 
                                 </section>
-
+                            
     </div>
     <div class="search-results">
         <div class="has-results">
-
+            
             <h1 class="search-results-title"><span class='search-results-count'></span> results matching "<span class='search-query'></span>"</h1>
             <ul class="search-results-list"></ul>
-
+            
         </div>
         <div class="no-results">
-
+            
             <h1 class="search-results-title">No results matching "<span class='search-query'></span>"</h1>
-
+            
         </div>
     </div>
 </div>
 
                         </div>
                     </div>
-
+                
             </div>
 
-
-
+            
+                
                 <a href="variables.html" class="navigation navigation-prev " aria-label="Previous page: Variables">
                     <i class="fa fa-angle-left"></i>
                 </a>
-
-
+                
+                
                 <a href="../plugins/" class="navigation navigation-next " aria-label="Next page: Plugins">
                     <i class="fa fa-angle-right"></i>
                 </a>
-
-
-
+                
+            
+        
     </div>
 
     <script>
         var gitbook = gitbook || [];
         gitbook.push(function() {
-
+            
         });
     </script>
 </div>
 
-
+        
     <noscript>
         <style>
             .honkit-cloak {
@@ -17656,27 +17656,27 @@ Render inline asciidoc</p>
     </script>
     <script src="../gitbook/gitbook.js"></script>
     <script src="../gitbook/theme.js"></script>
-
-
+    
+        
         <script src="../gitbook/gitbook-plugin-search/search-engine.js"></script>
-
-
-
+        
+    
+        
         <script src="../gitbook/gitbook-plugin-search/search.js"></script>
-
-
-
+        
+    
+        
         <script src="../gitbook/gitbook-plugin-lunr/lunr.min.js"></script>
-
-
-
+        
+    
+        
         <script src="../gitbook/gitbook-plugin-lunr/search-lunr.js"></script>
-
-
-
+        
+    
+        
         <script src="../gitbook/gitbook-plugin-fontsettings/fontsettings.js"></script>
-
-
+        
+    
 
     </body>
 </html>
@@ -17702,50 +17702,50 @@ exports[`HonKit snapshots: templating/conrefs.html 1`] = `
         <title>Content References · HonKit Documentation</title>
         <meta http-equiv="X-UA-Compatible" content="IE=edge" />
         <meta name="description" content="">
-
-
-
-
-
+        
+        
+        
+        
+    
     <link rel="stylesheet" href="../gitbook/style.css">
 
-
-
-
+    
+            
+                
                 <link rel="stylesheet" href="../gitbook/@honkit/honkit-plugin-highlight/website.css">
-
-
-
+                
+            
+                
                 <link rel="stylesheet" href="../gitbook/gitbook-plugin-search/search.css">
-
-
-
+                
+            
+                
                 <link rel="stylesheet" href="../gitbook/gitbook-plugin-fontsettings/website.css">
+                
+            
+        
 
+    
 
-
-
-
-
-
-
+    
+        
         <link rel="stylesheet" href="../styles/website.css">
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
+        
+    
+    
     <meta name="HandheldFriendly" content="true"/>
     <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no">
     <meta name="apple-mobile-web-app-capable" content="yes">
@@ -17753,557 +17753,557 @@ exports[`HonKit snapshots: templating/conrefs.html 1`] = `
     <link rel="apple-touch-icon-precomposed" sizes="152x152" href="../gitbook/images/apple-touch-icon-precomposed-152.png">
     <link rel="shortcut icon" href="../gitbook/images/favicon.ico" type="image/x-icon">
 
-
+    
     <link rel="next" href="variables.html" />
-
-
+    
+    
     <link rel="prev" href="./" />
-
+    
 
     </head>
     <body>
-
+        
 <div class="book honkit-cloak">
     <div class="book-summary">
-
-
+        
+            
 <div id="book-search-input" role="search">
     <input type="text" placeholder="Type to search" />
 </div>
 
-
+            
                 <nav role="navigation">
-
+                
 
 
 <ul class="summary">
+    
+    
 
+    
 
-
-
-
-
-
+    
+        
         <li class="header">Getting Started</li>
-
-
-
+        
+        
+    
         <li class="chapter " data-level="1.1" data-path="../">
-
+            
                 <a href="../">
-
-
+            
+                    
                     About this documentation
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="1.2" data-path="../setup.html">
-
+            
                 <a href="../setup.html">
-
-
+            
+                    
                     Installation and Setup
-
+            
                 </a>
+            
 
-
-
+            
         </li>
+    
 
-
-
-
+    
+        
         <li class="header">Your Content</li>
-
-
-
+        
+        
+    
         <li class="chapter " data-level="2.1" data-path="../structure.html">
-
+            
                 <a href="../structure.html">
-
-
+            
+                    
                     Directory structure
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.2" data-path="../pages.html">
-
+            
                 <a href="../pages.html">
-
-
+            
+                    
                     Pages and Summary
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.3" data-path="../config.html">
-
+            
                 <a href="../config.html">
-
-
+            
+                    
                     Configuration
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.4" data-path="../lexicon.html">
-
+            
                 <a href="../lexicon.html">
-
-
+            
+                    
                     Glossary
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.5" data-path="../languages.html">
-
+            
                 <a href="../languages.html">
-
-
+            
+                    
                     Multi-Lingual
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.6" data-path="../syntax/markdown.html">
-
+            
                 <a href="../syntax/markdown.html">
-
-
+            
+                    
                     Markdown
-
+            
                 </a>
+            
 
-
-
+            
             <ul class="articles">
-
-
+                
+    
         <li class="chapter " data-level="2.6.1" data-path="../syntax/markdown.html">
-
+            
                 <a href="../syntax/markdown.html#headings">
-
-
+            
+                    
                     Headings
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.6.2" data-path="../syntax/markdown.html">
-
+            
                 <a href="../syntax/markdown.html#paragraphs">
-
-
+            
+                    
                     Paragraphs
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.6.3" data-path="../syntax/markdown.html">
-
+            
                 <a href="../syntax/markdown.html#lists">
-
-
+            
+                    
                     Lists
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.6.4" data-path="../syntax/markdown.html">
-
+            
                 <a href="../syntax/markdown.html#links">
-
-
+            
+                    
                     Links
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.6.5" data-path="../syntax/markdown.html">
-
+            
                 <a href="../syntax/markdown.html#images">
-
-
+            
+                    
                     Images
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.6.6" data-path="../syntax/markdown.html">
-
+            
                 <a href="../syntax/markdown.html#blockquotes">
-
-
+            
+                    
                     Blockquotes
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.6.7" data-path="../syntax/markdown.html">
-
+            
                 <a href="../syntax/markdown.html#tables">
-
-
+            
+                    
                     Tables
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.6.8" data-path="../syntax/markdown.html">
-
+            
                 <a href="../syntax/markdown.html#code">
-
-
+            
+                    
                     Code
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.6.9" data-path="../syntax/markdown.html">
-
+            
                 <a href="../syntax/markdown.html#html">
-
-
+            
+                    
                     HTML
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.6.10" data-path="../syntax/markdown.html">
-
+            
                 <a href="../syntax/markdown.html#footnotes">
-
-
+            
+                    
                     Footnotes
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
 
             </ul>
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.7" data-path="../syntax/asciidoc.html">
-
+            
                 <a href="../syntax/asciidoc.html">
-
-
+            
+                    
                     AsciiDoc
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.8" data-path="../ebook.html">
-
+            
                 <a href="../ebook.html">
-
-
+            
+                    
                     eBook and PDF
-
+            
                 </a>
+            
 
-
-
+            
         </li>
+    
 
-
-
-
+    
+        
         <li class="header">Customization</li>
-
-
-
+        
+        
+    
         <li class="chapter " data-level="3.1" data-path="./">
-
+            
                 <a href="./">
-
-
+            
+                    
                     Templating
-
+            
                 </a>
+            
 
-
-
+            
             <ul class="articles">
-
-
+                
+    
         <li class="chapter active" data-level="3.1.1" data-path="conrefs.html">
-
+            
                 <a href="conrefs.html">
-
-
+            
+                    
                     Content References
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="3.1.2" data-path="variables.html">
-
+            
                 <a href="variables.html">
-
-
+            
+                    
                     Variables
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="3.1.3" data-path="builtin.html">
-
+            
                 <a href="builtin.html">
-
-
+            
+                    
                     Builtin
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
 
             </ul>
-
+            
         </li>
-
+    
         <li class="chapter " data-level="3.2" data-path="../plugins/">
-
+            
                 <a href="../plugins/">
-
-
+            
+                    
                     Plugins
-
+            
                 </a>
+            
 
-
-
+            
             <ul class="articles">
-
-
+                
+    
         <li class="chapter " data-level="3.2.1" data-path="../plugins/create.html">
-
+            
                 <a href="../plugins/create.html">
-
-
+            
+                    
                     Create a plugin
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="3.2.2" data-path="../plugins/hooks.html">
-
+            
                 <a href="../plugins/hooks.html">
-
-
+            
+                    
                     Hooks
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="3.2.3" data-path="../plugins/blocks.html">
-
+            
                 <a href="../plugins/blocks.html">
-
-
+            
+                    
                     Blocks
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="3.2.4" data-path="../plugins/filters.html">
-
+            
                 <a href="../plugins/filters.html">
-
-
+            
+                    
                     Filters
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="3.2.5" data-path="../plugins/api.html">
-
+            
                 <a href="../plugins/api.html">
-
-
+            
+                    
                     API & Context
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="3.2.6" data-path="../plugins/testing.html">
-
+            
                 <a href="../plugins/testing.html">
-
-
+            
+                    
                     Test your plugin
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
 
             </ul>
-
+            
         </li>
-
+    
         <li class="chapter " data-level="3.3" data-path="../themes/">
-
+            
                 <a href="../themes/">
-
-
+            
+                    
                     Theming
-
+            
                 </a>
+            
 
-
-
+            
         </li>
+    
 
-
-
-
+    
+        
         <li class="divider"></li>
-
-
-
+        
+        
+    
         <li class="chapter " data-level="4.1" data-path="../faq.html">
-
+            
                 <a href="../faq.html">
-
-
+            
+                    
                     FAQ
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="4.2" data-path="../examples.md">
-
+            
                 <span>
-
-
+            
+                    
                     Examples
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="4.3" >
-
+            
                 <a target="_blank" href="https://github.com/honkit/honkit/blob/master/CHANGELOG.md">
-
-
+            
+                    
                     Release notes
-
+            
                 </a>
+            
 
-
-
+            
         </li>
+    
 
-
-
-
+    
+        
         <li class="divider"></li>
-
-
-
+        
+        
+    
         <li class="chapter " data-level="5.1" data-path="../encoding.html">
-
+            
                 <a href="../encoding.html">
-
-
+            
+                    
                     Encoding
-
+            
                 </a>
+            
 
-
-
+            
         </li>
+    
 
-
-
+    
 
     <li class="divider"></li>
 
@@ -18316,18 +18316,18 @@ exports[`HonKit snapshots: templating/conrefs.html 1`] = `
 
 
                 </nav>
-
-
+            
+        
     </div>
 
     <div class="book-body">
-
+        
             <div class="body-inner">
-
-
+                
+                    
 
 <div class="book-header" role="navigation">
-
+    
 
     <!-- Title -->
     <h1>
@@ -18341,12 +18341,12 @@ exports[`HonKit snapshots: templating/conrefs.html 1`] = `
 
                     <div class="page-wrapper" tabindex="-1" role="main">
                         <div class="page-inner">
-
+                            
 <div id="book-search-results">
     <div class="search-noresults">
-
+    
                                 <section class="normal markdown-section">
-
+                                
 
                                 <h1 id="content-references">Content References</h1>
 <p>Content referencing (conref) is a convenient mechanism to reuse content from other files or books.</p>
@@ -18377,64 +18377,64 @@ This is the default content
 
 {% include &quot;./LICENSE&quot; %}
 </code></pre>
-
+                                
 <hr>
 <div class="btn-group btn-group-justified">
-
+    
     <a class="btn" href="./"><b>Previous:</b> Templating</a>
-
-
+    
+    
     <a class="btn" href="variables.html"><b>Next:</b> Variables</a>
-
+    
 </div>
 
                                 </section>
-
+                            
     </div>
     <div class="search-results">
         <div class="has-results">
-
+            
             <h1 class="search-results-title"><span class='search-results-count'></span> results matching "<span class='search-query'></span>"</h1>
             <ul class="search-results-list"></ul>
-
+            
         </div>
         <div class="no-results">
-
+            
             <h1 class="search-results-title">No results matching "<span class='search-query'></span>"</h1>
-
+            
         </div>
     </div>
 </div>
 
                         </div>
                     </div>
-
+                
             </div>
 
-
-
+            
+                
                 <a href="./" class="navigation navigation-prev " aria-label="Previous page: Templating">
                     <i class="fa fa-angle-left"></i>
                 </a>
-
-
+                
+                
                 <a href="variables.html" class="navigation navigation-next " aria-label="Next page: Variables">
                     <i class="fa fa-angle-right"></i>
                 </a>
-
-
-
+                
+            
+        
     </div>
 
     <script>
         var gitbook = gitbook || [];
         gitbook.push(function() {
-
+            
         });
     </script>
 </div>
 
-
+        
     <noscript>
         <style>
             .honkit-cloak {
@@ -18481,27 +18481,27 @@ This is the default content
     </script>
     <script src="../gitbook/gitbook.js"></script>
     <script src="../gitbook/theme.js"></script>
-
-
+    
+        
         <script src="../gitbook/gitbook-plugin-search/search-engine.js"></script>
-
-
-
+        
+    
+        
         <script src="../gitbook/gitbook-plugin-search/search.js"></script>
-
-
-
+        
+    
+        
         <script src="../gitbook/gitbook-plugin-lunr/lunr.min.js"></script>
-
-
-
+        
+    
+        
         <script src="../gitbook/gitbook-plugin-lunr/search-lunr.js"></script>
-
-
-
+        
+    
+        
         <script src="../gitbook/gitbook-plugin-fontsettings/fontsettings.js"></script>
-
-
+        
+    
 
     </body>
 </html>
@@ -18527,50 +18527,50 @@ exports[`HonKit snapshots: templating/index.html 1`] = `
         <title>Templating · HonKit Documentation</title>
         <meta http-equiv="X-UA-Compatible" content="IE=edge" />
         <meta name="description" content="">
-
-
-
-
-
+        
+        
+        
+        
+    
     <link rel="stylesheet" href="../gitbook/style.css">
 
-
-
-
+    
+            
+                
                 <link rel="stylesheet" href="../gitbook/@honkit/honkit-plugin-highlight/website.css">
-
-
-
+                
+            
+                
                 <link rel="stylesheet" href="../gitbook/gitbook-plugin-search/search.css">
-
-
-
+                
+            
+                
                 <link rel="stylesheet" href="../gitbook/gitbook-plugin-fontsettings/website.css">
+                
+            
+        
 
+    
 
-
-
-
-
-
-
+    
+        
         <link rel="stylesheet" href="../styles/website.css">
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
+        
+    
+    
     <meta name="HandheldFriendly" content="true"/>
     <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no">
     <meta name="apple-mobile-web-app-capable" content="yes">
@@ -18578,557 +18578,557 @@ exports[`HonKit snapshots: templating/index.html 1`] = `
     <link rel="apple-touch-icon-precomposed" sizes="152x152" href="../gitbook/images/apple-touch-icon-precomposed-152.png">
     <link rel="shortcut icon" href="../gitbook/images/favicon.ico" type="image/x-icon">
 
-
+    
     <link rel="next" href="conrefs.html" />
-
-
+    
+    
     <link rel="prev" href="../ebook.html" />
-
+    
 
     </head>
     <body>
-
+        
 <div class="book honkit-cloak">
     <div class="book-summary">
-
-
+        
+            
 <div id="book-search-input" role="search">
     <input type="text" placeholder="Type to search" />
 </div>
 
-
+            
                 <nav role="navigation">
-
+                
 
 
 <ul class="summary">
+    
+    
 
+    
 
-
-
-
-
-
+    
+        
         <li class="header">Getting Started</li>
-
-
-
+        
+        
+    
         <li class="chapter " data-level="1.1" data-path="../">
-
+            
                 <a href="../">
-
-
+            
+                    
                     About this documentation
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="1.2" data-path="../setup.html">
-
+            
                 <a href="../setup.html">
-
-
+            
+                    
                     Installation and Setup
-
+            
                 </a>
+            
 
-
-
+            
         </li>
+    
 
-
-
-
+    
+        
         <li class="header">Your Content</li>
-
-
-
+        
+        
+    
         <li class="chapter " data-level="2.1" data-path="../structure.html">
-
+            
                 <a href="../structure.html">
-
-
+            
+                    
                     Directory structure
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.2" data-path="../pages.html">
-
+            
                 <a href="../pages.html">
-
-
+            
+                    
                     Pages and Summary
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.3" data-path="../config.html">
-
+            
                 <a href="../config.html">
-
-
+            
+                    
                     Configuration
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.4" data-path="../lexicon.html">
-
+            
                 <a href="../lexicon.html">
-
-
+            
+                    
                     Glossary
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.5" data-path="../languages.html">
-
+            
                 <a href="../languages.html">
-
-
+            
+                    
                     Multi-Lingual
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.6" data-path="../syntax/markdown.html">
-
+            
                 <a href="../syntax/markdown.html">
-
-
+            
+                    
                     Markdown
-
+            
                 </a>
+            
 
-
-
+            
             <ul class="articles">
-
-
+                
+    
         <li class="chapter " data-level="2.6.1" data-path="../syntax/markdown.html">
-
+            
                 <a href="../syntax/markdown.html#headings">
-
-
+            
+                    
                     Headings
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.6.2" data-path="../syntax/markdown.html">
-
+            
                 <a href="../syntax/markdown.html#paragraphs">
-
-
+            
+                    
                     Paragraphs
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.6.3" data-path="../syntax/markdown.html">
-
+            
                 <a href="../syntax/markdown.html#lists">
-
-
+            
+                    
                     Lists
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.6.4" data-path="../syntax/markdown.html">
-
+            
                 <a href="../syntax/markdown.html#links">
-
-
+            
+                    
                     Links
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.6.5" data-path="../syntax/markdown.html">
-
+            
                 <a href="../syntax/markdown.html#images">
-
-
+            
+                    
                     Images
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.6.6" data-path="../syntax/markdown.html">
-
+            
                 <a href="../syntax/markdown.html#blockquotes">
-
-
+            
+                    
                     Blockquotes
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.6.7" data-path="../syntax/markdown.html">
-
+            
                 <a href="../syntax/markdown.html#tables">
-
-
+            
+                    
                     Tables
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.6.8" data-path="../syntax/markdown.html">
-
+            
                 <a href="../syntax/markdown.html#code">
-
-
+            
+                    
                     Code
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.6.9" data-path="../syntax/markdown.html">
-
+            
                 <a href="../syntax/markdown.html#html">
-
-
+            
+                    
                     HTML
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.6.10" data-path="../syntax/markdown.html">
-
+            
                 <a href="../syntax/markdown.html#footnotes">
-
-
+            
+                    
                     Footnotes
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
 
             </ul>
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.7" data-path="../syntax/asciidoc.html">
-
+            
                 <a href="../syntax/asciidoc.html">
-
-
+            
+                    
                     AsciiDoc
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.8" data-path="../ebook.html">
-
+            
                 <a href="../ebook.html">
-
-
+            
+                    
                     eBook and PDF
-
+            
                 </a>
+            
 
-
-
+            
         </li>
+    
 
-
-
-
+    
+        
         <li class="header">Customization</li>
-
-
-
+        
+        
+    
         <li class="chapter active" data-level="3.1" data-path="./">
-
+            
                 <a href="./">
-
-
+            
+                    
                     Templating
-
+            
                 </a>
+            
 
-
-
+            
             <ul class="articles">
-
-
+                
+    
         <li class="chapter " data-level="3.1.1" data-path="conrefs.html">
-
+            
                 <a href="conrefs.html">
-
-
+            
+                    
                     Content References
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="3.1.2" data-path="variables.html">
-
+            
                 <a href="variables.html">
-
-
+            
+                    
                     Variables
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="3.1.3" data-path="builtin.html">
-
+            
                 <a href="builtin.html">
-
-
+            
+                    
                     Builtin
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
 
             </ul>
-
+            
         </li>
-
+    
         <li class="chapter " data-level="3.2" data-path="../plugins/">
-
+            
                 <a href="../plugins/">
-
-
+            
+                    
                     Plugins
-
+            
                 </a>
+            
 
-
-
+            
             <ul class="articles">
-
-
+                
+    
         <li class="chapter " data-level="3.2.1" data-path="../plugins/create.html">
-
+            
                 <a href="../plugins/create.html">
-
-
+            
+                    
                     Create a plugin
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="3.2.2" data-path="../plugins/hooks.html">
-
+            
                 <a href="../plugins/hooks.html">
-
-
+            
+                    
                     Hooks
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="3.2.3" data-path="../plugins/blocks.html">
-
+            
                 <a href="../plugins/blocks.html">
-
-
+            
+                    
                     Blocks
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="3.2.4" data-path="../plugins/filters.html">
-
+            
                 <a href="../plugins/filters.html">
-
-
+            
+                    
                     Filters
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="3.2.5" data-path="../plugins/api.html">
-
+            
                 <a href="../plugins/api.html">
-
-
+            
+                    
                     API & Context
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="3.2.6" data-path="../plugins/testing.html">
-
+            
                 <a href="../plugins/testing.html">
-
-
+            
+                    
                     Test your plugin
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
 
             </ul>
-
+            
         </li>
-
+    
         <li class="chapter " data-level="3.3" data-path="../themes/">
-
+            
                 <a href="../themes/">
-
-
+            
+                    
                     Theming
-
+            
                 </a>
+            
 
-
-
+            
         </li>
+    
 
-
-
-
+    
+        
         <li class="divider"></li>
-
-
-
+        
+        
+    
         <li class="chapter " data-level="4.1" data-path="../faq.html">
-
+            
                 <a href="../faq.html">
-
-
+            
+                    
                     FAQ
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="4.2" data-path="../examples.md">
-
+            
                 <span>
-
-
+            
+                    
                     Examples
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="4.3" >
-
+            
                 <a target="_blank" href="https://github.com/honkit/honkit/blob/master/CHANGELOG.md">
-
-
+            
+                    
                     Release notes
-
+            
                 </a>
+            
 
-
-
+            
         </li>
+    
 
-
-
-
+    
+        
         <li class="divider"></li>
-
-
-
+        
+        
+    
         <li class="chapter " data-level="5.1" data-path="../encoding.html">
-
+            
                 <a href="../encoding.html">
-
-
+            
+                    
                     Encoding
-
+            
                 </a>
+            
 
-
-
+            
         </li>
+    
 
-
-
+    
 
     <li class="divider"></li>
 
@@ -19141,18 +19141,18 @@ exports[`HonKit snapshots: templating/index.html 1`] = `
 
 
                 </nav>
-
-
+            
+        
     </div>
 
     <div class="book-body">
-
+        
             <div class="body-inner">
-
-
+                
+                    
 
 <div class="book-header" role="navigation">
-
+    
 
     <!-- Title -->
     <h1>
@@ -19166,12 +19166,12 @@ exports[`HonKit snapshots: templating/index.html 1`] = `
 
                     <div class="page-wrapper" tabindex="-1" role="main">
                         <div class="page-inner">
-
+                            
 <div id="book-search-results">
     <div class="search-noresults">
-
+    
                                 <section class="normal markdown-section">
-
+                                
 
                                 <h1 id="templating">Templating</h1>
 <p><a href="../GLOSSARY.html#honkit" class="glossary-term" title="Honkit is a command line tool for building beautiful books using GitHub/Git and Markdown (or AsciiDoc).">HonKit</a> uses the <a href="https://mozilla.github.io/nunjucks/" target="_blank">Nunjucks templating language</a> to process pages and theme&apos;s templates.</p>
@@ -19234,64 +19234,64 @@ Current version is </span><span class="hljs-template-variable">{{ softwareVersio
 </span><span class="hljs-template-tag">{% <span class="hljs-name">endraw</span> %}</span><span class="xml">
 </span></code></pre>
 
-
+                                
 <hr>
 <div class="btn-group btn-group-justified">
-
+    
     <a class="btn" href="../ebook.html"><b>Previous:</b> eBook and PDF</a>
-
-
+    
+    
     <a class="btn" href="conrefs.html"><b>Next:</b> Content References</a>
-
+    
 </div>
 
                                 </section>
-
+                            
     </div>
     <div class="search-results">
         <div class="has-results">
-
+            
             <h1 class="search-results-title"><span class='search-results-count'></span> results matching "<span class='search-query'></span>"</h1>
             <ul class="search-results-list"></ul>
-
+            
         </div>
         <div class="no-results">
-
+            
             <h1 class="search-results-title">No results matching "<span class='search-query'></span>"</h1>
-
+            
         </div>
     </div>
 </div>
 
                         </div>
                     </div>
-
+                
             </div>
 
-
-
+            
+                
                 <a href="../ebook.html" class="navigation navigation-prev " aria-label="Previous page: eBook and PDF">
                     <i class="fa fa-angle-left"></i>
                 </a>
-
-
+                
+                
                 <a href="conrefs.html" class="navigation navigation-next " aria-label="Next page: Content References">
                     <i class="fa fa-angle-right"></i>
                 </a>
-
-
-
+                
+            
+        
     </div>
 
     <script>
         var gitbook = gitbook || [];
         gitbook.push(function() {
-
+            
         });
     </script>
 </div>
 
-
+        
     <noscript>
         <style>
             .honkit-cloak {
@@ -19338,27 +19338,27 @@ Current version is </span><span class="hljs-template-variable">{{ softwareVersio
     </script>
     <script src="../gitbook/gitbook.js"></script>
     <script src="../gitbook/theme.js"></script>
-
-
+    
+        
         <script src="../gitbook/gitbook-plugin-search/search-engine.js"></script>
-
-
-
+        
+    
+        
         <script src="../gitbook/gitbook-plugin-search/search.js"></script>
-
-
-
+        
+    
+        
         <script src="../gitbook/gitbook-plugin-lunr/lunr.min.js"></script>
-
-
-
+        
+    
+        
         <script src="../gitbook/gitbook-plugin-lunr/search-lunr.js"></script>
-
-
-
+        
+    
+        
         <script src="../gitbook/gitbook-plugin-fontsettings/fontsettings.js"></script>
-
-
+        
+    
 
     </body>
 </html>
@@ -19384,50 +19384,50 @@ exports[`HonKit snapshots: templating/variables.html 1`] = `
         <title>Variables · HonKit Documentation</title>
         <meta http-equiv="X-UA-Compatible" content="IE=edge" />
         <meta name="description" content="">
-
-
-
-
-
+        
+        
+        
+        
+    
     <link rel="stylesheet" href="../gitbook/style.css">
 
-
-
-
+    
+            
+                
                 <link rel="stylesheet" href="../gitbook/@honkit/honkit-plugin-highlight/website.css">
-
-
-
+                
+            
+                
                 <link rel="stylesheet" href="../gitbook/gitbook-plugin-search/search.css">
-
-
-
+                
+            
+                
                 <link rel="stylesheet" href="../gitbook/gitbook-plugin-fontsettings/website.css">
+                
+            
+        
 
+    
 
-
-
-
-
-
-
+    
+        
         <link rel="stylesheet" href="../styles/website.css">
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
+        
+    
+    
     <meta name="HandheldFriendly" content="true"/>
     <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no">
     <meta name="apple-mobile-web-app-capable" content="yes">
@@ -19435,557 +19435,557 @@ exports[`HonKit snapshots: templating/variables.html 1`] = `
     <link rel="apple-touch-icon-precomposed" sizes="152x152" href="../gitbook/images/apple-touch-icon-precomposed-152.png">
     <link rel="shortcut icon" href="../gitbook/images/favicon.ico" type="image/x-icon">
 
-
+    
     <link rel="next" href="builtin.html" />
-
-
+    
+    
     <link rel="prev" href="conrefs.html" />
-
+    
 
     </head>
     <body>
-
+        
 <div class="book honkit-cloak">
     <div class="book-summary">
-
-
+        
+            
 <div id="book-search-input" role="search">
     <input type="text" placeholder="Type to search" />
 </div>
 
-
+            
                 <nav role="navigation">
-
+                
 
 
 <ul class="summary">
+    
+    
 
+    
 
-
-
-
-
-
+    
+        
         <li class="header">Getting Started</li>
-
-
-
+        
+        
+    
         <li class="chapter " data-level="1.1" data-path="../">
-
+            
                 <a href="../">
-
-
+            
+                    
                     About this documentation
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="1.2" data-path="../setup.html">
-
+            
                 <a href="../setup.html">
-
-
+            
+                    
                     Installation and Setup
-
+            
                 </a>
+            
 
-
-
+            
         </li>
+    
 
-
-
-
+    
+        
         <li class="header">Your Content</li>
-
-
-
+        
+        
+    
         <li class="chapter " data-level="2.1" data-path="../structure.html">
-
+            
                 <a href="../structure.html">
-
-
+            
+                    
                     Directory structure
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.2" data-path="../pages.html">
-
+            
                 <a href="../pages.html">
-
-
+            
+                    
                     Pages and Summary
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.3" data-path="../config.html">
-
+            
                 <a href="../config.html">
-
-
+            
+                    
                     Configuration
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.4" data-path="../lexicon.html">
-
+            
                 <a href="../lexicon.html">
-
-
+            
+                    
                     Glossary
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.5" data-path="../languages.html">
-
+            
                 <a href="../languages.html">
-
-
+            
+                    
                     Multi-Lingual
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.6" data-path="../syntax/markdown.html">
-
+            
                 <a href="../syntax/markdown.html">
-
-
+            
+                    
                     Markdown
-
+            
                 </a>
+            
 
-
-
+            
             <ul class="articles">
-
-
+                
+    
         <li class="chapter " data-level="2.6.1" data-path="../syntax/markdown.html">
-
+            
                 <a href="../syntax/markdown.html#headings">
-
-
+            
+                    
                     Headings
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.6.2" data-path="../syntax/markdown.html">
-
+            
                 <a href="../syntax/markdown.html#paragraphs">
-
-
+            
+                    
                     Paragraphs
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.6.3" data-path="../syntax/markdown.html">
-
+            
                 <a href="../syntax/markdown.html#lists">
-
-
+            
+                    
                     Lists
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.6.4" data-path="../syntax/markdown.html">
-
+            
                 <a href="../syntax/markdown.html#links">
-
-
+            
+                    
                     Links
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.6.5" data-path="../syntax/markdown.html">
-
+            
                 <a href="../syntax/markdown.html#images">
-
-
+            
+                    
                     Images
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.6.6" data-path="../syntax/markdown.html">
-
+            
                 <a href="../syntax/markdown.html#blockquotes">
-
-
+            
+                    
                     Blockquotes
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.6.7" data-path="../syntax/markdown.html">
-
+            
                 <a href="../syntax/markdown.html#tables">
-
-
+            
+                    
                     Tables
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.6.8" data-path="../syntax/markdown.html">
-
+            
                 <a href="../syntax/markdown.html#code">
-
-
+            
+                    
                     Code
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.6.9" data-path="../syntax/markdown.html">
-
+            
                 <a href="../syntax/markdown.html#html">
-
-
+            
+                    
                     HTML
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.6.10" data-path="../syntax/markdown.html">
-
+            
                 <a href="../syntax/markdown.html#footnotes">
-
-
+            
+                    
                     Footnotes
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
 
             </ul>
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.7" data-path="../syntax/asciidoc.html">
-
+            
                 <a href="../syntax/asciidoc.html">
-
-
+            
+                    
                     AsciiDoc
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.8" data-path="../ebook.html">
-
+            
                 <a href="../ebook.html">
-
-
+            
+                    
                     eBook and PDF
-
+            
                 </a>
+            
 
-
-
+            
         </li>
+    
 
-
-
-
+    
+        
         <li class="header">Customization</li>
-
-
-
+        
+        
+    
         <li class="chapter " data-level="3.1" data-path="./">
-
+            
                 <a href="./">
-
-
+            
+                    
                     Templating
-
+            
                 </a>
+            
 
-
-
+            
             <ul class="articles">
-
-
+                
+    
         <li class="chapter " data-level="3.1.1" data-path="conrefs.html">
-
+            
                 <a href="conrefs.html">
-
-
+            
+                    
                     Content References
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter active" data-level="3.1.2" data-path="variables.html">
-
+            
                 <a href="variables.html">
-
-
+            
+                    
                     Variables
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="3.1.3" data-path="builtin.html">
-
+            
                 <a href="builtin.html">
-
-
+            
+                    
                     Builtin
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
 
             </ul>
-
+            
         </li>
-
+    
         <li class="chapter " data-level="3.2" data-path="../plugins/">
-
+            
                 <a href="../plugins/">
-
-
+            
+                    
                     Plugins
-
+            
                 </a>
+            
 
-
-
+            
             <ul class="articles">
-
-
+                
+    
         <li class="chapter " data-level="3.2.1" data-path="../plugins/create.html">
-
+            
                 <a href="../plugins/create.html">
-
-
+            
+                    
                     Create a plugin
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="3.2.2" data-path="../plugins/hooks.html">
-
+            
                 <a href="../plugins/hooks.html">
-
-
+            
+                    
                     Hooks
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="3.2.3" data-path="../plugins/blocks.html">
-
+            
                 <a href="../plugins/blocks.html">
-
-
+            
+                    
                     Blocks
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="3.2.4" data-path="../plugins/filters.html">
-
+            
                 <a href="../plugins/filters.html">
-
-
+            
+                    
                     Filters
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="3.2.5" data-path="../plugins/api.html">
-
+            
                 <a href="../plugins/api.html">
-
-
+            
+                    
                     API & Context
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="3.2.6" data-path="../plugins/testing.html">
-
+            
                 <a href="../plugins/testing.html">
-
-
+            
+                    
                     Test your plugin
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
 
             </ul>
-
+            
         </li>
-
+    
         <li class="chapter " data-level="3.3" data-path="../themes/">
-
+            
                 <a href="../themes/">
-
-
+            
+                    
                     Theming
-
+            
                 </a>
+            
 
-
-
+            
         </li>
+    
 
-
-
-
+    
+        
         <li class="divider"></li>
-
-
-
+        
+        
+    
         <li class="chapter " data-level="4.1" data-path="../faq.html">
-
+            
                 <a href="../faq.html">
-
-
+            
+                    
                     FAQ
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="4.2" data-path="../examples.md">
-
+            
                 <span>
-
-
+            
+                    
                     Examples
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="4.3" >
-
+            
                 <a target="_blank" href="https://github.com/honkit/honkit/blob/master/CHANGELOG.md">
-
-
+            
+                    
                     Release notes
-
+            
                 </a>
+            
 
-
-
+            
         </li>
+    
 
-
-
-
+    
+        
         <li class="divider"></li>
-
-
-
+        
+        
+    
         <li class="chapter " data-level="5.1" data-path="../encoding.html">
-
+            
                 <a href="../encoding.html">
-
-
+            
+                    
                     Encoding
-
+            
                 </a>
+            
 
-
-
+            
         </li>
+    
 
-
-
+    
 
     <li class="divider"></li>
 
@@ -19998,18 +19998,18 @@ exports[`HonKit snapshots: templating/variables.html 1`] = `
 
 
                 </nav>
-
-
+            
+        
     </div>
 
     <div class="book-body">
-
+        
             <div class="body-inner">
-
-
+                
+                    
 
 <div class="book-header" role="navigation">
-
+    
 
     <!-- Title -->
     <h1>
@@ -20023,12 +20023,12 @@ exports[`HonKit snapshots: templating/variables.html 1`] = `
 
                     <div class="page-wrapper" tabindex="-1" role="main">
                         <div class="page-inner">
-
+                            
 <div id="book-search-results">
     <div class="search-noresults">
-
+    
                                 <section class="normal markdown-section">
-
+                                
 
                                 <h1 id="variables">Variables</h1>
 <p>The following is a reference of the available data during book&apos;s parsing and theme generation.</p>
@@ -20255,64 +20255,64 @@ exports[`HonKit snapshots: templating/variables.html 1`] = `
 </tbody>
 </table>
 
-
+                                
 <hr>
 <div class="btn-group btn-group-justified">
-
+    
     <a class="btn" href="conrefs.html"><b>Previous:</b> Content References</a>
-
-
+    
+    
     <a class="btn" href="builtin.html"><b>Next:</b> Builtin</a>
-
+    
 </div>
 
                                 </section>
-
+                            
     </div>
     <div class="search-results">
         <div class="has-results">
-
+            
             <h1 class="search-results-title"><span class='search-results-count'></span> results matching "<span class='search-query'></span>"</h1>
             <ul class="search-results-list"></ul>
-
+            
         </div>
         <div class="no-results">
-
+            
             <h1 class="search-results-title">No results matching "<span class='search-query'></span>"</h1>
-
+            
         </div>
     </div>
 </div>
 
                         </div>
                     </div>
-
+                
             </div>
 
-
-
+            
+                
                 <a href="conrefs.html" class="navigation navigation-prev " aria-label="Previous page: Content References">
                     <i class="fa fa-angle-left"></i>
                 </a>
-
-
+                
+                
                 <a href="builtin.html" class="navigation navigation-next " aria-label="Next page: Builtin">
                     <i class="fa fa-angle-right"></i>
                 </a>
-
-
-
+                
+            
+        
     </div>
 
     <script>
         var gitbook = gitbook || [];
         gitbook.push(function() {
-
+            
         });
     </script>
 </div>
 
-
+        
     <noscript>
         <style>
             .honkit-cloak {
@@ -20359,27 +20359,27 @@ exports[`HonKit snapshots: templating/variables.html 1`] = `
     </script>
     <script src="../gitbook/gitbook.js"></script>
     <script src="../gitbook/theme.js"></script>
-
-
+    
+        
         <script src="../gitbook/gitbook-plugin-search/search-engine.js"></script>
-
-
-
+        
+    
+        
         <script src="../gitbook/gitbook-plugin-search/search.js"></script>
-
-
-
+        
+    
+        
         <script src="../gitbook/gitbook-plugin-lunr/lunr.min.js"></script>
-
-
-
+        
+    
+        
         <script src="../gitbook/gitbook-plugin-lunr/search-lunr.js"></script>
-
-
-
+        
+    
+        
         <script src="../gitbook/gitbook-plugin-fontsettings/fontsettings.js"></script>
-
-
+        
+    
 
     </body>
 </html>
@@ -20405,50 +20405,50 @@ exports[`HonKit snapshots: themes/index.html 1`] = `
         <title>Theming · HonKit Documentation</title>
         <meta http-equiv="X-UA-Compatible" content="IE=edge" />
         <meta name="description" content="">
-
-
-
-
-
+        
+        
+        
+        
+    
     <link rel="stylesheet" href="../gitbook/style.css">
 
-
-
-
+    
+            
+                
                 <link rel="stylesheet" href="../gitbook/@honkit/honkit-plugin-highlight/website.css">
-
-
-
+                
+            
+                
                 <link rel="stylesheet" href="../gitbook/gitbook-plugin-search/search.css">
-
-
-
+                
+            
+                
                 <link rel="stylesheet" href="../gitbook/gitbook-plugin-fontsettings/website.css">
+                
+            
+        
 
+    
 
-
-
-
-
-
-
+    
+        
         <link rel="stylesheet" href="../styles/website.css">
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
+        
+    
+    
     <meta name="HandheldFriendly" content="true"/>
     <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no">
     <meta name="apple-mobile-web-app-capable" content="yes">
@@ -20456,557 +20456,557 @@ exports[`HonKit snapshots: themes/index.html 1`] = `
     <link rel="apple-touch-icon-precomposed" sizes="152x152" href="../gitbook/images/apple-touch-icon-precomposed-152.png">
     <link rel="shortcut icon" href="../gitbook/images/favicon.ico" type="image/x-icon">
 
-
+    
     <link rel="next" href="../faq.html" />
-
-
+    
+    
     <link rel="prev" href="../plugins/testing.html" />
-
+    
 
     </head>
     <body>
-
+        
 <div class="book honkit-cloak">
     <div class="book-summary">
-
-
+        
+            
 <div id="book-search-input" role="search">
     <input type="text" placeholder="Type to search" />
 </div>
 
-
+            
                 <nav role="navigation">
-
+                
 
 
 <ul class="summary">
+    
+    
 
+    
 
-
-
-
-
-
+    
+        
         <li class="header">Getting Started</li>
-
-
-
+        
+        
+    
         <li class="chapter " data-level="1.1" data-path="../">
-
+            
                 <a href="../">
-
-
+            
+                    
                     About this documentation
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="1.2" data-path="../setup.html">
-
+            
                 <a href="../setup.html">
-
-
+            
+                    
                     Installation and Setup
-
+            
                 </a>
+            
 
-
-
+            
         </li>
+    
 
-
-
-
+    
+        
         <li class="header">Your Content</li>
-
-
-
+        
+        
+    
         <li class="chapter " data-level="2.1" data-path="../structure.html">
-
+            
                 <a href="../structure.html">
-
-
+            
+                    
                     Directory structure
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.2" data-path="../pages.html">
-
+            
                 <a href="../pages.html">
-
-
+            
+                    
                     Pages and Summary
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.3" data-path="../config.html">
-
+            
                 <a href="../config.html">
-
-
+            
+                    
                     Configuration
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.4" data-path="../lexicon.html">
-
+            
                 <a href="../lexicon.html">
-
-
+            
+                    
                     Glossary
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.5" data-path="../languages.html">
-
+            
                 <a href="../languages.html">
-
-
+            
+                    
                     Multi-Lingual
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.6" data-path="../syntax/markdown.html">
-
+            
                 <a href="../syntax/markdown.html">
-
-
+            
+                    
                     Markdown
-
+            
                 </a>
+            
 
-
-
+            
             <ul class="articles">
-
-
+                
+    
         <li class="chapter " data-level="2.6.1" data-path="../syntax/markdown.html">
-
+            
                 <a href="../syntax/markdown.html#headings">
-
-
+            
+                    
                     Headings
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.6.2" data-path="../syntax/markdown.html">
-
+            
                 <a href="../syntax/markdown.html#paragraphs">
-
-
+            
+                    
                     Paragraphs
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.6.3" data-path="../syntax/markdown.html">
-
+            
                 <a href="../syntax/markdown.html#lists">
-
-
+            
+                    
                     Lists
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.6.4" data-path="../syntax/markdown.html">
-
+            
                 <a href="../syntax/markdown.html#links">
-
-
+            
+                    
                     Links
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.6.5" data-path="../syntax/markdown.html">
-
+            
                 <a href="../syntax/markdown.html#images">
-
-
+            
+                    
                     Images
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.6.6" data-path="../syntax/markdown.html">
-
+            
                 <a href="../syntax/markdown.html#blockquotes">
-
-
+            
+                    
                     Blockquotes
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.6.7" data-path="../syntax/markdown.html">
-
+            
                 <a href="../syntax/markdown.html#tables">
-
-
+            
+                    
                     Tables
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.6.8" data-path="../syntax/markdown.html">
-
+            
                 <a href="../syntax/markdown.html#code">
-
-
+            
+                    
                     Code
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.6.9" data-path="../syntax/markdown.html">
-
+            
                 <a href="../syntax/markdown.html#html">
-
-
+            
+                    
                     HTML
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.6.10" data-path="../syntax/markdown.html">
-
+            
                 <a href="../syntax/markdown.html#footnotes">
-
-
+            
+                    
                     Footnotes
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
 
             </ul>
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.7" data-path="../syntax/asciidoc.html">
-
+            
                 <a href="../syntax/asciidoc.html">
-
-
+            
+                    
                     AsciiDoc
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="2.8" data-path="../ebook.html">
-
+            
                 <a href="../ebook.html">
-
-
+            
+                    
                     eBook and PDF
-
+            
                 </a>
+            
 
-
-
+            
         </li>
+    
 
-
-
-
+    
+        
         <li class="header">Customization</li>
-
-
-
+        
+        
+    
         <li class="chapter " data-level="3.1" data-path="../templating/">
-
+            
                 <a href="../templating/">
-
-
+            
+                    
                     Templating
-
+            
                 </a>
+            
 
-
-
+            
             <ul class="articles">
-
-
+                
+    
         <li class="chapter " data-level="3.1.1" data-path="../templating/conrefs.html">
-
+            
                 <a href="../templating/conrefs.html">
-
-
+            
+                    
                     Content References
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="3.1.2" data-path="../templating/variables.html">
-
+            
                 <a href="../templating/variables.html">
-
-
+            
+                    
                     Variables
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="3.1.3" data-path="../templating/builtin.html">
-
+            
                 <a href="../templating/builtin.html">
-
-
+            
+                    
                     Builtin
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
 
             </ul>
-
+            
         </li>
-
+    
         <li class="chapter " data-level="3.2" data-path="../plugins/">
-
+            
                 <a href="../plugins/">
-
-
+            
+                    
                     Plugins
-
+            
                 </a>
+            
 
-
-
+            
             <ul class="articles">
-
-
+                
+    
         <li class="chapter " data-level="3.2.1" data-path="../plugins/create.html">
-
+            
                 <a href="../plugins/create.html">
-
-
+            
+                    
                     Create a plugin
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="3.2.2" data-path="../plugins/hooks.html">
-
+            
                 <a href="../plugins/hooks.html">
-
-
+            
+                    
                     Hooks
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="3.2.3" data-path="../plugins/blocks.html">
-
+            
                 <a href="../plugins/blocks.html">
-
-
+            
+                    
                     Blocks
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="3.2.4" data-path="../plugins/filters.html">
-
+            
                 <a href="../plugins/filters.html">
-
-
+            
+                    
                     Filters
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="3.2.5" data-path="../plugins/api.html">
-
+            
                 <a href="../plugins/api.html">
-
-
+            
+                    
                     API & Context
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="3.2.6" data-path="../plugins/testing.html">
-
+            
                 <a href="../plugins/testing.html">
-
-
+            
+                    
                     Test your plugin
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
 
             </ul>
-
+            
         </li>
-
+    
         <li class="chapter active" data-level="3.3" data-path="./">
-
+            
                 <a href="./">
-
-
+            
+                    
                     Theming
-
+            
                 </a>
+            
 
-
-
+            
         </li>
+    
 
-
-
-
+    
+        
         <li class="divider"></li>
-
-
-
+        
+        
+    
         <li class="chapter " data-level="4.1" data-path="../faq.html">
-
+            
                 <a href="../faq.html">
-
-
+            
+                    
                     FAQ
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="4.2" data-path="../examples.md">
-
+            
                 <span>
-
-
+            
+                    
                     Examples
-
+            
                 </a>
+            
 
-
-
+            
         </li>
-
+    
         <li class="chapter " data-level="4.3" >
-
+            
                 <a target="_blank" href="https://github.com/honkit/honkit/blob/master/CHANGELOG.md">
-
-
+            
+                    
                     Release notes
-
+            
                 </a>
+            
 
-
-
+            
         </li>
+    
 
-
-
-
+    
+        
         <li class="divider"></li>
-
-
-
+        
+        
+    
         <li class="chapter " data-level="5.1" data-path="../encoding.html">
-
+            
                 <a href="../encoding.html">
-
-
+            
+                    
                     Encoding
-
+            
                 </a>
+            
 
-
-
+            
         </li>
+    
 
-
-
+    
 
     <li class="divider"></li>
 
@@ -21019,18 +21019,18 @@ exports[`HonKit snapshots: themes/index.html 1`] = `
 
 
                 </nav>
-
-
+            
+        
     </div>
 
     <div class="book-body">
-
+        
             <div class="body-inner">
-
-
+                
+                    
 
 <div class="book-header" role="navigation">
-
+    
 
     <!-- Title -->
     <h1>
@@ -21044,12 +21044,12 @@ exports[`HonKit snapshots: themes/index.html 1`] = `
 
                     <div class="page-wrapper" tabindex="-1" role="main">
                         <div class="page-inner">
-
+                            
 <div id="book-search-results">
     <div class="search-noresults">
-
+    
                                 <section class="normal markdown-section">
-
+                                
 
                                 <h1 id="theming">Theming</h1>
 <p>Since version 3.0.0, <a href="../GLOSSARY.html#honkit" class="glossary-term" title="Honkit is a command line tool for building beautiful books using GitHub/Git and Markdown (or AsciiDoc).">HonKit</a> can be easily themed. Books use the <a href="https://github.com/GitbookIO/theme-default" target="_blank">theme-default</a> theme by default.</p>
@@ -21095,64 +21095,64 @@ exports[`HonKit snapshots: themes/index.html 1`] = `
 <h3 id="publish-a-theme">Publish a theme</h3>
 <p>Themes are published as <a href="../GLOSSARY.html#plugins" class="glossary-term" title="Plugins are the best way to extend HonKit functionalities (ebook and website).">plugins</a> (<a href="../plugins/">see related docs</a>) with a <code>theme-</code> prefix. For example the theme <code>awesome</code> will be loaded from the <code>theme-awesome</code> plugin, and then from the <code>honkit-plugin-theme-awesome</code> NPM package.</p>
 
-
+                                
 <hr>
 <div class="btn-group btn-group-justified">
-
+    
     <a class="btn" href="../plugins/testing.html"><b>Previous:</b> Test your plugin</a>
-
-
+    
+    
     <a class="btn" href="../faq.html"><b>Next:</b> FAQ</a>
-
+    
 </div>
 
                                 </section>
-
+                            
     </div>
     <div class="search-results">
         <div class="has-results">
-
+            
             <h1 class="search-results-title"><span class='search-results-count'></span> results matching "<span class='search-query'></span>"</h1>
             <ul class="search-results-list"></ul>
-
+            
         </div>
         <div class="no-results">
-
+            
             <h1 class="search-results-title">No results matching "<span class='search-query'></span>"</h1>
-
+            
         </div>
     </div>
 </div>
 
                         </div>
                     </div>
-
+                
             </div>
 
-
-
+            
+                
                 <a href="../plugins/testing.html" class="navigation navigation-prev " aria-label="Previous page: Test your plugin">
                     <i class="fa fa-angle-left"></i>
                 </a>
-
-
+                
+                
                 <a href="../faq.html" class="navigation navigation-next " aria-label="Next page: FAQ">
                     <i class="fa fa-angle-right"></i>
                 </a>
-
-
-
+                
+            
+        
     </div>
 
     <script>
         var gitbook = gitbook || [];
         gitbook.push(function() {
-
+            
         });
     </script>
 </div>
 
-
+        
     <noscript>
         <style>
             .honkit-cloak {
@@ -21199,27 +21199,27 @@ exports[`HonKit snapshots: themes/index.html 1`] = `
     </script>
     <script src="../gitbook/gitbook.js"></script>
     <script src="../gitbook/theme.js"></script>
-
-
+    
+        
         <script src="../gitbook/gitbook-plugin-search/search-engine.js"></script>
-
-
-
+        
+    
+        
         <script src="../gitbook/gitbook-plugin-search/search.js"></script>
-
-
-
+        
+    
+        
         <script src="../gitbook/gitbook-plugin-lunr/lunr.min.js"></script>
-
-
-
+        
+    
+        
         <script src="../gitbook/gitbook-plugin-lunr/search-lunr.js"></script>
-
-
-
+        
+    
+        
         <script src="../gitbook/gitbook-plugin-fontsettings/fontsettings.js"></script>
-
-
+        
+    
 
     </body>
 </html>

--- a/packages/honkit/src/__tests__/__snapshots__/snapshot-honkit.ts.snap
+++ b/packages/honkit/src/__tests__/__snapshots__/snapshot-honkit.ts.snap
@@ -10,50 +10,50 @@ exports[`HonKit snapshots: GLOSSARY.html 1`] = `
         <title> · HonKit Documentation</title>
         <meta http-equiv="X-UA-Compatible" content="IE=edge" />
         <meta name="description" content="">
-        
-        
-        
-        
-    
+
+
+
+
+
     <link rel="stylesheet" href="gitbook/style.css">
 
-    
-            
-                
+
+
+
                 <link rel="stylesheet" href="gitbook/@honkit/honkit-plugin-highlight/website.css">
-                
-            
-                
+
+
+
                 <link rel="stylesheet" href="gitbook/gitbook-plugin-search/search.css">
-                
-            
-                
+
+
+
                 <link rel="stylesheet" href="gitbook/gitbook-plugin-fontsettings/website.css">
-                
-            
-        
 
-    
 
-    
-        
+
+
+
+
+
+
         <link rel="stylesheet" href="styles/website.css">
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
 
-        
-    
-    
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
     <meta name="HandheldFriendly" content="true"/>
     <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no">
     <meta name="apple-mobile-web-app-capable" content="yes">
@@ -61,553 +61,553 @@ exports[`HonKit snapshots: GLOSSARY.html 1`] = `
     <link rel="apple-touch-icon-precomposed" sizes="152x152" href="gitbook/images/apple-touch-icon-precomposed-152.png">
     <link rel="shortcut icon" href="gitbook/images/favicon.ico" type="image/x-icon">
 
-    
-    
+
+
 
     </head>
     <body>
-        
+
 <div class="book honkit-cloak">
     <div class="book-summary">
-        
-            
+
+
 <div id="book-search-input" role="search">
     <input type="text" placeholder="Type to search" />
 </div>
 
-            
+
                 <nav role="navigation">
-                
+
 
 
 <ul class="summary">
-    
-    
 
-    
 
-    
-        
+
+
+
+
+
         <li class="header">Getting Started</li>
-        
-        
-    
+
+
+
         <li class="chapter " data-level="1.1" data-path="./">
-            
+
                 <a href="./">
-            
-                    
+
+
                     About this documentation
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="1.2" data-path="setup.html">
-            
+
                 <a href="setup.html">
-            
-                    
+
+
                     Installation and Setup
-            
+
                 </a>
-            
 
-            
+
+
         </li>
-    
 
-    
-        
+
+
+
         <li class="header">Your Content</li>
-        
-        
-    
+
+
+
         <li class="chapter " data-level="2.1" data-path="structure.html">
-            
+
                 <a href="structure.html">
-            
-                    
+
+
                     Directory structure
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.2" data-path="pages.html">
-            
+
                 <a href="pages.html">
-            
-                    
+
+
                     Pages and Summary
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.3" data-path="config.html">
-            
+
                 <a href="config.html">
-            
-                    
+
+
                     Configuration
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.4" data-path="lexicon.html">
-            
+
                 <a href="lexicon.html">
-            
-                    
+
+
                     Glossary
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.5" data-path="languages.html">
-            
+
                 <a href="languages.html">
-            
-                    
+
+
                     Multi-Lingual
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.6" data-path="syntax/markdown.html">
-            
+
                 <a href="syntax/markdown.html">
-            
-                    
+
+
                     Markdown
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
             <ul class="articles">
-                
-    
+
+
         <li class="chapter " data-level="2.6.1" data-path="syntax/markdown.html">
-            
+
                 <a href="syntax/markdown.html#headings">
-            
-                    
+
+
                     Headings
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.6.2" data-path="syntax/markdown.html">
-            
+
                 <a href="syntax/markdown.html#paragraphs">
-            
-                    
+
+
                     Paragraphs
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.6.3" data-path="syntax/markdown.html">
-            
+
                 <a href="syntax/markdown.html#lists">
-            
-                    
+
+
                     Lists
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.6.4" data-path="syntax/markdown.html">
-            
+
                 <a href="syntax/markdown.html#links">
-            
-                    
+
+
                     Links
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.6.5" data-path="syntax/markdown.html">
-            
+
                 <a href="syntax/markdown.html#images">
-            
-                    
+
+
                     Images
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.6.6" data-path="syntax/markdown.html">
-            
+
                 <a href="syntax/markdown.html#blockquotes">
-            
-                    
+
+
                     Blockquotes
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.6.7" data-path="syntax/markdown.html">
-            
+
                 <a href="syntax/markdown.html#tables">
-            
-                    
+
+
                     Tables
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.6.8" data-path="syntax/markdown.html">
-            
+
                 <a href="syntax/markdown.html#code">
-            
-                    
+
+
                     Code
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.6.9" data-path="syntax/markdown.html">
-            
+
                 <a href="syntax/markdown.html#html">
-            
-                    
+
+
                     HTML
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.6.10" data-path="syntax/markdown.html">
-            
+
                 <a href="syntax/markdown.html#footnotes">
-            
-                    
+
+
                     Footnotes
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
 
             </ul>
-            
+
         </li>
-    
+
         <li class="chapter " data-level="2.7" data-path="syntax/asciidoc.html">
-            
+
                 <a href="syntax/asciidoc.html">
-            
-                    
+
+
                     AsciiDoc
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.8" data-path="ebook.html">
-            
+
                 <a href="ebook.html">
-            
-                    
+
+
                     eBook and PDF
-            
+
                 </a>
-            
 
-            
+
+
         </li>
-    
 
-    
-        
+
+
+
         <li class="header">Customization</li>
-        
-        
-    
+
+
+
         <li class="chapter " data-level="3.1" data-path="templating/">
-            
+
                 <a href="templating/">
-            
-                    
+
+
                     Templating
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
             <ul class="articles">
-                
-    
+
+
         <li class="chapter " data-level="3.1.1" data-path="templating/conrefs.html">
-            
+
                 <a href="templating/conrefs.html">
-            
-                    
+
+
                     Content References
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="3.1.2" data-path="templating/variables.html">
-            
+
                 <a href="templating/variables.html">
-            
-                    
+
+
                     Variables
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="3.1.3" data-path="templating/builtin.html">
-            
+
                 <a href="templating/builtin.html">
-            
-                    
+
+
                     Builtin
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
 
             </ul>
-            
+
         </li>
-    
+
         <li class="chapter " data-level="3.2" data-path="plugins/">
-            
+
                 <a href="plugins/">
-            
-                    
+
+
                     Plugins
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
             <ul class="articles">
-                
-    
+
+
         <li class="chapter " data-level="3.2.1" data-path="plugins/create.html">
-            
+
                 <a href="plugins/create.html">
-            
-                    
+
+
                     Create a plugin
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="3.2.2" data-path="plugins/hooks.html">
-            
+
                 <a href="plugins/hooks.html">
-            
-                    
+
+
                     Hooks
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="3.2.3" data-path="plugins/blocks.html">
-            
+
                 <a href="plugins/blocks.html">
-            
-                    
+
+
                     Blocks
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="3.2.4" data-path="plugins/filters.html">
-            
+
                 <a href="plugins/filters.html">
-            
-                    
+
+
                     Filters
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="3.2.5" data-path="plugins/api.html">
-            
+
                 <a href="plugins/api.html">
-            
-                    
+
+
                     API & Context
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="3.2.6" data-path="plugins/testing.html">
-            
-                <a href="plugins/testing.html">
-            
-                    
-                    Test your plugin
-            
-                </a>
-            
 
-            
+                <a href="plugins/testing.html">
+
+
+                    Test your plugin
+
+                </a>
+
+
+
         </li>
-    
+
 
             </ul>
-            
+
         </li>
-    
+
         <li class="chapter " data-level="3.3" data-path="themes/">
-            
+
                 <a href="themes/">
-            
-                    
+
+
                     Theming
-            
+
                 </a>
-            
 
-            
+
+
         </li>
-    
 
-    
-        
+
+
+
         <li class="divider"></li>
-        
-        
-    
+
+
+
         <li class="chapter " data-level="4.1" data-path="faq.html">
-            
+
                 <a href="faq.html">
-            
-                    
+
+
                     FAQ
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="4.2" data-path="examples.md">
-            
+
                 <span>
-            
-                    
+
+
                     Examples
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="4.3" >
-            
+
                 <a target="_blank" href="https://github.com/honkit/honkit/blob/master/CHANGELOG.md">
-            
-                    
+
+
                     Release notes
-            
+
                 </a>
-            
 
-            
+
+
         </li>
-    
 
-    
-        
+
+
+
         <li class="divider"></li>
-        
-        
-    
+
+
+
         <li class="chapter " data-level="5.1" data-path="encoding.html">
-            
+
                 <a href="encoding.html">
-            
-                    
+
+
                     Encoding
-            
+
                 </a>
-            
 
-            
+
+
         </li>
-    
 
-    
+
+
 
     <li class="divider"></li>
 
@@ -620,18 +620,18 @@ exports[`HonKit snapshots: GLOSSARY.html 1`] = `
 
 
                 </nav>
-            
-        
+
+
     </div>
 
     <div class="book-body">
-        
+
             <div class="body-inner">
-                
-                    
+
+
 
 <div class="book-header" role="navigation">
-    
+
 
     <!-- Title -->
     <h1>
@@ -645,12 +645,12 @@ exports[`HonKit snapshots: GLOSSARY.html 1`] = `
 
                     <div class="page-wrapper" tabindex="-1" role="main">
                         <div class="page-inner">
-                            
+
 <div id="book-search-results">
     <div class="search-noresults">
-    
+
                                 <section class="normal markdown-section">
-                                
+
 
                                 <h2 id="honkit">HonKit</h2>
 <p><a href="GLOSSARY.html#honkit" class="glossary-term" title="Honkit is a command line tool for building beautiful books using GitHub/Git and Markdown (or AsciiDoc).">Honkit</a> is a command line tool for building beautiful books using GitHub/Git and Markdown (or AsciiDoc).</p>
@@ -661,52 +661,52 @@ exports[`HonKit snapshots: GLOSSARY.html 1`] = `
 <p><a href="GLOSSARY.html#honkit" class="glossary-term" title="Honkit is a command line tool for building beautiful books using GitHub/Git and Markdown (or AsciiDoc).">HonKit</a> uses the <a href="https://mozilla.github.io/nunjucks/" target="_blank">Nunjucks templating language</a> to process pages and theme&apos;s templates.</p>
 <p>For more details, see <a href="templating/">Templating</a>.</p>
 
-                                
+
 <hr>
 <div class="btn-group btn-group-justified">
-    
-    
+
+
 </div>
 
                                 </section>
-                            
+
     </div>
     <div class="search-results">
         <div class="has-results">
-            
+
             <h1 class="search-results-title"><span class='search-results-count'></span> results matching "<span class='search-query'></span>"</h1>
             <ul class="search-results-list"></ul>
-            
+
         </div>
         <div class="no-results">
-            
+
             <h1 class="search-results-title">No results matching "<span class='search-query'></span>"</h1>
-            
+
         </div>
     </div>
 </div>
 
                         </div>
                     </div>
-                
+
             </div>
 
-            
-                
-                
-            
-        
+
+
+
+
+
     </div>
 
     <script>
         var gitbook = gitbook || [];
         gitbook.push(function() {
-            
+
         });
     </script>
 </div>
 
-        
+
     <noscript>
         <style>
             .honkit-cloak {
@@ -753,27 +753,27 @@ exports[`HonKit snapshots: GLOSSARY.html 1`] = `
     </script>
     <script src="gitbook/gitbook.js"></script>
     <script src="gitbook/theme.js"></script>
-    
-        
+
+
         <script src="gitbook/gitbook-plugin-search/search-engine.js"></script>
-        
-    
-        
+
+
+
         <script src="gitbook/gitbook-plugin-search/search.js"></script>
-        
-    
-        
+
+
+
         <script src="gitbook/gitbook-plugin-lunr/lunr.min.js"></script>
-        
-    
-        
+
+
+
         <script src="gitbook/gitbook-plugin-lunr/search-lunr.js"></script>
-        
-    
-        
+
+
+
         <script src="gitbook/gitbook-plugin-fontsettings/fontsettings.js"></script>
-        
-    
+
+
 
     </body>
 </html>
@@ -799,50 +799,50 @@ exports[`HonKit snapshots: config.html 1`] = `
         <title>Configuration · HonKit Documentation</title>
         <meta http-equiv="X-UA-Compatible" content="IE=edge" />
         <meta name="description" content="">
-        
-        
-        
-        
-    
+
+
+
+
+
     <link rel="stylesheet" href="gitbook/style.css">
 
-    
-            
-                
+
+
+
                 <link rel="stylesheet" href="gitbook/@honkit/honkit-plugin-highlight/website.css">
-                
-            
-                
+
+
+
                 <link rel="stylesheet" href="gitbook/gitbook-plugin-search/search.css">
-                
-            
-                
+
+
+
                 <link rel="stylesheet" href="gitbook/gitbook-plugin-fontsettings/website.css">
-                
-            
-        
 
-    
 
-    
-        
+
+
+
+
+
+
         <link rel="stylesheet" href="styles/website.css">
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
 
-        
-    
-    
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
     <meta name="HandheldFriendly" content="true"/>
     <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no">
     <meta name="apple-mobile-web-app-capable" content="yes">
@@ -850,557 +850,557 @@ exports[`HonKit snapshots: config.html 1`] = `
     <link rel="apple-touch-icon-precomposed" sizes="152x152" href="gitbook/images/apple-touch-icon-precomposed-152.png">
     <link rel="shortcut icon" href="gitbook/images/favicon.ico" type="image/x-icon">
 
-    
+
     <link rel="next" href="lexicon.html" />
-    
-    
+
+
     <link rel="prev" href="pages.html" />
-    
+
 
     </head>
     <body>
-        
+
 <div class="book honkit-cloak">
     <div class="book-summary">
-        
-            
+
+
 <div id="book-search-input" role="search">
     <input type="text" placeholder="Type to search" />
 </div>
 
-            
+
                 <nav role="navigation">
-                
+
 
 
 <ul class="summary">
-    
-    
 
-    
 
-    
-        
+
+
+
+
+
         <li class="header">Getting Started</li>
-        
-        
-    
+
+
+
         <li class="chapter " data-level="1.1" data-path="./">
-            
+
                 <a href="./">
-            
-                    
+
+
                     About this documentation
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="1.2" data-path="setup.html">
-            
+
                 <a href="setup.html">
-            
-                    
+
+
                     Installation and Setup
-            
+
                 </a>
-            
 
-            
+
+
         </li>
-    
 
-    
-        
+
+
+
         <li class="header">Your Content</li>
-        
-        
-    
+
+
+
         <li class="chapter " data-level="2.1" data-path="structure.html">
-            
+
                 <a href="structure.html">
-            
-                    
+
+
                     Directory structure
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.2" data-path="pages.html">
-            
+
                 <a href="pages.html">
-            
-                    
+
+
                     Pages and Summary
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter active" data-level="2.3" data-path="config.html">
-            
+
                 <a href="config.html">
-            
-                    
+
+
                     Configuration
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.4" data-path="lexicon.html">
-            
+
                 <a href="lexicon.html">
-            
-                    
+
+
                     Glossary
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.5" data-path="languages.html">
-            
+
                 <a href="languages.html">
-            
-                    
+
+
                     Multi-Lingual
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.6" data-path="syntax/markdown.html">
-            
+
                 <a href="syntax/markdown.html">
-            
-                    
+
+
                     Markdown
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
             <ul class="articles">
-                
-    
+
+
         <li class="chapter " data-level="2.6.1" data-path="syntax/markdown.html">
-            
+
                 <a href="syntax/markdown.html#headings">
-            
-                    
+
+
                     Headings
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.6.2" data-path="syntax/markdown.html">
-            
+
                 <a href="syntax/markdown.html#paragraphs">
-            
-                    
+
+
                     Paragraphs
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.6.3" data-path="syntax/markdown.html">
-            
+
                 <a href="syntax/markdown.html#lists">
-            
-                    
+
+
                     Lists
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.6.4" data-path="syntax/markdown.html">
-            
+
                 <a href="syntax/markdown.html#links">
-            
-                    
+
+
                     Links
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.6.5" data-path="syntax/markdown.html">
-            
+
                 <a href="syntax/markdown.html#images">
-            
-                    
+
+
                     Images
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.6.6" data-path="syntax/markdown.html">
-            
+
                 <a href="syntax/markdown.html#blockquotes">
-            
-                    
+
+
                     Blockquotes
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.6.7" data-path="syntax/markdown.html">
-            
+
                 <a href="syntax/markdown.html#tables">
-            
-                    
+
+
                     Tables
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.6.8" data-path="syntax/markdown.html">
-            
+
                 <a href="syntax/markdown.html#code">
-            
-                    
+
+
                     Code
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.6.9" data-path="syntax/markdown.html">
-            
+
                 <a href="syntax/markdown.html#html">
-            
-                    
+
+
                     HTML
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.6.10" data-path="syntax/markdown.html">
-            
+
                 <a href="syntax/markdown.html#footnotes">
-            
-                    
+
+
                     Footnotes
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
 
             </ul>
-            
+
         </li>
-    
+
         <li class="chapter " data-level="2.7" data-path="syntax/asciidoc.html">
-            
+
                 <a href="syntax/asciidoc.html">
-            
-                    
+
+
                     AsciiDoc
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.8" data-path="ebook.html">
-            
+
                 <a href="ebook.html">
-            
-                    
+
+
                     eBook and PDF
-            
+
                 </a>
-            
 
-            
+
+
         </li>
-    
 
-    
-        
+
+
+
         <li class="header">Customization</li>
-        
-        
-    
+
+
+
         <li class="chapter " data-level="3.1" data-path="templating/">
-            
+
                 <a href="templating/">
-            
-                    
+
+
                     Templating
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
             <ul class="articles">
-                
-    
+
+
         <li class="chapter " data-level="3.1.1" data-path="templating/conrefs.html">
-            
+
                 <a href="templating/conrefs.html">
-            
-                    
+
+
                     Content References
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="3.1.2" data-path="templating/variables.html">
-            
+
                 <a href="templating/variables.html">
-            
-                    
+
+
                     Variables
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="3.1.3" data-path="templating/builtin.html">
-            
+
                 <a href="templating/builtin.html">
-            
-                    
+
+
                     Builtin
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
 
             </ul>
-            
+
         </li>
-    
+
         <li class="chapter " data-level="3.2" data-path="plugins/">
-            
+
                 <a href="plugins/">
-            
-                    
+
+
                     Plugins
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
             <ul class="articles">
-                
-    
+
+
         <li class="chapter " data-level="3.2.1" data-path="plugins/create.html">
-            
+
                 <a href="plugins/create.html">
-            
-                    
+
+
                     Create a plugin
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="3.2.2" data-path="plugins/hooks.html">
-            
+
                 <a href="plugins/hooks.html">
-            
-                    
+
+
                     Hooks
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="3.2.3" data-path="plugins/blocks.html">
-            
+
                 <a href="plugins/blocks.html">
-            
-                    
+
+
                     Blocks
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="3.2.4" data-path="plugins/filters.html">
-            
+
                 <a href="plugins/filters.html">
-            
-                    
+
+
                     Filters
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="3.2.5" data-path="plugins/api.html">
-            
+
                 <a href="plugins/api.html">
-            
-                    
+
+
                     API & Context
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="3.2.6" data-path="plugins/testing.html">
-            
-                <a href="plugins/testing.html">
-            
-                    
-                    Test your plugin
-            
-                </a>
-            
 
-            
+                <a href="plugins/testing.html">
+
+
+                    Test your plugin
+
+                </a>
+
+
+
         </li>
-    
+
 
             </ul>
-            
+
         </li>
-    
+
         <li class="chapter " data-level="3.3" data-path="themes/">
-            
+
                 <a href="themes/">
-            
-                    
+
+
                     Theming
-            
+
                 </a>
-            
 
-            
+
+
         </li>
-    
 
-    
-        
+
+
+
         <li class="divider"></li>
-        
-        
-    
+
+
+
         <li class="chapter " data-level="4.1" data-path="faq.html">
-            
+
                 <a href="faq.html">
-            
-                    
+
+
                     FAQ
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="4.2" data-path="examples.md">
-            
+
                 <span>
-            
-                    
+
+
                     Examples
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="4.3" >
-            
+
                 <a target="_blank" href="https://github.com/honkit/honkit/blob/master/CHANGELOG.md">
-            
-                    
+
+
                     Release notes
-            
+
                 </a>
-            
 
-            
+
+
         </li>
-    
 
-    
-        
+
+
+
         <li class="divider"></li>
-        
-        
-    
+
+
+
         <li class="chapter " data-level="5.1" data-path="encoding.html">
-            
+
                 <a href="encoding.html">
-            
-                    
+
+
                     Encoding
-            
+
                 </a>
-            
 
-            
+
+
         </li>
-    
 
-    
+
+
 
     <li class="divider"></li>
 
@@ -1413,18 +1413,18 @@ exports[`HonKit snapshots: config.html 1`] = `
 
 
                 </nav>
-            
-        
+
+
     </div>
 
     <div class="book-body">
-        
+
             <div class="body-inner">
-                
-                    
+
+
 
 <div class="book-header" role="navigation">
-    
+
 
     <!-- Title -->
     <h1>
@@ -1438,12 +1438,12 @@ exports[`HonKit snapshots: config.html 1`] = `
 
                     <div class="page-wrapper" tabindex="-1" role="main">
                         <div class="page-inner">
-                            
+
 <div id="book-search-results">
     <div class="search-noresults">
-    
+
                                 <section class="normal markdown-section">
-                                
+
 
                                 <h1 id="configuration">Configuration</h1>
 <p><a href="GLOSSARY.html#honkit" class="glossary-term" title="Honkit is a command line tool for building beautiful books using GitHub/Git and Markdown (or AsciiDoc).">HonKit</a> allows you to customize your book using a flexible configuration. These options are specified in a <code>book.json</code> file. For authors unfamiliar with the JSON syntax, you can validate the syntax using tools such as <a href="http://jsonlint.com" target="_blank">JSONlint</a>.</p>
@@ -1597,64 +1597,64 @@ These files must be at the root of your book (or the root of every language book
 </tbody>
 </table>
 
-                                
+
 <hr>
 <div class="btn-group btn-group-justified">
-    
+
     <a class="btn" href="pages.html"><b>Previous:</b> Pages and Summary</a>
-    
-    
+
+
     <a class="btn" href="lexicon.html"><b>Next:</b> Glossary</a>
-    
+
 </div>
 
                                 </section>
-                            
+
     </div>
     <div class="search-results">
         <div class="has-results">
-            
+
             <h1 class="search-results-title"><span class='search-results-count'></span> results matching "<span class='search-query'></span>"</h1>
             <ul class="search-results-list"></ul>
-            
+
         </div>
         <div class="no-results">
-            
+
             <h1 class="search-results-title">No results matching "<span class='search-query'></span>"</h1>
-            
+
         </div>
     </div>
 </div>
 
                         </div>
                     </div>
-                
+
             </div>
 
-            
-                
+
+
                 <a href="pages.html" class="navigation navigation-prev " aria-label="Previous page: Pages and Summary">
                     <i class="fa fa-angle-left"></i>
                 </a>
-                
-                
+
+
                 <a href="lexicon.html" class="navigation navigation-next " aria-label="Next page: Glossary">
                     <i class="fa fa-angle-right"></i>
                 </a>
-                
-            
-        
+
+
+
     </div>
 
     <script>
         var gitbook = gitbook || [];
         gitbook.push(function() {
-            
+
         });
     </script>
 </div>
 
-        
+
     <noscript>
         <style>
             .honkit-cloak {
@@ -1701,27 +1701,27 @@ These files must be at the root of your book (or the root of every language book
     </script>
     <script src="gitbook/gitbook.js"></script>
     <script src="gitbook/theme.js"></script>
-    
-        
+
+
         <script src="gitbook/gitbook-plugin-search/search-engine.js"></script>
-        
-    
-        
+
+
+
         <script src="gitbook/gitbook-plugin-search/search.js"></script>
-        
-    
-        
+
+
+
         <script src="gitbook/gitbook-plugin-lunr/lunr.min.js"></script>
-        
-    
-        
+
+
+
         <script src="gitbook/gitbook-plugin-lunr/search-lunr.js"></script>
-        
-    
-        
+
+
+
         <script src="gitbook/gitbook-plugin-fontsettings/fontsettings.js"></script>
-        
-    
+
+
 
     </body>
 </html>
@@ -1747,50 +1747,50 @@ exports[`HonKit snapshots: ebook.html 1`] = `
         <title>eBook and PDF · HonKit Documentation</title>
         <meta http-equiv="X-UA-Compatible" content="IE=edge" />
         <meta name="description" content="">
-        
-        
-        
-        
-    
+
+
+
+
+
     <link rel="stylesheet" href="gitbook/style.css">
 
-    
-            
-                
+
+
+
                 <link rel="stylesheet" href="gitbook/@honkit/honkit-plugin-highlight/website.css">
-                
-            
-                
+
+
+
                 <link rel="stylesheet" href="gitbook/gitbook-plugin-search/search.css">
-                
-            
-                
+
+
+
                 <link rel="stylesheet" href="gitbook/gitbook-plugin-fontsettings/website.css">
-                
-            
-        
 
-    
 
-    
-        
+
+
+
+
+
+
         <link rel="stylesheet" href="styles/website.css">
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
 
-        
-    
-    
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
     <meta name="HandheldFriendly" content="true"/>
     <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no">
     <meta name="apple-mobile-web-app-capable" content="yes">
@@ -1798,557 +1798,557 @@ exports[`HonKit snapshots: ebook.html 1`] = `
     <link rel="apple-touch-icon-precomposed" sizes="152x152" href="gitbook/images/apple-touch-icon-precomposed-152.png">
     <link rel="shortcut icon" href="gitbook/images/favicon.ico" type="image/x-icon">
 
-    
+
     <link rel="next" href="templating/" />
-    
-    
+
+
     <link rel="prev" href="syntax/asciidoc.html" />
-    
+
 
     </head>
     <body>
-        
+
 <div class="book honkit-cloak">
     <div class="book-summary">
-        
-            
+
+
 <div id="book-search-input" role="search">
     <input type="text" placeholder="Type to search" />
 </div>
 
-            
+
                 <nav role="navigation">
-                
+
 
 
 <ul class="summary">
-    
-    
 
-    
 
-    
-        
+
+
+
+
+
         <li class="header">Getting Started</li>
-        
-        
-    
+
+
+
         <li class="chapter " data-level="1.1" data-path="./">
-            
+
                 <a href="./">
-            
-                    
+
+
                     About this documentation
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="1.2" data-path="setup.html">
-            
+
                 <a href="setup.html">
-            
-                    
+
+
                     Installation and Setup
-            
+
                 </a>
-            
 
-            
+
+
         </li>
-    
 
-    
-        
+
+
+
         <li class="header">Your Content</li>
-        
-        
-    
+
+
+
         <li class="chapter " data-level="2.1" data-path="structure.html">
-            
+
                 <a href="structure.html">
-            
-                    
+
+
                     Directory structure
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.2" data-path="pages.html">
-            
+
                 <a href="pages.html">
-            
-                    
+
+
                     Pages and Summary
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.3" data-path="config.html">
-            
+
                 <a href="config.html">
-            
-                    
+
+
                     Configuration
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.4" data-path="lexicon.html">
-            
+
                 <a href="lexicon.html">
-            
-                    
+
+
                     Glossary
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.5" data-path="languages.html">
-            
+
                 <a href="languages.html">
-            
-                    
+
+
                     Multi-Lingual
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.6" data-path="syntax/markdown.html">
-            
+
                 <a href="syntax/markdown.html">
-            
-                    
+
+
                     Markdown
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
             <ul class="articles">
-                
-    
+
+
         <li class="chapter " data-level="2.6.1" data-path="syntax/markdown.html">
-            
+
                 <a href="syntax/markdown.html#headings">
-            
-                    
+
+
                     Headings
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.6.2" data-path="syntax/markdown.html">
-            
+
                 <a href="syntax/markdown.html#paragraphs">
-            
-                    
+
+
                     Paragraphs
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.6.3" data-path="syntax/markdown.html">
-            
+
                 <a href="syntax/markdown.html#lists">
-            
-                    
+
+
                     Lists
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.6.4" data-path="syntax/markdown.html">
-            
+
                 <a href="syntax/markdown.html#links">
-            
-                    
+
+
                     Links
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.6.5" data-path="syntax/markdown.html">
-            
+
                 <a href="syntax/markdown.html#images">
-            
-                    
+
+
                     Images
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.6.6" data-path="syntax/markdown.html">
-            
+
                 <a href="syntax/markdown.html#blockquotes">
-            
-                    
+
+
                     Blockquotes
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.6.7" data-path="syntax/markdown.html">
-            
+
                 <a href="syntax/markdown.html#tables">
-            
-                    
+
+
                     Tables
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.6.8" data-path="syntax/markdown.html">
-            
+
                 <a href="syntax/markdown.html#code">
-            
-                    
+
+
                     Code
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.6.9" data-path="syntax/markdown.html">
-            
+
                 <a href="syntax/markdown.html#html">
-            
-                    
+
+
                     HTML
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.6.10" data-path="syntax/markdown.html">
-            
+
                 <a href="syntax/markdown.html#footnotes">
-            
-                    
+
+
                     Footnotes
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
 
             </ul>
-            
+
         </li>
-    
+
         <li class="chapter " data-level="2.7" data-path="syntax/asciidoc.html">
-            
+
                 <a href="syntax/asciidoc.html">
-            
-                    
+
+
                     AsciiDoc
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter active" data-level="2.8" data-path="ebook.html">
-            
+
                 <a href="ebook.html">
-            
-                    
+
+
                     eBook and PDF
-            
+
                 </a>
-            
 
-            
+
+
         </li>
-    
 
-    
-        
+
+
+
         <li class="header">Customization</li>
-        
-        
-    
+
+
+
         <li class="chapter " data-level="3.1" data-path="templating/">
-            
+
                 <a href="templating/">
-            
-                    
+
+
                     Templating
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
             <ul class="articles">
-                
-    
+
+
         <li class="chapter " data-level="3.1.1" data-path="templating/conrefs.html">
-            
+
                 <a href="templating/conrefs.html">
-            
-                    
+
+
                     Content References
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="3.1.2" data-path="templating/variables.html">
-            
+
                 <a href="templating/variables.html">
-            
-                    
+
+
                     Variables
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="3.1.3" data-path="templating/builtin.html">
-            
+
                 <a href="templating/builtin.html">
-            
-                    
+
+
                     Builtin
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
 
             </ul>
-            
+
         </li>
-    
+
         <li class="chapter " data-level="3.2" data-path="plugins/">
-            
+
                 <a href="plugins/">
-            
-                    
+
+
                     Plugins
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
             <ul class="articles">
-                
-    
+
+
         <li class="chapter " data-level="3.2.1" data-path="plugins/create.html">
-            
+
                 <a href="plugins/create.html">
-            
-                    
+
+
                     Create a plugin
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="3.2.2" data-path="plugins/hooks.html">
-            
+
                 <a href="plugins/hooks.html">
-            
-                    
+
+
                     Hooks
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="3.2.3" data-path="plugins/blocks.html">
-            
+
                 <a href="plugins/blocks.html">
-            
-                    
+
+
                     Blocks
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="3.2.4" data-path="plugins/filters.html">
-            
+
                 <a href="plugins/filters.html">
-            
-                    
+
+
                     Filters
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="3.2.5" data-path="plugins/api.html">
-            
+
                 <a href="plugins/api.html">
-            
-                    
+
+
                     API & Context
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="3.2.6" data-path="plugins/testing.html">
-            
-                <a href="plugins/testing.html">
-            
-                    
-                    Test your plugin
-            
-                </a>
-            
 
-            
+                <a href="plugins/testing.html">
+
+
+                    Test your plugin
+
+                </a>
+
+
+
         </li>
-    
+
 
             </ul>
-            
+
         </li>
-    
+
         <li class="chapter " data-level="3.3" data-path="themes/">
-            
+
                 <a href="themes/">
-            
-                    
+
+
                     Theming
-            
+
                 </a>
-            
 
-            
+
+
         </li>
-    
 
-    
-        
+
+
+
         <li class="divider"></li>
-        
-        
-    
+
+
+
         <li class="chapter " data-level="4.1" data-path="faq.html">
-            
+
                 <a href="faq.html">
-            
-                    
+
+
                     FAQ
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="4.2" data-path="examples.md">
-            
+
                 <span>
-            
-                    
+
+
                     Examples
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="4.3" >
-            
+
                 <a target="_blank" href="https://github.com/honkit/honkit/blob/master/CHANGELOG.md">
-            
-                    
+
+
                     Release notes
-            
+
                 </a>
-            
 
-            
+
+
         </li>
-    
 
-    
-        
+
+
+
         <li class="divider"></li>
-        
-        
-    
+
+
+
         <li class="chapter " data-level="5.1" data-path="encoding.html">
-            
+
                 <a href="encoding.html">
-            
-                    
+
+
                     Encoding
-            
+
                 </a>
-            
 
-            
+
+
         </li>
-    
 
-    
+
+
 
     <li class="divider"></li>
 
@@ -2361,18 +2361,18 @@ exports[`HonKit snapshots: ebook.html 1`] = `
 
 
                 </nav>
-            
-        
+
+
     </div>
 
     <div class="book-body">
-        
+
             <div class="body-inner">
-                
-                    
+
+
 
 <div class="book-header" role="navigation">
-    
+
 
     <!-- Title -->
     <h1>
@@ -2386,12 +2386,12 @@ exports[`HonKit snapshots: ebook.html 1`] = `
 
                     <div class="page-wrapper" tabindex="-1" role="main">
                         <div class="page-inner">
-                            
+
 <div id="book-search-results">
     <div class="search-noresults">
-    
+
                                 <section class="normal markdown-section">
-                                
+
 
                                 <h1 id="generating-ebooks-and-pdfs">Generating eBooks and PDFs</h1>
 <p><a href="GLOSSARY.html#honkit" class="glossary-term" title="Honkit is a command line tool for building beautiful books using GitHub/Git and Markdown (or AsciiDoc).">HonKit</a> can generates a website, but can also output content as ebook (ePub, Mobi, PDF).</p>
@@ -2420,64 +2420,64 @@ $ honkit mobi ./ ./mybook.mobi
 <li>Any important text should be visible in the small version</li>
 </ul>
 
-                                
+
 <hr>
 <div class="btn-group btn-group-justified">
-    
+
     <a class="btn" href="syntax/asciidoc.html"><b>Previous:</b> AsciiDoc</a>
-    
-    
+
+
     <a class="btn" href="templating/"><b>Next:</b> Templating</a>
-    
+
 </div>
 
                                 </section>
-                            
+
     </div>
     <div class="search-results">
         <div class="has-results">
-            
+
             <h1 class="search-results-title"><span class='search-results-count'></span> results matching "<span class='search-query'></span>"</h1>
             <ul class="search-results-list"></ul>
-            
+
         </div>
         <div class="no-results">
-            
+
             <h1 class="search-results-title">No results matching "<span class='search-query'></span>"</h1>
-            
+
         </div>
     </div>
 </div>
 
                         </div>
                     </div>
-                
+
             </div>
 
-            
-                
+
+
                 <a href="syntax/asciidoc.html" class="navigation navigation-prev " aria-label="Previous page: AsciiDoc">
                     <i class="fa fa-angle-left"></i>
                 </a>
-                
-                
+
+
                 <a href="templating/" class="navigation navigation-next " aria-label="Next page: Templating">
                     <i class="fa fa-angle-right"></i>
                 </a>
-                
-            
-        
+
+
+
     </div>
 
     <script>
         var gitbook = gitbook || [];
         gitbook.push(function() {
-            
+
         });
     </script>
 </div>
 
-        
+
     <noscript>
         <style>
             .honkit-cloak {
@@ -2524,27 +2524,27 @@ $ honkit mobi ./ ./mybook.mobi
     </script>
     <script src="gitbook/gitbook.js"></script>
     <script src="gitbook/theme.js"></script>
-    
-        
+
+
         <script src="gitbook/gitbook-plugin-search/search-engine.js"></script>
-        
-    
-        
+
+
+
         <script src="gitbook/gitbook-plugin-search/search.js"></script>
-        
-    
-        
+
+
+
         <script src="gitbook/gitbook-plugin-lunr/lunr.min.js"></script>
-        
-    
-        
+
+
+
         <script src="gitbook/gitbook-plugin-lunr/search-lunr.js"></script>
-        
-    
-        
+
+
+
         <script src="gitbook/gitbook-plugin-fontsettings/fontsettings.js"></script>
-        
-    
+
+
 
     </body>
 </html>
@@ -2570,50 +2570,50 @@ exports[`HonKit snapshots: encoding.html 1`] = `
         <title>Encoding · HonKit Documentation</title>
         <meta http-equiv="X-UA-Compatible" content="IE=edge" />
         <meta name="description" content="">
-        
-        
-        
-        
-    
+
+
+
+
+
     <link rel="stylesheet" href="gitbook/style.css">
 
-    
-            
-                
+
+
+
                 <link rel="stylesheet" href="gitbook/@honkit/honkit-plugin-highlight/website.css">
-                
-            
-                
+
+
+
                 <link rel="stylesheet" href="gitbook/gitbook-plugin-search/search.css">
-                
-            
-                
+
+
+
                 <link rel="stylesheet" href="gitbook/gitbook-plugin-fontsettings/website.css">
-                
-            
-        
 
-    
 
-    
-        
+
+
+
+
+
+
         <link rel="stylesheet" href="styles/website.css">
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
 
-        
-    
-    
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
     <meta name="HandheldFriendly" content="true"/>
     <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no">
     <meta name="apple-mobile-web-app-capable" content="yes">
@@ -2621,553 +2621,553 @@ exports[`HonKit snapshots: encoding.html 1`] = `
     <link rel="apple-touch-icon-precomposed" sizes="152x152" href="gitbook/images/apple-touch-icon-precomposed-152.png">
     <link rel="shortcut icon" href="gitbook/images/favicon.ico" type="image/x-icon">
 
-    
-    
+
+
 
     </head>
     <body>
-        
+
 <div class="book honkit-cloak">
     <div class="book-summary">
-        
-            
+
+
 <div id="book-search-input" role="search">
     <input type="text" placeholder="Type to search" />
 </div>
 
-            
+
                 <nav role="navigation">
-                
+
 
 
 <ul class="summary">
-    
-    
 
-    
 
-    
-        
+
+
+
+
+
         <li class="header">Getting Started</li>
-        
-        
-    
+
+
+
         <li class="chapter " data-level="1.1" data-path="./">
-            
+
                 <a href="./">
-            
-                    
+
+
                     About this documentation
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="1.2" data-path="setup.html">
-            
+
                 <a href="setup.html">
-            
-                    
+
+
                     Installation and Setup
-            
+
                 </a>
-            
 
-            
+
+
         </li>
-    
 
-    
-        
+
+
+
         <li class="header">Your Content</li>
-        
-        
-    
+
+
+
         <li class="chapter " data-level="2.1" data-path="structure.html">
-            
+
                 <a href="structure.html">
-            
-                    
+
+
                     Directory structure
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.2" data-path="pages.html">
-            
+
                 <a href="pages.html">
-            
-                    
+
+
                     Pages and Summary
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.3" data-path="config.html">
-            
+
                 <a href="config.html">
-            
-                    
+
+
                     Configuration
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.4" data-path="lexicon.html">
-            
+
                 <a href="lexicon.html">
-            
-                    
+
+
                     Glossary
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.5" data-path="languages.html">
-            
+
                 <a href="languages.html">
-            
-                    
+
+
                     Multi-Lingual
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.6" data-path="syntax/markdown.html">
-            
+
                 <a href="syntax/markdown.html">
-            
-                    
+
+
                     Markdown
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
             <ul class="articles">
-                
-    
+
+
         <li class="chapter " data-level="2.6.1" data-path="syntax/markdown.html">
-            
+
                 <a href="syntax/markdown.html#headings">
-            
-                    
+
+
                     Headings
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.6.2" data-path="syntax/markdown.html">
-            
+
                 <a href="syntax/markdown.html#paragraphs">
-            
-                    
+
+
                     Paragraphs
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.6.3" data-path="syntax/markdown.html">
-            
+
                 <a href="syntax/markdown.html#lists">
-            
-                    
+
+
                     Lists
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.6.4" data-path="syntax/markdown.html">
-            
+
                 <a href="syntax/markdown.html#links">
-            
-                    
+
+
                     Links
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.6.5" data-path="syntax/markdown.html">
-            
+
                 <a href="syntax/markdown.html#images">
-            
-                    
+
+
                     Images
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.6.6" data-path="syntax/markdown.html">
-            
+
                 <a href="syntax/markdown.html#blockquotes">
-            
-                    
+
+
                     Blockquotes
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.6.7" data-path="syntax/markdown.html">
-            
+
                 <a href="syntax/markdown.html#tables">
-            
-                    
+
+
                     Tables
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.6.8" data-path="syntax/markdown.html">
-            
+
                 <a href="syntax/markdown.html#code">
-            
-                    
+
+
                     Code
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.6.9" data-path="syntax/markdown.html">
-            
+
                 <a href="syntax/markdown.html#html">
-            
-                    
+
+
                     HTML
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.6.10" data-path="syntax/markdown.html">
-            
+
                 <a href="syntax/markdown.html#footnotes">
-            
-                    
+
+
                     Footnotes
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
 
             </ul>
-            
+
         </li>
-    
+
         <li class="chapter " data-level="2.7" data-path="syntax/asciidoc.html">
-            
+
                 <a href="syntax/asciidoc.html">
-            
-                    
+
+
                     AsciiDoc
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.8" data-path="ebook.html">
-            
+
                 <a href="ebook.html">
-            
-                    
+
+
                     eBook and PDF
-            
+
                 </a>
-            
 
-            
+
+
         </li>
-    
 
-    
-        
+
+
+
         <li class="header">Customization</li>
-        
-        
-    
+
+
+
         <li class="chapter " data-level="3.1" data-path="templating/">
-            
+
                 <a href="templating/">
-            
-                    
+
+
                     Templating
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
             <ul class="articles">
-                
-    
+
+
         <li class="chapter " data-level="3.1.1" data-path="templating/conrefs.html">
-            
+
                 <a href="templating/conrefs.html">
-            
-                    
+
+
                     Content References
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="3.1.2" data-path="templating/variables.html">
-            
+
                 <a href="templating/variables.html">
-            
-                    
+
+
                     Variables
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="3.1.3" data-path="templating/builtin.html">
-            
+
                 <a href="templating/builtin.html">
-            
-                    
+
+
                     Builtin
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
 
             </ul>
-            
+
         </li>
-    
+
         <li class="chapter " data-level="3.2" data-path="plugins/">
-            
+
                 <a href="plugins/">
-            
-                    
+
+
                     Plugins
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
             <ul class="articles">
-                
-    
+
+
         <li class="chapter " data-level="3.2.1" data-path="plugins/create.html">
-            
+
                 <a href="plugins/create.html">
-            
-                    
+
+
                     Create a plugin
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="3.2.2" data-path="plugins/hooks.html">
-            
+
                 <a href="plugins/hooks.html">
-            
-                    
+
+
                     Hooks
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="3.2.3" data-path="plugins/blocks.html">
-            
+
                 <a href="plugins/blocks.html">
-            
-                    
+
+
                     Blocks
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="3.2.4" data-path="plugins/filters.html">
-            
+
                 <a href="plugins/filters.html">
-            
-                    
+
+
                     Filters
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="3.2.5" data-path="plugins/api.html">
-            
+
                 <a href="plugins/api.html">
-            
-                    
+
+
                     API & Context
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="3.2.6" data-path="plugins/testing.html">
-            
-                <a href="plugins/testing.html">
-            
-                    
-                    Test your plugin
-            
-                </a>
-            
 
-            
+                <a href="plugins/testing.html">
+
+
+                    Test your plugin
+
+                </a>
+
+
+
         </li>
-    
+
 
             </ul>
-            
+
         </li>
-    
+
         <li class="chapter " data-level="3.3" data-path="themes/">
-            
+
                 <a href="themes/">
-            
-                    
+
+
                     Theming
-            
+
                 </a>
-            
 
-            
+
+
         </li>
-    
 
-    
-        
+
+
+
         <li class="divider"></li>
-        
-        
-    
+
+
+
         <li class="chapter " data-level="4.1" data-path="faq.html">
-            
+
                 <a href="faq.html">
-            
-                    
+
+
                     FAQ
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="4.2" data-path="examples.md">
-            
+
                 <span>
-            
-                    
+
+
                     Examples
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="4.3" >
-            
+
                 <a target="_blank" href="https://github.com/honkit/honkit/blob/master/CHANGELOG.md">
-            
-                    
+
+
                     Release notes
-            
+
                 </a>
-            
 
-            
+
+
         </li>
-    
 
-    
-        
+
+
+
         <li class="divider"></li>
-        
-        
-    
+
+
+
         <li class="chapter active" data-level="5.1" data-path="encoding.html">
-            
+
                 <a href="encoding.html">
-            
-                    
+
+
                     Encoding
-            
+
                 </a>
-            
 
-            
+
+
         </li>
-    
 
-    
+
+
 
     <li class="divider"></li>
 
@@ -3180,18 +3180,18 @@ exports[`HonKit snapshots: encoding.html 1`] = `
 
 
                 </nav>
-            
-        
+
+
     </div>
 
     <div class="book-body">
-        
+
             <div class="body-inner">
-                
-                    
+
+
 
 <div class="book-header" role="navigation">
-    
+
 
     <!-- Title -->
     <h1>
@@ -3205,12 +3205,12 @@ exports[`HonKit snapshots: encoding.html 1`] = `
 
                     <div class="page-wrapper" tabindex="-1" role="main">
                         <div class="page-inner">
-                            
+
 <div id="book-search-results">
     <div class="search-noresults">
-    
+
                                 <section class="normal markdown-section">
-                                
+
 
                                 <h1 id="encoding">Encoding</h1>
 <table>
@@ -3248,52 +3248,52 @@ exports[`HonKit snapshots: encoding.html 1`] = `
 </tbody>
 </table>
 
-                                
+
 <hr>
 <div class="btn-group btn-group-justified">
-    
-    
+
+
 </div>
 
                                 </section>
-                            
+
     </div>
     <div class="search-results">
         <div class="has-results">
-            
+
             <h1 class="search-results-title"><span class='search-results-count'></span> results matching "<span class='search-query'></span>"</h1>
             <ul class="search-results-list"></ul>
-            
+
         </div>
         <div class="no-results">
-            
+
             <h1 class="search-results-title">No results matching "<span class='search-query'></span>"</h1>
-            
+
         </div>
     </div>
 </div>
 
                         </div>
                     </div>
-                
+
             </div>
 
-            
-                
-                
-            
-        
+
+
+
+
+
     </div>
 
     <script>
         var gitbook = gitbook || [];
         gitbook.push(function() {
-            
+
         });
     </script>
 </div>
 
-        
+
     <noscript>
         <style>
             .honkit-cloak {
@@ -3340,27 +3340,27 @@ exports[`HonKit snapshots: encoding.html 1`] = `
     </script>
     <script src="gitbook/gitbook.js"></script>
     <script src="gitbook/theme.js"></script>
-    
-        
+
+
         <script src="gitbook/gitbook-plugin-search/search-engine.js"></script>
-        
-    
-        
+
+
+
         <script src="gitbook/gitbook-plugin-search/search.js"></script>
-        
-    
-        
+
+
+
         <script src="gitbook/gitbook-plugin-lunr/lunr.min.js"></script>
-        
-    
-        
+
+
+
         <script src="gitbook/gitbook-plugin-lunr/search-lunr.js"></script>
-        
-    
-        
+
+
+
         <script src="gitbook/gitbook-plugin-fontsettings/fontsettings.js"></script>
-        
-    
+
+
 
     </body>
 </html>
@@ -3386,50 +3386,50 @@ exports[`HonKit snapshots: faq.html 1`] = `
         <title>FAQ · HonKit Documentation</title>
         <meta http-equiv="X-UA-Compatible" content="IE=edge" />
         <meta name="description" content="">
-        
-        
-        
-        
-    
+
+
+
+
+
     <link rel="stylesheet" href="gitbook/style.css">
 
-    
-            
-                
+
+
+
                 <link rel="stylesheet" href="gitbook/@honkit/honkit-plugin-highlight/website.css">
-                
-            
-                
+
+
+
                 <link rel="stylesheet" href="gitbook/gitbook-plugin-search/search.css">
-                
-            
-                
+
+
+
                 <link rel="stylesheet" href="gitbook/gitbook-plugin-fontsettings/website.css">
-                
-            
-        
 
-    
 
-    
-        
+
+
+
+
+
+
         <link rel="stylesheet" href="styles/website.css">
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
 
-        
-    
-    
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
     <meta name="HandheldFriendly" content="true"/>
     <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no">
     <meta name="apple-mobile-web-app-capable" content="yes">
@@ -3437,557 +3437,557 @@ exports[`HonKit snapshots: faq.html 1`] = `
     <link rel="apple-touch-icon-precomposed" sizes="152x152" href="gitbook/images/apple-touch-icon-precomposed-152.png">
     <link rel="shortcut icon" href="gitbook/images/favicon.ico" type="image/x-icon">
 
-    
+
     <link rel="next" href="examples.md" />
-    
-    
+
+
     <link rel="prev" href="themes/" />
-    
+
 
     </head>
     <body>
-        
+
 <div class="book honkit-cloak">
     <div class="book-summary">
-        
-            
+
+
 <div id="book-search-input" role="search">
     <input type="text" placeholder="Type to search" />
 </div>
 
-            
+
                 <nav role="navigation">
-                
+
 
 
 <ul class="summary">
-    
-    
 
-    
 
-    
-        
+
+
+
+
+
         <li class="header">Getting Started</li>
-        
-        
-    
+
+
+
         <li class="chapter " data-level="1.1" data-path="./">
-            
+
                 <a href="./">
-            
-                    
+
+
                     About this documentation
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="1.2" data-path="setup.html">
-            
+
                 <a href="setup.html">
-            
-                    
+
+
                     Installation and Setup
-            
+
                 </a>
-            
 
-            
+
+
         </li>
-    
 
-    
-        
+
+
+
         <li class="header">Your Content</li>
-        
-        
-    
+
+
+
         <li class="chapter " data-level="2.1" data-path="structure.html">
-            
+
                 <a href="structure.html">
-            
-                    
+
+
                     Directory structure
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.2" data-path="pages.html">
-            
+
                 <a href="pages.html">
-            
-                    
+
+
                     Pages and Summary
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.3" data-path="config.html">
-            
+
                 <a href="config.html">
-            
-                    
+
+
                     Configuration
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.4" data-path="lexicon.html">
-            
+
                 <a href="lexicon.html">
-            
-                    
+
+
                     Glossary
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.5" data-path="languages.html">
-            
+
                 <a href="languages.html">
-            
-                    
+
+
                     Multi-Lingual
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.6" data-path="syntax/markdown.html">
-            
+
                 <a href="syntax/markdown.html">
-            
-                    
+
+
                     Markdown
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
             <ul class="articles">
-                
-    
+
+
         <li class="chapter " data-level="2.6.1" data-path="syntax/markdown.html">
-            
+
                 <a href="syntax/markdown.html#headings">
-            
-                    
+
+
                     Headings
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.6.2" data-path="syntax/markdown.html">
-            
+
                 <a href="syntax/markdown.html#paragraphs">
-            
-                    
+
+
                     Paragraphs
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.6.3" data-path="syntax/markdown.html">
-            
+
                 <a href="syntax/markdown.html#lists">
-            
-                    
+
+
                     Lists
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.6.4" data-path="syntax/markdown.html">
-            
+
                 <a href="syntax/markdown.html#links">
-            
-                    
+
+
                     Links
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.6.5" data-path="syntax/markdown.html">
-            
+
                 <a href="syntax/markdown.html#images">
-            
-                    
+
+
                     Images
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.6.6" data-path="syntax/markdown.html">
-            
+
                 <a href="syntax/markdown.html#blockquotes">
-            
-                    
+
+
                     Blockquotes
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.6.7" data-path="syntax/markdown.html">
-            
+
                 <a href="syntax/markdown.html#tables">
-            
-                    
+
+
                     Tables
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.6.8" data-path="syntax/markdown.html">
-            
+
                 <a href="syntax/markdown.html#code">
-            
-                    
+
+
                     Code
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.6.9" data-path="syntax/markdown.html">
-            
+
                 <a href="syntax/markdown.html#html">
-            
-                    
+
+
                     HTML
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.6.10" data-path="syntax/markdown.html">
-            
+
                 <a href="syntax/markdown.html#footnotes">
-            
-                    
+
+
                     Footnotes
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
 
             </ul>
-            
+
         </li>
-    
+
         <li class="chapter " data-level="2.7" data-path="syntax/asciidoc.html">
-            
+
                 <a href="syntax/asciidoc.html">
-            
-                    
+
+
                     AsciiDoc
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.8" data-path="ebook.html">
-            
+
                 <a href="ebook.html">
-            
-                    
+
+
                     eBook and PDF
-            
+
                 </a>
-            
 
-            
+
+
         </li>
-    
 
-    
-        
+
+
+
         <li class="header">Customization</li>
-        
-        
-    
+
+
+
         <li class="chapter " data-level="3.1" data-path="templating/">
-            
+
                 <a href="templating/">
-            
-                    
+
+
                     Templating
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
             <ul class="articles">
-                
-    
+
+
         <li class="chapter " data-level="3.1.1" data-path="templating/conrefs.html">
-            
+
                 <a href="templating/conrefs.html">
-            
-                    
+
+
                     Content References
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="3.1.2" data-path="templating/variables.html">
-            
+
                 <a href="templating/variables.html">
-            
-                    
+
+
                     Variables
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="3.1.3" data-path="templating/builtin.html">
-            
+
                 <a href="templating/builtin.html">
-            
-                    
+
+
                     Builtin
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
 
             </ul>
-            
+
         </li>
-    
+
         <li class="chapter " data-level="3.2" data-path="plugins/">
-            
+
                 <a href="plugins/">
-            
-                    
+
+
                     Plugins
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
             <ul class="articles">
-                
-    
+
+
         <li class="chapter " data-level="3.2.1" data-path="plugins/create.html">
-            
+
                 <a href="plugins/create.html">
-            
-                    
+
+
                     Create a plugin
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="3.2.2" data-path="plugins/hooks.html">
-            
+
                 <a href="plugins/hooks.html">
-            
-                    
+
+
                     Hooks
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="3.2.3" data-path="plugins/blocks.html">
-            
+
                 <a href="plugins/blocks.html">
-            
-                    
+
+
                     Blocks
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="3.2.4" data-path="plugins/filters.html">
-            
+
                 <a href="plugins/filters.html">
-            
-                    
+
+
                     Filters
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="3.2.5" data-path="plugins/api.html">
-            
+
                 <a href="plugins/api.html">
-            
-                    
+
+
                     API & Context
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="3.2.6" data-path="plugins/testing.html">
-            
-                <a href="plugins/testing.html">
-            
-                    
-                    Test your plugin
-            
-                </a>
-            
 
-            
+                <a href="plugins/testing.html">
+
+
+                    Test your plugin
+
+                </a>
+
+
+
         </li>
-    
+
 
             </ul>
-            
+
         </li>
-    
+
         <li class="chapter " data-level="3.3" data-path="themes/">
-            
+
                 <a href="themes/">
-            
-                    
+
+
                     Theming
-            
+
                 </a>
-            
 
-            
+
+
         </li>
-    
 
-    
-        
+
+
+
         <li class="divider"></li>
-        
-        
-    
+
+
+
         <li class="chapter active" data-level="4.1" data-path="faq.html">
-            
+
                 <a href="faq.html">
-            
-                    
+
+
                     FAQ
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="4.2" data-path="examples.md">
-            
+
                 <span>
-            
-                    
+
+
                     Examples
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="4.3" >
-            
+
                 <a target="_blank" href="https://github.com/honkit/honkit/blob/master/CHANGELOG.md">
-            
-                    
+
+
                     Release notes
-            
+
                 </a>
-            
 
-            
+
+
         </li>
-    
 
-    
-        
+
+
+
         <li class="divider"></li>
-        
-        
-    
+
+
+
         <li class="chapter " data-level="5.1" data-path="encoding.html">
-            
+
                 <a href="encoding.html">
-            
-                    
+
+
                     Encoding
-            
+
                 </a>
-            
 
-            
+
+
         </li>
-    
 
-    
+
+
 
     <li class="divider"></li>
 
@@ -4000,18 +4000,18 @@ exports[`HonKit snapshots: faq.html 1`] = `
 
 
                 </nav>
-            
-        
+
+
     </div>
 
     <div class="book-body">
-        
+
             <div class="body-inner">
-                
-                    
+
+
 
 <div class="book-header" role="navigation">
-    
+
 
     <!-- Title -->
     <h1>
@@ -4025,12 +4025,12 @@ exports[`HonKit snapshots: faq.html 1`] = `
 
                     <div class="page-wrapper" tabindex="-1" role="main">
                         <div class="page-inner">
-                            
+
 <div id="book-search-results">
     <div class="search-noresults">
-    
+
                                 <section class="normal markdown-section">
-                                
+
 
                                 <h1 id="honkit-faq">HonKit FAQ</h1>
 <p>This page gathers common questions and answers concerning the <a href="GLOSSARY.html#honkit" class="glossary-term" title="Honkit is a command line tool for building beautiful books using GitHub/Git and Markdown (or AsciiDoc).">HonKit</a> format and toolchain.</p>
@@ -4065,64 +4065,64 @@ In some case, <a href="GLOSSARY.html#honkit" class="glossary-term" title="Honkit
 <h4 id="can-i-add-interactive-content-videos-etc">Can I add interactive content (videos, etc)?</h4>
 <p><a href="GLOSSARY.html#honkit" class="glossary-term" title="Honkit is a command line tool for building beautiful books using GitHub/Git and Markdown (or AsciiDoc).">HonKit</a> is very <a href="plugins/">extensible</a>. You can use <a href="https://plugins.honkit.com" target="_blank">existing plugins</a> or create your own!</p>
 
-                                
+
 <hr>
 <div class="btn-group btn-group-justified">
-    
+
     <a class="btn" href="themes/"><b>Previous:</b> Theming</a>
-    
-    
+
+
     <a class="btn" href="examples.md"><b>Next:</b> Examples</a>
-    
+
 </div>
 
                                 </section>
-                            
+
     </div>
     <div class="search-results">
         <div class="has-results">
-            
+
             <h1 class="search-results-title"><span class='search-results-count'></span> results matching "<span class='search-query'></span>"</h1>
             <ul class="search-results-list"></ul>
-            
+
         </div>
         <div class="no-results">
-            
+
             <h1 class="search-results-title">No results matching "<span class='search-query'></span>"</h1>
-            
+
         </div>
     </div>
 </div>
 
                         </div>
                     </div>
-                
+
             </div>
 
-            
-                
+
+
                 <a href="themes/" class="navigation navigation-prev " aria-label="Previous page: Theming">
                     <i class="fa fa-angle-left"></i>
                 </a>
-                
-                
+
+
                 <a href="examples.md" class="navigation navigation-next " aria-label="Next page: Examples">
                     <i class="fa fa-angle-right"></i>
                 </a>
-                
-            
-        
+
+
+
     </div>
 
     <script>
         var gitbook = gitbook || [];
         gitbook.push(function() {
-            
+
         });
     </script>
 </div>
 
-        
+
     <noscript>
         <style>
             .honkit-cloak {
@@ -4169,27 +4169,27 @@ In some case, <a href="GLOSSARY.html#honkit" class="glossary-term" title="Honkit
     </script>
     <script src="gitbook/gitbook.js"></script>
     <script src="gitbook/theme.js"></script>
-    
-        
+
+
         <script src="gitbook/gitbook-plugin-search/search-engine.js"></script>
-        
-    
-        
+
+
+
         <script src="gitbook/gitbook-plugin-search/search.js"></script>
-        
-    
-        
+
+
+
         <script src="gitbook/gitbook-plugin-lunr/lunr.min.js"></script>
-        
-    
-        
+
+
+
         <script src="gitbook/gitbook-plugin-lunr/search-lunr.js"></script>
-        
-    
-        
+
+
+
         <script src="gitbook/gitbook-plugin-fontsettings/fontsettings.js"></script>
-        
-    
+
+
 
     </body>
 </html>
@@ -4215,50 +4215,50 @@ exports[`HonKit snapshots: index.html 1`] = `
         <title>About this documentation · HonKit Documentation</title>
         <meta http-equiv="X-UA-Compatible" content="IE=edge" />
         <meta name="description" content="">
-        
-        
-        
-        
-    
+
+
+
+
+
     <link rel="stylesheet" href="gitbook/style.css">
 
-    
-            
-                
+
+
+
                 <link rel="stylesheet" href="gitbook/@honkit/honkit-plugin-highlight/website.css">
-                
-            
-                
+
+
+
                 <link rel="stylesheet" href="gitbook/gitbook-plugin-search/search.css">
-                
-            
-                
+
+
+
                 <link rel="stylesheet" href="gitbook/gitbook-plugin-fontsettings/website.css">
-                
-            
-        
 
-    
 
-    
-        
+
+
+
+
+
+
         <link rel="stylesheet" href="styles/website.css">
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
 
-        
-    
-    
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
     <meta name="HandheldFriendly" content="true"/>
     <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no">
     <meta name="apple-mobile-web-app-capable" content="yes">
@@ -4266,555 +4266,555 @@ exports[`HonKit snapshots: index.html 1`] = `
     <link rel="apple-touch-icon-precomposed" sizes="152x152" href="gitbook/images/apple-touch-icon-precomposed-152.png">
     <link rel="shortcut icon" href="gitbook/images/favicon.ico" type="image/x-icon">
 
-    
+
     <link rel="next" href="setup.html" />
-    
-    
+
+
 
     </head>
     <body>
-        
+
 <div class="book honkit-cloak">
     <div class="book-summary">
-        
-            
+
+
 <div id="book-search-input" role="search">
     <input type="text" placeholder="Type to search" />
 </div>
 
-            
+
                 <nav role="navigation">
-                
+
 
 
 <ul class="summary">
-    
-    
 
-    
 
-    
-        
+
+
+
+
+
         <li class="header">Getting Started</li>
-        
-        
-    
+
+
+
         <li class="chapter active" data-level="1.1" data-path="./">
-            
+
                 <a href="./">
-            
-                    
+
+
                     About this documentation
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="1.2" data-path="setup.html">
-            
+
                 <a href="setup.html">
-            
-                    
+
+
                     Installation and Setup
-            
+
                 </a>
-            
 
-            
+
+
         </li>
-    
 
-    
-        
+
+
+
         <li class="header">Your Content</li>
-        
-        
-    
+
+
+
         <li class="chapter " data-level="2.1" data-path="structure.html">
-            
+
                 <a href="structure.html">
-            
-                    
+
+
                     Directory structure
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.2" data-path="pages.html">
-            
+
                 <a href="pages.html">
-            
-                    
+
+
                     Pages and Summary
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.3" data-path="config.html">
-            
+
                 <a href="config.html">
-            
-                    
+
+
                     Configuration
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.4" data-path="lexicon.html">
-            
+
                 <a href="lexicon.html">
-            
-                    
+
+
                     Glossary
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.5" data-path="languages.html">
-            
+
                 <a href="languages.html">
-            
-                    
+
+
                     Multi-Lingual
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.6" data-path="syntax/markdown.html">
-            
+
                 <a href="syntax/markdown.html">
-            
-                    
+
+
                     Markdown
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
             <ul class="articles">
-                
-    
+
+
         <li class="chapter " data-level="2.6.1" data-path="syntax/markdown.html">
-            
+
                 <a href="syntax/markdown.html#headings">
-            
-                    
+
+
                     Headings
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.6.2" data-path="syntax/markdown.html">
-            
+
                 <a href="syntax/markdown.html#paragraphs">
-            
-                    
+
+
                     Paragraphs
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.6.3" data-path="syntax/markdown.html">
-            
+
                 <a href="syntax/markdown.html#lists">
-            
-                    
+
+
                     Lists
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.6.4" data-path="syntax/markdown.html">
-            
+
                 <a href="syntax/markdown.html#links">
-            
-                    
+
+
                     Links
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.6.5" data-path="syntax/markdown.html">
-            
+
                 <a href="syntax/markdown.html#images">
-            
-                    
+
+
                     Images
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.6.6" data-path="syntax/markdown.html">
-            
+
                 <a href="syntax/markdown.html#blockquotes">
-            
-                    
+
+
                     Blockquotes
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.6.7" data-path="syntax/markdown.html">
-            
+
                 <a href="syntax/markdown.html#tables">
-            
-                    
+
+
                     Tables
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.6.8" data-path="syntax/markdown.html">
-            
+
                 <a href="syntax/markdown.html#code">
-            
-                    
+
+
                     Code
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.6.9" data-path="syntax/markdown.html">
-            
+
                 <a href="syntax/markdown.html#html">
-            
-                    
+
+
                     HTML
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.6.10" data-path="syntax/markdown.html">
-            
+
                 <a href="syntax/markdown.html#footnotes">
-            
-                    
+
+
                     Footnotes
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
 
             </ul>
-            
+
         </li>
-    
+
         <li class="chapter " data-level="2.7" data-path="syntax/asciidoc.html">
-            
+
                 <a href="syntax/asciidoc.html">
-            
-                    
+
+
                     AsciiDoc
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.8" data-path="ebook.html">
-            
+
                 <a href="ebook.html">
-            
-                    
+
+
                     eBook and PDF
-            
+
                 </a>
-            
 
-            
+
+
         </li>
-    
 
-    
-        
+
+
+
         <li class="header">Customization</li>
-        
-        
-    
+
+
+
         <li class="chapter " data-level="3.1" data-path="templating/">
-            
+
                 <a href="templating/">
-            
-                    
+
+
                     Templating
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
             <ul class="articles">
-                
-    
+
+
         <li class="chapter " data-level="3.1.1" data-path="templating/conrefs.html">
-            
+
                 <a href="templating/conrefs.html">
-            
-                    
+
+
                     Content References
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="3.1.2" data-path="templating/variables.html">
-            
+
                 <a href="templating/variables.html">
-            
-                    
+
+
                     Variables
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="3.1.3" data-path="templating/builtin.html">
-            
+
                 <a href="templating/builtin.html">
-            
-                    
+
+
                     Builtin
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
 
             </ul>
-            
+
         </li>
-    
+
         <li class="chapter " data-level="3.2" data-path="plugins/">
-            
+
                 <a href="plugins/">
-            
-                    
+
+
                     Plugins
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
             <ul class="articles">
-                
-    
+
+
         <li class="chapter " data-level="3.2.1" data-path="plugins/create.html">
-            
+
                 <a href="plugins/create.html">
-            
-                    
+
+
                     Create a plugin
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="3.2.2" data-path="plugins/hooks.html">
-            
+
                 <a href="plugins/hooks.html">
-            
-                    
+
+
                     Hooks
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="3.2.3" data-path="plugins/blocks.html">
-            
+
                 <a href="plugins/blocks.html">
-            
-                    
+
+
                     Blocks
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="3.2.4" data-path="plugins/filters.html">
-            
+
                 <a href="plugins/filters.html">
-            
-                    
+
+
                     Filters
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="3.2.5" data-path="plugins/api.html">
-            
+
                 <a href="plugins/api.html">
-            
-                    
+
+
                     API & Context
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="3.2.6" data-path="plugins/testing.html">
-            
-                <a href="plugins/testing.html">
-            
-                    
-                    Test your plugin
-            
-                </a>
-            
 
-            
+                <a href="plugins/testing.html">
+
+
+                    Test your plugin
+
+                </a>
+
+
+
         </li>
-    
+
 
             </ul>
-            
+
         </li>
-    
+
         <li class="chapter " data-level="3.3" data-path="themes/">
-            
+
                 <a href="themes/">
-            
-                    
+
+
                     Theming
-            
+
                 </a>
-            
 
-            
+
+
         </li>
-    
 
-    
-        
+
+
+
         <li class="divider"></li>
-        
-        
-    
+
+
+
         <li class="chapter " data-level="4.1" data-path="faq.html">
-            
+
                 <a href="faq.html">
-            
-                    
+
+
                     FAQ
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="4.2" data-path="examples.md">
-            
+
                 <span>
-            
-                    
+
+
                     Examples
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="4.3" >
-            
+
                 <a target="_blank" href="https://github.com/honkit/honkit/blob/master/CHANGELOG.md">
-            
-                    
+
+
                     Release notes
-            
+
                 </a>
-            
 
-            
+
+
         </li>
-    
 
-    
-        
+
+
+
         <li class="divider"></li>
-        
-        
-    
+
+
+
         <li class="chapter " data-level="5.1" data-path="encoding.html">
-            
+
                 <a href="encoding.html">
-            
-                    
+
+
                     Encoding
-            
+
                 </a>
-            
 
-            
+
+
         </li>
-    
 
-    
+
+
 
     <li class="divider"></li>
 
@@ -4827,18 +4827,18 @@ exports[`HonKit snapshots: index.html 1`] = `
 
 
                 </nav>
-            
-        
+
+
     </div>
 
     <div class="book-body">
-        
+
             <div class="body-inner">
-                
-                    
+
+
 
 <div class="book-header" role="navigation">
-    
+
 
     <!-- Title -->
     <h1>
@@ -4852,12 +4852,12 @@ exports[`HonKit snapshots: index.html 1`] = `
 
                     <div class="page-wrapper" tabindex="-1" role="main">
                         <div class="page-inner">
-                            
+
 <div id="book-search-results">
     <div class="search-noresults">
-    
+
                                 <section class="normal markdown-section">
-                                
+
 
                                 <h1 id="honkit-toolchain-documentation">HonKit Toolchain Documentation</h1>
 <p>This document aims to be a comprehensive guide to the <a href="GLOSSARY.html#honkit" class="glossary-term" title="Honkit is a command line tool for building beautiful books using GitHub/Git and Markdown (or AsciiDoc).">HonKit</a> command line tool.</p>
@@ -4872,58 +4872,58 @@ exports[`HonKit snapshots: index.html 1`] = `
 <h3 id="contribute-to-this-documentation">Contribute to this documentation</h3>
 <p>You can contribute to improve this documentation on <a href="https://github.com/honkit/honkit" target="_blank">GitHub</a> by signaling issues or proposing changes.</p>
 
-                                
+
 <hr>
 <div class="btn-group btn-group-justified">
-    
-    
+
+
     <a class="btn" href="setup.html"><b>Next:</b> Installation and Setup</a>
-    
+
 </div>
 
                                 </section>
-                            
+
     </div>
     <div class="search-results">
         <div class="has-results">
-            
+
             <h1 class="search-results-title"><span class='search-results-count'></span> results matching "<span class='search-query'></span>"</h1>
             <ul class="search-results-list"></ul>
-            
+
         </div>
         <div class="no-results">
-            
+
             <h1 class="search-results-title">No results matching "<span class='search-query'></span>"</h1>
-            
+
         </div>
     </div>
 </div>
 
                         </div>
                     </div>
-                
+
             </div>
 
-            
-                
-                
+
+
+
                 <a href="setup.html" class="navigation navigation-next navigation-unique" aria-label="Next page: Installation and Setup">
                     <i class="fa fa-angle-right"></i>
                 </a>
-                
-            
-        
+
+
+
     </div>
 
     <script>
         var gitbook = gitbook || [];
         gitbook.push(function() {
-            
+
         });
     </script>
 </div>
 
-        
+
     <noscript>
         <style>
             .honkit-cloak {
@@ -4970,27 +4970,27 @@ exports[`HonKit snapshots: index.html 1`] = `
     </script>
     <script src="gitbook/gitbook.js"></script>
     <script src="gitbook/theme.js"></script>
-    
-        
+
+
         <script src="gitbook/gitbook-plugin-search/search-engine.js"></script>
-        
-    
-        
+
+
+
         <script src="gitbook/gitbook-plugin-search/search.js"></script>
-        
-    
-        
+
+
+
         <script src="gitbook/gitbook-plugin-lunr/lunr.min.js"></script>
-        
-    
-        
+
+
+
         <script src="gitbook/gitbook-plugin-lunr/search-lunr.js"></script>
-        
-    
-        
+
+
+
         <script src="gitbook/gitbook-plugin-fontsettings/fontsettings.js"></script>
-        
-    
+
+
 
     </body>
 </html>
@@ -5016,50 +5016,50 @@ exports[`HonKit snapshots: languages.html 1`] = `
         <title>Multi-Lingual · HonKit Documentation</title>
         <meta http-equiv="X-UA-Compatible" content="IE=edge" />
         <meta name="description" content="">
-        
-        
-        
-        
-    
+
+
+
+
+
     <link rel="stylesheet" href="gitbook/style.css">
 
-    
-            
-                
+
+
+
                 <link rel="stylesheet" href="gitbook/@honkit/honkit-plugin-highlight/website.css">
-                
-            
-                
+
+
+
                 <link rel="stylesheet" href="gitbook/gitbook-plugin-search/search.css">
-                
-            
-                
+
+
+
                 <link rel="stylesheet" href="gitbook/gitbook-plugin-fontsettings/website.css">
-                
-            
-        
 
-    
 
-    
-        
+
+
+
+
+
+
         <link rel="stylesheet" href="styles/website.css">
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
 
-        
-    
-    
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
     <meta name="HandheldFriendly" content="true"/>
     <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no">
     <meta name="apple-mobile-web-app-capable" content="yes">
@@ -5067,557 +5067,557 @@ exports[`HonKit snapshots: languages.html 1`] = `
     <link rel="apple-touch-icon-precomposed" sizes="152x152" href="gitbook/images/apple-touch-icon-precomposed-152.png">
     <link rel="shortcut icon" href="gitbook/images/favicon.ico" type="image/x-icon">
 
-    
+
     <link rel="next" href="syntax/markdown.html" />
-    
-    
+
+
     <link rel="prev" href="lexicon.html" />
-    
+
 
     </head>
     <body>
-        
+
 <div class="book honkit-cloak">
     <div class="book-summary">
-        
-            
+
+
 <div id="book-search-input" role="search">
     <input type="text" placeholder="Type to search" />
 </div>
 
-            
+
                 <nav role="navigation">
-                
+
 
 
 <ul class="summary">
-    
-    
 
-    
 
-    
-        
+
+
+
+
+
         <li class="header">Getting Started</li>
-        
-        
-    
+
+
+
         <li class="chapter " data-level="1.1" data-path="./">
-            
+
                 <a href="./">
-            
-                    
+
+
                     About this documentation
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="1.2" data-path="setup.html">
-            
+
                 <a href="setup.html">
-            
-                    
+
+
                     Installation and Setup
-            
+
                 </a>
-            
 
-            
+
+
         </li>
-    
 
-    
-        
+
+
+
         <li class="header">Your Content</li>
-        
-        
-    
+
+
+
         <li class="chapter " data-level="2.1" data-path="structure.html">
-            
+
                 <a href="structure.html">
-            
-                    
+
+
                     Directory structure
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.2" data-path="pages.html">
-            
+
                 <a href="pages.html">
-            
-                    
+
+
                     Pages and Summary
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.3" data-path="config.html">
-            
+
                 <a href="config.html">
-            
-                    
+
+
                     Configuration
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.4" data-path="lexicon.html">
-            
+
                 <a href="lexicon.html">
-            
-                    
+
+
                     Glossary
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter active" data-level="2.5" data-path="languages.html">
-            
+
                 <a href="languages.html">
-            
-                    
+
+
                     Multi-Lingual
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.6" data-path="syntax/markdown.html">
-            
+
                 <a href="syntax/markdown.html">
-            
-                    
+
+
                     Markdown
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
             <ul class="articles">
-                
-    
+
+
         <li class="chapter " data-level="2.6.1" data-path="syntax/markdown.html">
-            
+
                 <a href="syntax/markdown.html#headings">
-            
-                    
+
+
                     Headings
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.6.2" data-path="syntax/markdown.html">
-            
+
                 <a href="syntax/markdown.html#paragraphs">
-            
-                    
+
+
                     Paragraphs
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.6.3" data-path="syntax/markdown.html">
-            
+
                 <a href="syntax/markdown.html#lists">
-            
-                    
+
+
                     Lists
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.6.4" data-path="syntax/markdown.html">
-            
+
                 <a href="syntax/markdown.html#links">
-            
-                    
+
+
                     Links
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.6.5" data-path="syntax/markdown.html">
-            
+
                 <a href="syntax/markdown.html#images">
-            
-                    
+
+
                     Images
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.6.6" data-path="syntax/markdown.html">
-            
+
                 <a href="syntax/markdown.html#blockquotes">
-            
-                    
+
+
                     Blockquotes
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.6.7" data-path="syntax/markdown.html">
-            
+
                 <a href="syntax/markdown.html#tables">
-            
-                    
+
+
                     Tables
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.6.8" data-path="syntax/markdown.html">
-            
+
                 <a href="syntax/markdown.html#code">
-            
-                    
+
+
                     Code
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.6.9" data-path="syntax/markdown.html">
-            
+
                 <a href="syntax/markdown.html#html">
-            
-                    
+
+
                     HTML
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.6.10" data-path="syntax/markdown.html">
-            
+
                 <a href="syntax/markdown.html#footnotes">
-            
-                    
+
+
                     Footnotes
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
 
             </ul>
-            
+
         </li>
-    
+
         <li class="chapter " data-level="2.7" data-path="syntax/asciidoc.html">
-            
+
                 <a href="syntax/asciidoc.html">
-            
-                    
+
+
                     AsciiDoc
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.8" data-path="ebook.html">
-            
+
                 <a href="ebook.html">
-            
-                    
+
+
                     eBook and PDF
-            
+
                 </a>
-            
 
-            
+
+
         </li>
-    
 
-    
-        
+
+
+
         <li class="header">Customization</li>
-        
-        
-    
+
+
+
         <li class="chapter " data-level="3.1" data-path="templating/">
-            
+
                 <a href="templating/">
-            
-                    
+
+
                     Templating
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
             <ul class="articles">
-                
-    
+
+
         <li class="chapter " data-level="3.1.1" data-path="templating/conrefs.html">
-            
+
                 <a href="templating/conrefs.html">
-            
-                    
+
+
                     Content References
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="3.1.2" data-path="templating/variables.html">
-            
+
                 <a href="templating/variables.html">
-            
-                    
+
+
                     Variables
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="3.1.3" data-path="templating/builtin.html">
-            
+
                 <a href="templating/builtin.html">
-            
-                    
+
+
                     Builtin
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
 
             </ul>
-            
+
         </li>
-    
+
         <li class="chapter " data-level="3.2" data-path="plugins/">
-            
+
                 <a href="plugins/">
-            
-                    
+
+
                     Plugins
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
             <ul class="articles">
-                
-    
+
+
         <li class="chapter " data-level="3.2.1" data-path="plugins/create.html">
-            
+
                 <a href="plugins/create.html">
-            
-                    
+
+
                     Create a plugin
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="3.2.2" data-path="plugins/hooks.html">
-            
+
                 <a href="plugins/hooks.html">
-            
-                    
+
+
                     Hooks
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="3.2.3" data-path="plugins/blocks.html">
-            
+
                 <a href="plugins/blocks.html">
-            
-                    
+
+
                     Blocks
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="3.2.4" data-path="plugins/filters.html">
-            
+
                 <a href="plugins/filters.html">
-            
-                    
+
+
                     Filters
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="3.2.5" data-path="plugins/api.html">
-            
+
                 <a href="plugins/api.html">
-            
-                    
+
+
                     API & Context
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="3.2.6" data-path="plugins/testing.html">
-            
-                <a href="plugins/testing.html">
-            
-                    
-                    Test your plugin
-            
-                </a>
-            
 
-            
+                <a href="plugins/testing.html">
+
+
+                    Test your plugin
+
+                </a>
+
+
+
         </li>
-    
+
 
             </ul>
-            
+
         </li>
-    
+
         <li class="chapter " data-level="3.3" data-path="themes/">
-            
+
                 <a href="themes/">
-            
-                    
+
+
                     Theming
-            
+
                 </a>
-            
 
-            
+
+
         </li>
-    
 
-    
-        
+
+
+
         <li class="divider"></li>
-        
-        
-    
+
+
+
         <li class="chapter " data-level="4.1" data-path="faq.html">
-            
+
                 <a href="faq.html">
-            
-                    
+
+
                     FAQ
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="4.2" data-path="examples.md">
-            
+
                 <span>
-            
-                    
+
+
                     Examples
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="4.3" >
-            
+
                 <a target="_blank" href="https://github.com/honkit/honkit/blob/master/CHANGELOG.md">
-            
-                    
+
+
                     Release notes
-            
+
                 </a>
-            
 
-            
+
+
         </li>
-    
 
-    
-        
+
+
+
         <li class="divider"></li>
-        
-        
-    
+
+
+
         <li class="chapter " data-level="5.1" data-path="encoding.html">
-            
+
                 <a href="encoding.html">
-            
-                    
+
+
                     Encoding
-            
+
                 </a>
-            
 
-            
+
+
         </li>
-    
 
-    
+
+
 
     <li class="divider"></li>
 
@@ -5630,18 +5630,18 @@ exports[`HonKit snapshots: languages.html 1`] = `
 
 
                 </nav>
-            
-        
+
+
     </div>
 
     <div class="book-body">
-        
+
             <div class="body-inner">
-                
-                    
+
+
 
 <div class="book-header" role="navigation">
-    
+
 
     <!-- Title -->
     <h1>
@@ -5655,12 +5655,12 @@ exports[`HonKit snapshots: languages.html 1`] = `
 
                     <div class="page-wrapper" tabindex="-1" role="main">
                         <div class="page-inner">
-                            
+
 <div id="book-search-results">
     <div class="search-noresults">
-    
+
                                 <section class="normal markdown-section">
-                                
+
 
                                 <h1 id="multi-languages">Multi-Languages</h1>
 <p><a href="GLOSSARY.html#honkit" class="glossary-term" title="Honkit is a command line tool for building beautiful books using GitHub/Git and Markdown (or AsciiDoc).">HonKit</a> supports building books written in multiple languages. Each language should be a sub-directory following the normal <a href="GLOSSARY.html#honkit" class="glossary-term" title="Honkit is a command line tool for building beautiful books using GitHub/Git and Markdown (or AsciiDoc).">HonKit</a> format, and a file named <code>LANGS.md</code> should be present at the root of the repository with the following format:</p>
@@ -5674,64 +5674,64 @@ exports[`HonKit snapshots: languages.html 1`] = `
 <p>When a language book (ex: <code>en</code>) has a <code>book.json</code>, its configuration will extend the main configuration.</p>
 <p>The only exception is <a href="GLOSSARY.html#plugins" class="glossary-term" title="Plugins are the best way to extend HonKit functionalities (ebook and website).">plugins</a>, <a href="GLOSSARY.html#plugins" class="glossary-term" title="Plugins are the best way to extend HonKit functionalities (ebook and website).">plugins</a> are specified globally, and language specific <a href="GLOSSARY.html#plugins" class="glossary-term" title="Plugins are the best way to extend HonKit functionalities (ebook and website).">plugins</a> cannot be specified.</p>
 
-                                
+
 <hr>
 <div class="btn-group btn-group-justified">
-    
+
     <a class="btn" href="lexicon.html"><b>Previous:</b> Glossary</a>
-    
-    
+
+
     <a class="btn" href="syntax/markdown.html"><b>Next:</b> Markdown</a>
-    
+
 </div>
 
                                 </section>
-                            
+
     </div>
     <div class="search-results">
         <div class="has-results">
-            
+
             <h1 class="search-results-title"><span class='search-results-count'></span> results matching "<span class='search-query'></span>"</h1>
             <ul class="search-results-list"></ul>
-            
+
         </div>
         <div class="no-results">
-            
+
             <h1 class="search-results-title">No results matching "<span class='search-query'></span>"</h1>
-            
+
         </div>
     </div>
 </div>
 
                         </div>
                     </div>
-                
+
             </div>
 
-            
-                
+
+
                 <a href="lexicon.html" class="navigation navigation-prev " aria-label="Previous page: Glossary">
                     <i class="fa fa-angle-left"></i>
                 </a>
-                
-                
+
+
                 <a href="syntax/markdown.html" class="navigation navigation-next " aria-label="Next page: Markdown">
                     <i class="fa fa-angle-right"></i>
                 </a>
-                
-            
-        
+
+
+
     </div>
 
     <script>
         var gitbook = gitbook || [];
         gitbook.push(function() {
-            
+
         });
     </script>
 </div>
 
-        
+
     <noscript>
         <style>
             .honkit-cloak {
@@ -5778,27 +5778,27 @@ exports[`HonKit snapshots: languages.html 1`] = `
     </script>
     <script src="gitbook/gitbook.js"></script>
     <script src="gitbook/theme.js"></script>
-    
-        
+
+
         <script src="gitbook/gitbook-plugin-search/search-engine.js"></script>
-        
-    
-        
+
+
+
         <script src="gitbook/gitbook-plugin-search/search.js"></script>
-        
-    
-        
+
+
+
         <script src="gitbook/gitbook-plugin-lunr/lunr.min.js"></script>
-        
-    
-        
+
+
+
         <script src="gitbook/gitbook-plugin-lunr/search-lunr.js"></script>
-        
-    
-        
+
+
+
         <script src="gitbook/gitbook-plugin-fontsettings/fontsettings.js"></script>
-        
-    
+
+
 
     </body>
 </html>
@@ -5824,50 +5824,50 @@ exports[`HonKit snapshots: lexicon.html 1`] = `
         <title>Glossary · HonKit Documentation</title>
         <meta http-equiv="X-UA-Compatible" content="IE=edge" />
         <meta name="description" content="">
-        
-        
-        
-        
-    
+
+
+
+
+
     <link rel="stylesheet" href="gitbook/style.css">
 
-    
-            
-                
+
+
+
                 <link rel="stylesheet" href="gitbook/@honkit/honkit-plugin-highlight/website.css">
-                
-            
-                
+
+
+
                 <link rel="stylesheet" href="gitbook/gitbook-plugin-search/search.css">
-                
-            
-                
+
+
+
                 <link rel="stylesheet" href="gitbook/gitbook-plugin-fontsettings/website.css">
-                
-            
-        
 
-    
 
-    
-        
+
+
+
+
+
+
         <link rel="stylesheet" href="styles/website.css">
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
 
-        
-    
-    
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
     <meta name="HandheldFriendly" content="true"/>
     <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no">
     <meta name="apple-mobile-web-app-capable" content="yes">
@@ -5875,557 +5875,557 @@ exports[`HonKit snapshots: lexicon.html 1`] = `
     <link rel="apple-touch-icon-precomposed" sizes="152x152" href="gitbook/images/apple-touch-icon-precomposed-152.png">
     <link rel="shortcut icon" href="gitbook/images/favicon.ico" type="image/x-icon">
 
-    
+
     <link rel="next" href="languages.html" />
-    
-    
+
+
     <link rel="prev" href="config.html" />
-    
+
 
     </head>
     <body>
-        
+
 <div class="book honkit-cloak">
     <div class="book-summary">
-        
-            
+
+
 <div id="book-search-input" role="search">
     <input type="text" placeholder="Type to search" />
 </div>
 
-            
+
                 <nav role="navigation">
-                
+
 
 
 <ul class="summary">
-    
-    
 
-    
 
-    
-        
+
+
+
+
+
         <li class="header">Getting Started</li>
-        
-        
-    
+
+
+
         <li class="chapter " data-level="1.1" data-path="./">
-            
+
                 <a href="./">
-            
-                    
+
+
                     About this documentation
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="1.2" data-path="setup.html">
-            
+
                 <a href="setup.html">
-            
-                    
+
+
                     Installation and Setup
-            
+
                 </a>
-            
 
-            
+
+
         </li>
-    
 
-    
-        
+
+
+
         <li class="header">Your Content</li>
-        
-        
-    
+
+
+
         <li class="chapter " data-level="2.1" data-path="structure.html">
-            
+
                 <a href="structure.html">
-            
-                    
+
+
                     Directory structure
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.2" data-path="pages.html">
-            
+
                 <a href="pages.html">
-            
-                    
+
+
                     Pages and Summary
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.3" data-path="config.html">
-            
+
                 <a href="config.html">
-            
-                    
+
+
                     Configuration
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter active" data-level="2.4" data-path="lexicon.html">
-            
+
                 <a href="lexicon.html">
-            
-                    
+
+
                     Glossary
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.5" data-path="languages.html">
-            
+
                 <a href="languages.html">
-            
-                    
+
+
                     Multi-Lingual
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.6" data-path="syntax/markdown.html">
-            
+
                 <a href="syntax/markdown.html">
-            
-                    
+
+
                     Markdown
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
             <ul class="articles">
-                
-    
+
+
         <li class="chapter " data-level="2.6.1" data-path="syntax/markdown.html">
-            
+
                 <a href="syntax/markdown.html#headings">
-            
-                    
+
+
                     Headings
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.6.2" data-path="syntax/markdown.html">
-            
+
                 <a href="syntax/markdown.html#paragraphs">
-            
-                    
+
+
                     Paragraphs
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.6.3" data-path="syntax/markdown.html">
-            
+
                 <a href="syntax/markdown.html#lists">
-            
-                    
+
+
                     Lists
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.6.4" data-path="syntax/markdown.html">
-            
+
                 <a href="syntax/markdown.html#links">
-            
-                    
+
+
                     Links
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.6.5" data-path="syntax/markdown.html">
-            
+
                 <a href="syntax/markdown.html#images">
-            
-                    
+
+
                     Images
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.6.6" data-path="syntax/markdown.html">
-            
+
                 <a href="syntax/markdown.html#blockquotes">
-            
-                    
+
+
                     Blockquotes
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.6.7" data-path="syntax/markdown.html">
-            
+
                 <a href="syntax/markdown.html#tables">
-            
-                    
+
+
                     Tables
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.6.8" data-path="syntax/markdown.html">
-            
+
                 <a href="syntax/markdown.html#code">
-            
-                    
+
+
                     Code
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.6.9" data-path="syntax/markdown.html">
-            
+
                 <a href="syntax/markdown.html#html">
-            
-                    
+
+
                     HTML
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.6.10" data-path="syntax/markdown.html">
-            
+
                 <a href="syntax/markdown.html#footnotes">
-            
-                    
+
+
                     Footnotes
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
 
             </ul>
-            
+
         </li>
-    
+
         <li class="chapter " data-level="2.7" data-path="syntax/asciidoc.html">
-            
+
                 <a href="syntax/asciidoc.html">
-            
-                    
+
+
                     AsciiDoc
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.8" data-path="ebook.html">
-            
+
                 <a href="ebook.html">
-            
-                    
+
+
                     eBook and PDF
-            
+
                 </a>
-            
 
-            
+
+
         </li>
-    
 
-    
-        
+
+
+
         <li class="header">Customization</li>
-        
-        
-    
+
+
+
         <li class="chapter " data-level="3.1" data-path="templating/">
-            
+
                 <a href="templating/">
-            
-                    
+
+
                     Templating
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
             <ul class="articles">
-                
-    
+
+
         <li class="chapter " data-level="3.1.1" data-path="templating/conrefs.html">
-            
+
                 <a href="templating/conrefs.html">
-            
-                    
+
+
                     Content References
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="3.1.2" data-path="templating/variables.html">
-            
+
                 <a href="templating/variables.html">
-            
-                    
+
+
                     Variables
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="3.1.3" data-path="templating/builtin.html">
-            
+
                 <a href="templating/builtin.html">
-            
-                    
+
+
                     Builtin
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
 
             </ul>
-            
+
         </li>
-    
+
         <li class="chapter " data-level="3.2" data-path="plugins/">
-            
+
                 <a href="plugins/">
-            
-                    
+
+
                     Plugins
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
             <ul class="articles">
-                
-    
+
+
         <li class="chapter " data-level="3.2.1" data-path="plugins/create.html">
-            
+
                 <a href="plugins/create.html">
-            
-                    
+
+
                     Create a plugin
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="3.2.2" data-path="plugins/hooks.html">
-            
+
                 <a href="plugins/hooks.html">
-            
-                    
+
+
                     Hooks
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="3.2.3" data-path="plugins/blocks.html">
-            
+
                 <a href="plugins/blocks.html">
-            
-                    
+
+
                     Blocks
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="3.2.4" data-path="plugins/filters.html">
-            
+
                 <a href="plugins/filters.html">
-            
-                    
+
+
                     Filters
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="3.2.5" data-path="plugins/api.html">
-            
+
                 <a href="plugins/api.html">
-            
-                    
+
+
                     API & Context
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="3.2.6" data-path="plugins/testing.html">
-            
-                <a href="plugins/testing.html">
-            
-                    
-                    Test your plugin
-            
-                </a>
-            
 
-            
+                <a href="plugins/testing.html">
+
+
+                    Test your plugin
+
+                </a>
+
+
+
         </li>
-    
+
 
             </ul>
-            
+
         </li>
-    
+
         <li class="chapter " data-level="3.3" data-path="themes/">
-            
+
                 <a href="themes/">
-            
-                    
+
+
                     Theming
-            
+
                 </a>
-            
 
-            
+
+
         </li>
-    
 
-    
-        
+
+
+
         <li class="divider"></li>
-        
-        
-    
+
+
+
         <li class="chapter " data-level="4.1" data-path="faq.html">
-            
+
                 <a href="faq.html">
-            
-                    
+
+
                     FAQ
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="4.2" data-path="examples.md">
-            
+
                 <span>
-            
-                    
+
+
                     Examples
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="4.3" >
-            
+
                 <a target="_blank" href="https://github.com/honkit/honkit/blob/master/CHANGELOG.md">
-            
-                    
+
+
                     Release notes
-            
+
                 </a>
-            
 
-            
+
+
         </li>
-    
 
-    
-        
+
+
+
         <li class="divider"></li>
-        
-        
-    
+
+
+
         <li class="chapter " data-level="5.1" data-path="encoding.html">
-            
+
                 <a href="encoding.html">
-            
-                    
+
+
                     Encoding
-            
+
                 </a>
-            
 
-            
+
+
         </li>
-    
 
-    
+
+
 
     <li class="divider"></li>
 
@@ -6438,18 +6438,18 @@ exports[`HonKit snapshots: lexicon.html 1`] = `
 
 
                 </nav>
-            
-        
+
+
     </div>
 
     <div class="book-body">
-        
+
             <div class="body-inner">
-                
-                    
+
+
 
 <div class="book-header" role="navigation">
-    
+
 
     <!-- Title -->
     <h1>
@@ -6463,12 +6463,12 @@ exports[`HonKit snapshots: lexicon.html 1`] = `
 
                     <div class="page-wrapper" tabindex="-1" role="main">
                         <div class="page-inner">
-                            
+
 <div id="book-search-results">
     <div class="search-noresults">
-    
+
                                 <section class="normal markdown-section">
-                                
+
 
                                 <h1 id="glossary">Glossary</h1>
 <p>Allows you to specify terms and their respective definitions to be displayed as annotations. Based on those terms, <a href="GLOSSARY.html#honkit" class="glossary-term" title="Honkit is a command line tool for building beautiful books using GitHub/Git and Markdown (or AsciiDoc).">HonKit</a> will automatically build an index and highlight those terms in pages.</p>
@@ -6481,64 +6481,64 @@ With it&apos;s definition, this can contain bold text
 and all other kinds of inline markup ...
 </code></pre>
 
-                                
+
 <hr>
 <div class="btn-group btn-group-justified">
-    
+
     <a class="btn" href="config.html"><b>Previous:</b> Configuration</a>
-    
-    
+
+
     <a class="btn" href="languages.html"><b>Next:</b> Multi-Lingual</a>
-    
+
 </div>
 
                                 </section>
-                            
+
     </div>
     <div class="search-results">
         <div class="has-results">
-            
+
             <h1 class="search-results-title"><span class='search-results-count'></span> results matching "<span class='search-query'></span>"</h1>
             <ul class="search-results-list"></ul>
-            
+
         </div>
         <div class="no-results">
-            
+
             <h1 class="search-results-title">No results matching "<span class='search-query'></span>"</h1>
-            
+
         </div>
     </div>
 </div>
 
                         </div>
                     </div>
-                
+
             </div>
 
-            
-                
+
+
                 <a href="config.html" class="navigation navigation-prev " aria-label="Previous page: Configuration">
                     <i class="fa fa-angle-left"></i>
                 </a>
-                
-                
+
+
                 <a href="languages.html" class="navigation navigation-next " aria-label="Next page: Multi-Lingual">
                     <i class="fa fa-angle-right"></i>
                 </a>
-                
-            
-        
+
+
+
     </div>
 
     <script>
         var gitbook = gitbook || [];
         gitbook.push(function() {
-            
+
         });
     </script>
 </div>
 
-        
+
     <noscript>
         <style>
             .honkit-cloak {
@@ -6585,27 +6585,27 @@ and all other kinds of inline markup ...
     </script>
     <script src="gitbook/gitbook.js"></script>
     <script src="gitbook/theme.js"></script>
-    
-        
+
+
         <script src="gitbook/gitbook-plugin-search/search-engine.js"></script>
-        
-    
-        
+
+
+
         <script src="gitbook/gitbook-plugin-search/search.js"></script>
-        
-    
-        
+
+
+
         <script src="gitbook/gitbook-plugin-lunr/lunr.min.js"></script>
-        
-    
-        
+
+
+
         <script src="gitbook/gitbook-plugin-lunr/search-lunr.js"></script>
-        
-    
-        
+
+
+
         <script src="gitbook/gitbook-plugin-fontsettings/fontsettings.js"></script>
-        
-    
+
+
 
     </body>
 </html>
@@ -6631,50 +6631,50 @@ exports[`HonKit snapshots: pages.html 1`] = `
         <title>Pages and Summary · HonKit Documentation</title>
         <meta http-equiv="X-UA-Compatible" content="IE=edge" />
         <meta name="description" content="">
-        
-        
-        
-        
-    
+
+
+
+
+
     <link rel="stylesheet" href="gitbook/style.css">
 
-    
-            
-                
+
+
+
                 <link rel="stylesheet" href="gitbook/@honkit/honkit-plugin-highlight/website.css">
-                
-            
-                
+
+
+
                 <link rel="stylesheet" href="gitbook/gitbook-plugin-search/search.css">
-                
-            
-                
+
+
+
                 <link rel="stylesheet" href="gitbook/gitbook-plugin-fontsettings/website.css">
-                
-            
-        
 
-    
 
-    
-        
+
+
+
+
+
+
         <link rel="stylesheet" href="styles/website.css">
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
 
-        
-    
-    
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
     <meta name="HandheldFriendly" content="true"/>
     <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no">
     <meta name="apple-mobile-web-app-capable" content="yes">
@@ -6682,557 +6682,557 @@ exports[`HonKit snapshots: pages.html 1`] = `
     <link rel="apple-touch-icon-precomposed" sizes="152x152" href="gitbook/images/apple-touch-icon-precomposed-152.png">
     <link rel="shortcut icon" href="gitbook/images/favicon.ico" type="image/x-icon">
 
-    
+
     <link rel="next" href="config.html" />
-    
-    
+
+
     <link rel="prev" href="structure.html" />
-    
+
 
     </head>
     <body>
-        
+
 <div class="book honkit-cloak">
     <div class="book-summary">
-        
-            
+
+
 <div id="book-search-input" role="search">
     <input type="text" placeholder="Type to search" />
 </div>
 
-            
+
                 <nav role="navigation">
-                
+
 
 
 <ul class="summary">
-    
-    
 
-    
 
-    
-        
+
+
+
+
+
         <li class="header">Getting Started</li>
-        
-        
-    
+
+
+
         <li class="chapter " data-level="1.1" data-path="./">
-            
+
                 <a href="./">
-            
-                    
+
+
                     About this documentation
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="1.2" data-path="setup.html">
-            
+
                 <a href="setup.html">
-            
-                    
+
+
                     Installation and Setup
-            
+
                 </a>
-            
 
-            
+
+
         </li>
-    
 
-    
-        
+
+
+
         <li class="header">Your Content</li>
-        
-        
-    
+
+
+
         <li class="chapter " data-level="2.1" data-path="structure.html">
-            
+
                 <a href="structure.html">
-            
-                    
+
+
                     Directory structure
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter active" data-level="2.2" data-path="pages.html">
-            
+
                 <a href="pages.html">
-            
-                    
+
+
                     Pages and Summary
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.3" data-path="config.html">
-            
+
                 <a href="config.html">
-            
-                    
+
+
                     Configuration
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.4" data-path="lexicon.html">
-            
+
                 <a href="lexicon.html">
-            
-                    
+
+
                     Glossary
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.5" data-path="languages.html">
-            
+
                 <a href="languages.html">
-            
-                    
+
+
                     Multi-Lingual
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.6" data-path="syntax/markdown.html">
-            
+
                 <a href="syntax/markdown.html">
-            
-                    
+
+
                     Markdown
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
             <ul class="articles">
-                
-    
+
+
         <li class="chapter " data-level="2.6.1" data-path="syntax/markdown.html">
-            
+
                 <a href="syntax/markdown.html#headings">
-            
-                    
+
+
                     Headings
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.6.2" data-path="syntax/markdown.html">
-            
+
                 <a href="syntax/markdown.html#paragraphs">
-            
-                    
+
+
                     Paragraphs
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.6.3" data-path="syntax/markdown.html">
-            
+
                 <a href="syntax/markdown.html#lists">
-            
-                    
+
+
                     Lists
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.6.4" data-path="syntax/markdown.html">
-            
+
                 <a href="syntax/markdown.html#links">
-            
-                    
+
+
                     Links
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.6.5" data-path="syntax/markdown.html">
-            
+
                 <a href="syntax/markdown.html#images">
-            
-                    
+
+
                     Images
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.6.6" data-path="syntax/markdown.html">
-            
+
                 <a href="syntax/markdown.html#blockquotes">
-            
-                    
+
+
                     Blockquotes
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.6.7" data-path="syntax/markdown.html">
-            
+
                 <a href="syntax/markdown.html#tables">
-            
-                    
+
+
                     Tables
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.6.8" data-path="syntax/markdown.html">
-            
+
                 <a href="syntax/markdown.html#code">
-            
-                    
+
+
                     Code
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.6.9" data-path="syntax/markdown.html">
-            
+
                 <a href="syntax/markdown.html#html">
-            
-                    
+
+
                     HTML
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.6.10" data-path="syntax/markdown.html">
-            
+
                 <a href="syntax/markdown.html#footnotes">
-            
-                    
+
+
                     Footnotes
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
 
             </ul>
-            
+
         </li>
-    
+
         <li class="chapter " data-level="2.7" data-path="syntax/asciidoc.html">
-            
+
                 <a href="syntax/asciidoc.html">
-            
-                    
+
+
                     AsciiDoc
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.8" data-path="ebook.html">
-            
+
                 <a href="ebook.html">
-            
-                    
+
+
                     eBook and PDF
-            
+
                 </a>
-            
 
-            
+
+
         </li>
-    
 
-    
-        
+
+
+
         <li class="header">Customization</li>
-        
-        
-    
+
+
+
         <li class="chapter " data-level="3.1" data-path="templating/">
-            
+
                 <a href="templating/">
-            
-                    
+
+
                     Templating
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
             <ul class="articles">
-                
-    
+
+
         <li class="chapter " data-level="3.1.1" data-path="templating/conrefs.html">
-            
+
                 <a href="templating/conrefs.html">
-            
-                    
+
+
                     Content References
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="3.1.2" data-path="templating/variables.html">
-            
+
                 <a href="templating/variables.html">
-            
-                    
+
+
                     Variables
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="3.1.3" data-path="templating/builtin.html">
-            
+
                 <a href="templating/builtin.html">
-            
-                    
+
+
                     Builtin
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
 
             </ul>
-            
+
         </li>
-    
+
         <li class="chapter " data-level="3.2" data-path="plugins/">
-            
+
                 <a href="plugins/">
-            
-                    
+
+
                     Plugins
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
             <ul class="articles">
-                
-    
+
+
         <li class="chapter " data-level="3.2.1" data-path="plugins/create.html">
-            
+
                 <a href="plugins/create.html">
-            
-                    
+
+
                     Create a plugin
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="3.2.2" data-path="plugins/hooks.html">
-            
+
                 <a href="plugins/hooks.html">
-            
-                    
+
+
                     Hooks
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="3.2.3" data-path="plugins/blocks.html">
-            
+
                 <a href="plugins/blocks.html">
-            
-                    
+
+
                     Blocks
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="3.2.4" data-path="plugins/filters.html">
-            
+
                 <a href="plugins/filters.html">
-            
-                    
+
+
                     Filters
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="3.2.5" data-path="plugins/api.html">
-            
+
                 <a href="plugins/api.html">
-            
-                    
+
+
                     API & Context
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="3.2.6" data-path="plugins/testing.html">
-            
-                <a href="plugins/testing.html">
-            
-                    
-                    Test your plugin
-            
-                </a>
-            
 
-            
+                <a href="plugins/testing.html">
+
+
+                    Test your plugin
+
+                </a>
+
+
+
         </li>
-    
+
 
             </ul>
-            
+
         </li>
-    
+
         <li class="chapter " data-level="3.3" data-path="themes/">
-            
+
                 <a href="themes/">
-            
-                    
+
+
                     Theming
-            
+
                 </a>
-            
 
-            
+
+
         </li>
-    
 
-    
-        
+
+
+
         <li class="divider"></li>
-        
-        
-    
+
+
+
         <li class="chapter " data-level="4.1" data-path="faq.html">
-            
+
                 <a href="faq.html">
-            
-                    
+
+
                     FAQ
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="4.2" data-path="examples.md">
-            
+
                 <span>
-            
-                    
+
+
                     Examples
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="4.3" >
-            
+
                 <a target="_blank" href="https://github.com/honkit/honkit/blob/master/CHANGELOG.md">
-            
-                    
+
+
                     Release notes
-            
+
                 </a>
-            
 
-            
+
+
         </li>
-    
 
-    
-        
+
+
+
         <li class="divider"></li>
-        
-        
-    
+
+
+
         <li class="chapter " data-level="5.1" data-path="encoding.html">
-            
+
                 <a href="encoding.html">
-            
-                    
+
+
                     Encoding
-            
+
                 </a>
-            
 
-            
+
+
         </li>
-    
 
-    
+
+
 
     <li class="divider"></li>
 
@@ -7245,18 +7245,18 @@ exports[`HonKit snapshots: pages.html 1`] = `
 
 
                 </nav>
-            
-        
+
+
     </div>
 
     <div class="book-body">
-        
+
             <div class="body-inner">
-                
-                    
+
+
 
 <div class="book-header" role="navigation">
-    
+
 
     <!-- Title -->
     <h1>
@@ -7270,12 +7270,12 @@ exports[`HonKit snapshots: pages.html 1`] = `
 
                     <div class="page-wrapper" tabindex="-1" role="main">
                         <div class="page-inner">
-                            
+
 <div id="book-search-results">
     <div class="search-noresults">
-    
+
                                 <section class="normal markdown-section">
-                                
+
 
                                 <h1 id="pages-and-summary">Pages and Summary</h1>
 <h3 id="summary">Summary</h3>
@@ -7352,64 +7352,64 @@ Markdown will dictates <span class="hljs-emphasis">_most_</span> of your <span c
 </code></pre>
 <p>The front matter can define variables of your own, they will be added to the <a href="templating/variables.html">page variable</a> so you can use them in your <a href="GLOSSARY.html#templating" class="glossary-term" title="HonKit uses the Nunjucks templating language to process pages and theme&apos;s templates.">templating</a>.</p>
 
-                                
+
 <hr>
 <div class="btn-group btn-group-justified">
-    
+
     <a class="btn" href="structure.html"><b>Previous:</b> Directory structure</a>
-    
-    
+
+
     <a class="btn" href="config.html"><b>Next:</b> Configuration</a>
-    
+
 </div>
 
                                 </section>
-                            
+
     </div>
     <div class="search-results">
         <div class="has-results">
-            
+
             <h1 class="search-results-title"><span class='search-results-count'></span> results matching "<span class='search-query'></span>"</h1>
             <ul class="search-results-list"></ul>
-            
+
         </div>
         <div class="no-results">
-            
+
             <h1 class="search-results-title">No results matching "<span class='search-query'></span>"</h1>
-            
+
         </div>
     </div>
 </div>
 
                         </div>
                     </div>
-                
+
             </div>
 
-            
-                
+
+
                 <a href="structure.html" class="navigation navigation-prev " aria-label="Previous page: Directory structure">
                     <i class="fa fa-angle-left"></i>
                 </a>
-                
-                
+
+
                 <a href="config.html" class="navigation navigation-next " aria-label="Next page: Configuration">
                     <i class="fa fa-angle-right"></i>
                 </a>
-                
-            
-        
+
+
+
     </div>
 
     <script>
         var gitbook = gitbook || [];
         gitbook.push(function() {
-            
+
         });
     </script>
 </div>
 
-        
+
     <noscript>
         <style>
             .honkit-cloak {
@@ -7456,27 +7456,27 @@ Markdown will dictates <span class="hljs-emphasis">_most_</span> of your <span c
     </script>
     <script src="gitbook/gitbook.js"></script>
     <script src="gitbook/theme.js"></script>
-    
-        
+
+
         <script src="gitbook/gitbook-plugin-search/search-engine.js"></script>
-        
-    
-        
+
+
+
         <script src="gitbook/gitbook-plugin-search/search.js"></script>
-        
-    
-        
+
+
+
         <script src="gitbook/gitbook-plugin-lunr/lunr.min.js"></script>
-        
-    
-        
+
+
+
         <script src="gitbook/gitbook-plugin-lunr/search-lunr.js"></script>
-        
-    
-        
+
+
+
         <script src="gitbook/gitbook-plugin-fontsettings/fontsettings.js"></script>
-        
-    
+
+
 
     </body>
 </html>
@@ -7502,50 +7502,50 @@ exports[`HonKit snapshots: plugins/api.html 1`] = `
         <title>API & Context · HonKit Documentation</title>
         <meta http-equiv="X-UA-Compatible" content="IE=edge" />
         <meta name="description" content="">
-        
-        
-        
-        
-    
+
+
+
+
+
     <link rel="stylesheet" href="../gitbook/style.css">
 
-    
-            
-                
+
+
+
                 <link rel="stylesheet" href="../gitbook/@honkit/honkit-plugin-highlight/website.css">
-                
-            
-                
+
+
+
                 <link rel="stylesheet" href="../gitbook/gitbook-plugin-search/search.css">
-                
-            
-                
+
+
+
                 <link rel="stylesheet" href="../gitbook/gitbook-plugin-fontsettings/website.css">
-                
-            
-        
 
-    
 
-    
-        
+
+
+
+
+
+
         <link rel="stylesheet" href="../styles/website.css">
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
 
-        
-    
-    
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
     <meta name="HandheldFriendly" content="true"/>
     <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no">
     <meta name="apple-mobile-web-app-capable" content="yes">
@@ -7553,557 +7553,557 @@ exports[`HonKit snapshots: plugins/api.html 1`] = `
     <link rel="apple-touch-icon-precomposed" sizes="152x152" href="../gitbook/images/apple-touch-icon-precomposed-152.png">
     <link rel="shortcut icon" href="../gitbook/images/favicon.ico" type="image/x-icon">
 
-    
+
     <link rel="next" href="testing.html" />
-    
-    
+
+
     <link rel="prev" href="filters.html" />
-    
+
 
     </head>
     <body>
-        
+
 <div class="book honkit-cloak">
     <div class="book-summary">
-        
-            
+
+
 <div id="book-search-input" role="search">
     <input type="text" placeholder="Type to search" />
 </div>
 
-            
+
                 <nav role="navigation">
-                
+
 
 
 <ul class="summary">
-    
-    
 
-    
 
-    
-        
+
+
+
+
+
         <li class="header">Getting Started</li>
-        
-        
-    
+
+
+
         <li class="chapter " data-level="1.1" data-path="../">
-            
+
                 <a href="../">
-            
-                    
+
+
                     About this documentation
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="1.2" data-path="../setup.html">
-            
+
                 <a href="../setup.html">
-            
-                    
+
+
                     Installation and Setup
-            
+
                 </a>
-            
 
-            
+
+
         </li>
-    
 
-    
-        
+
+
+
         <li class="header">Your Content</li>
-        
-        
-    
+
+
+
         <li class="chapter " data-level="2.1" data-path="../structure.html">
-            
+
                 <a href="../structure.html">
-            
-                    
+
+
                     Directory structure
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.2" data-path="../pages.html">
-            
+
                 <a href="../pages.html">
-            
-                    
+
+
                     Pages and Summary
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.3" data-path="../config.html">
-            
+
                 <a href="../config.html">
-            
-                    
+
+
                     Configuration
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.4" data-path="../lexicon.html">
-            
+
                 <a href="../lexicon.html">
-            
-                    
+
+
                     Glossary
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.5" data-path="../languages.html">
-            
+
                 <a href="../languages.html">
-            
-                    
+
+
                     Multi-Lingual
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.6" data-path="../syntax/markdown.html">
-            
+
                 <a href="../syntax/markdown.html">
-            
-                    
+
+
                     Markdown
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
             <ul class="articles">
-                
-    
+
+
         <li class="chapter " data-level="2.6.1" data-path="../syntax/markdown.html">
-            
+
                 <a href="../syntax/markdown.html#headings">
-            
-                    
+
+
                     Headings
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.6.2" data-path="../syntax/markdown.html">
-            
+
                 <a href="../syntax/markdown.html#paragraphs">
-            
-                    
+
+
                     Paragraphs
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.6.3" data-path="../syntax/markdown.html">
-            
+
                 <a href="../syntax/markdown.html#lists">
-            
-                    
+
+
                     Lists
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.6.4" data-path="../syntax/markdown.html">
-            
+
                 <a href="../syntax/markdown.html#links">
-            
-                    
+
+
                     Links
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.6.5" data-path="../syntax/markdown.html">
-            
+
                 <a href="../syntax/markdown.html#images">
-            
-                    
+
+
                     Images
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.6.6" data-path="../syntax/markdown.html">
-            
+
                 <a href="../syntax/markdown.html#blockquotes">
-            
-                    
+
+
                     Blockquotes
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.6.7" data-path="../syntax/markdown.html">
-            
+
                 <a href="../syntax/markdown.html#tables">
-            
-                    
+
+
                     Tables
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.6.8" data-path="../syntax/markdown.html">
-            
+
                 <a href="../syntax/markdown.html#code">
-            
-                    
+
+
                     Code
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.6.9" data-path="../syntax/markdown.html">
-            
+
                 <a href="../syntax/markdown.html#html">
-            
-                    
+
+
                     HTML
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.6.10" data-path="../syntax/markdown.html">
-            
+
                 <a href="../syntax/markdown.html#footnotes">
-            
-                    
+
+
                     Footnotes
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
 
             </ul>
-            
+
         </li>
-    
+
         <li class="chapter " data-level="2.7" data-path="../syntax/asciidoc.html">
-            
+
                 <a href="../syntax/asciidoc.html">
-            
-                    
+
+
                     AsciiDoc
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.8" data-path="../ebook.html">
-            
+
                 <a href="../ebook.html">
-            
-                    
+
+
                     eBook and PDF
-            
+
                 </a>
-            
 
-            
+
+
         </li>
-    
 
-    
-        
+
+
+
         <li class="header">Customization</li>
-        
-        
-    
+
+
+
         <li class="chapter " data-level="3.1" data-path="../templating/">
-            
+
                 <a href="../templating/">
-            
-                    
+
+
                     Templating
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
             <ul class="articles">
-                
-    
+
+
         <li class="chapter " data-level="3.1.1" data-path="../templating/conrefs.html">
-            
+
                 <a href="../templating/conrefs.html">
-            
-                    
+
+
                     Content References
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="3.1.2" data-path="../templating/variables.html">
-            
+
                 <a href="../templating/variables.html">
-            
-                    
+
+
                     Variables
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="3.1.3" data-path="../templating/builtin.html">
-            
+
                 <a href="../templating/builtin.html">
-            
-                    
+
+
                     Builtin
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
 
             </ul>
-            
+
         </li>
-    
+
         <li class="chapter " data-level="3.2" data-path="./">
-            
+
                 <a href="./">
-            
-                    
+
+
                     Plugins
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
             <ul class="articles">
-                
-    
+
+
         <li class="chapter " data-level="3.2.1" data-path="create.html">
-            
+
                 <a href="create.html">
-            
-                    
+
+
                     Create a plugin
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="3.2.2" data-path="hooks.html">
-            
+
                 <a href="hooks.html">
-            
-                    
+
+
                     Hooks
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="3.2.3" data-path="blocks.html">
-            
+
                 <a href="blocks.html">
-            
-                    
+
+
                     Blocks
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="3.2.4" data-path="filters.html">
-            
+
                 <a href="filters.html">
-            
-                    
+
+
                     Filters
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter active" data-level="3.2.5" data-path="api.html">
-            
+
                 <a href="api.html">
-            
-                    
+
+
                     API & Context
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="3.2.6" data-path="testing.html">
-            
-                <a href="testing.html">
-            
-                    
-                    Test your plugin
-            
-                </a>
-            
 
-            
+                <a href="testing.html">
+
+
+                    Test your plugin
+
+                </a>
+
+
+
         </li>
-    
+
 
             </ul>
-            
+
         </li>
-    
+
         <li class="chapter " data-level="3.3" data-path="../themes/">
-            
+
                 <a href="../themes/">
-            
-                    
+
+
                     Theming
-            
+
                 </a>
-            
 
-            
+
+
         </li>
-    
 
-    
-        
+
+
+
         <li class="divider"></li>
-        
-        
-    
+
+
+
         <li class="chapter " data-level="4.1" data-path="../faq.html">
-            
+
                 <a href="../faq.html">
-            
-                    
+
+
                     FAQ
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="4.2" data-path="../examples.md">
-            
+
                 <span>
-            
-                    
+
+
                     Examples
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="4.3" >
-            
+
                 <a target="_blank" href="https://github.com/honkit/honkit/blob/master/CHANGELOG.md">
-            
-                    
+
+
                     Release notes
-            
+
                 </a>
-            
 
-            
+
+
         </li>
-    
 
-    
-        
+
+
+
         <li class="divider"></li>
-        
-        
-    
+
+
+
         <li class="chapter " data-level="5.1" data-path="../encoding.html">
-            
+
                 <a href="../encoding.html">
-            
-                    
+
+
                     Encoding
-            
+
                 </a>
-            
 
-            
+
+
         </li>
-    
 
-    
+
+
 
     <li class="divider"></li>
 
@@ -8116,18 +8116,18 @@ exports[`HonKit snapshots: plugins/api.html 1`] = `
 
 
                 </nav>
-            
-        
+
+
     </div>
 
     <div class="book-body">
-        
+
             <div class="body-inner">
-                
-                    
+
+
 
 <div class="book-header" role="navigation">
-    
+
 
     <!-- Title -->
     <h1>
@@ -8141,12 +8141,12 @@ exports[`HonKit snapshots: plugins/api.html 1`] = `
 
                     <div class="page-wrapper" tabindex="-1" role="main">
                         <div class="page-inner">
-                            
+
 <div id="book-search-results">
     <div class="search-noresults">
-    
+
                                 <section class="normal markdown-section">
-                                
+
 
                                 <h1 id="context-and-apis">Context and APIs</h1>
 <p>HonKits provides different APIs and contexts to <a href="../GLOSSARY.html#plugins" class="glossary-term" title="Plugins are the best way to extend HonKit functionalities (ebook and website).">plugins</a>. These APIs can vary according to the <a href="../GLOSSARY.html#honkit" class="glossary-term" title="Honkit is a command line tool for building beautiful books using GitHub/Git and Markdown (or AsciiDoc).">HonKit</a> version being used, your plugin should specify the <code>engines.gitbook</code> field in <code>package.json</code> accordingly.</p>
@@ -8226,64 +8226,64 @@ page.type (<span class="hljs-string">&apos;markdown&apos;</span> or <span class=
 <h4 id="context-for-hooks">Context for Hooks</h4>
 <p>Hooks only have access to the <code>&lt;Book&gt;</code> instance using <code>this.book</code>.</p>
 
-                                
+
 <hr>
 <div class="btn-group btn-group-justified">
-    
+
     <a class="btn" href="filters.html"><b>Previous:</b> Filters</a>
-    
-    
+
+
     <a class="btn" href="testing.html"><b>Next:</b> Test your plugin</a>
-    
+
 </div>
 
                                 </section>
-                            
+
     </div>
     <div class="search-results">
         <div class="has-results">
-            
+
             <h1 class="search-results-title"><span class='search-results-count'></span> results matching "<span class='search-query'></span>"</h1>
             <ul class="search-results-list"></ul>
-            
+
         </div>
         <div class="no-results">
-            
+
             <h1 class="search-results-title">No results matching "<span class='search-query'></span>"</h1>
-            
+
         </div>
     </div>
 </div>
 
                         </div>
                     </div>
-                
+
             </div>
 
-            
-                
+
+
                 <a href="filters.html" class="navigation navigation-prev " aria-label="Previous page: Filters">
                     <i class="fa fa-angle-left"></i>
                 </a>
-                
-                
+
+
                 <a href="testing.html" class="navigation navigation-next " aria-label="Next page: Test your plugin">
                     <i class="fa fa-angle-right"></i>
                 </a>
-                
-            
-        
+
+
+
     </div>
 
     <script>
         var gitbook = gitbook || [];
         gitbook.push(function() {
-            
+
         });
     </script>
 </div>
 
-        
+
     <noscript>
         <style>
             .honkit-cloak {
@@ -8330,27 +8330,27 @@ page.type (<span class="hljs-string">&apos;markdown&apos;</span> or <span class=
     </script>
     <script src="../gitbook/gitbook.js"></script>
     <script src="../gitbook/theme.js"></script>
-    
-        
+
+
         <script src="../gitbook/gitbook-plugin-search/search-engine.js"></script>
-        
-    
-        
+
+
+
         <script src="../gitbook/gitbook-plugin-search/search.js"></script>
-        
-    
-        
+
+
+
         <script src="../gitbook/gitbook-plugin-lunr/lunr.min.js"></script>
-        
-    
-        
+
+
+
         <script src="../gitbook/gitbook-plugin-lunr/search-lunr.js"></script>
-        
-    
-        
+
+
+
         <script src="../gitbook/gitbook-plugin-fontsettings/fontsettings.js"></script>
-        
-    
+
+
 
     </body>
 </html>
@@ -8376,50 +8376,50 @@ exports[`HonKit snapshots: plugins/blocks.html 1`] = `
         <title>Blocks · HonKit Documentation</title>
         <meta http-equiv="X-UA-Compatible" content="IE=edge" />
         <meta name="description" content="">
-        
-        
-        
-        
-    
+
+
+
+
+
     <link rel="stylesheet" href="../gitbook/style.css">
 
-    
-            
-                
+
+
+
                 <link rel="stylesheet" href="../gitbook/@honkit/honkit-plugin-highlight/website.css">
-                
-            
-                
+
+
+
                 <link rel="stylesheet" href="../gitbook/gitbook-plugin-search/search.css">
-                
-            
-                
+
+
+
                 <link rel="stylesheet" href="../gitbook/gitbook-plugin-fontsettings/website.css">
-                
-            
-        
 
-    
 
-    
-        
+
+
+
+
+
+
         <link rel="stylesheet" href="../styles/website.css">
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
 
-        
-    
-    
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
     <meta name="HandheldFriendly" content="true"/>
     <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no">
     <meta name="apple-mobile-web-app-capable" content="yes">
@@ -8427,557 +8427,557 @@ exports[`HonKit snapshots: plugins/blocks.html 1`] = `
     <link rel="apple-touch-icon-precomposed" sizes="152x152" href="../gitbook/images/apple-touch-icon-precomposed-152.png">
     <link rel="shortcut icon" href="../gitbook/images/favicon.ico" type="image/x-icon">
 
-    
+
     <link rel="next" href="filters.html" />
-    
-    
+
+
     <link rel="prev" href="hooks.html" />
-    
+
 
     </head>
     <body>
-        
+
 <div class="book honkit-cloak">
     <div class="book-summary">
-        
-            
+
+
 <div id="book-search-input" role="search">
     <input type="text" placeholder="Type to search" />
 </div>
 
-            
+
                 <nav role="navigation">
-                
+
 
 
 <ul class="summary">
-    
-    
 
-    
 
-    
-        
+
+
+
+
+
         <li class="header">Getting Started</li>
-        
-        
-    
+
+
+
         <li class="chapter " data-level="1.1" data-path="../">
-            
+
                 <a href="../">
-            
-                    
+
+
                     About this documentation
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="1.2" data-path="../setup.html">
-            
+
                 <a href="../setup.html">
-            
-                    
+
+
                     Installation and Setup
-            
+
                 </a>
-            
 
-            
+
+
         </li>
-    
 
-    
-        
+
+
+
         <li class="header">Your Content</li>
-        
-        
-    
+
+
+
         <li class="chapter " data-level="2.1" data-path="../structure.html">
-            
+
                 <a href="../structure.html">
-            
-                    
+
+
                     Directory structure
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.2" data-path="../pages.html">
-            
+
                 <a href="../pages.html">
-            
-                    
+
+
                     Pages and Summary
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.3" data-path="../config.html">
-            
+
                 <a href="../config.html">
-            
-                    
+
+
                     Configuration
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.4" data-path="../lexicon.html">
-            
+
                 <a href="../lexicon.html">
-            
-                    
+
+
                     Glossary
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.5" data-path="../languages.html">
-            
+
                 <a href="../languages.html">
-            
-                    
+
+
                     Multi-Lingual
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.6" data-path="../syntax/markdown.html">
-            
+
                 <a href="../syntax/markdown.html">
-            
-                    
+
+
                     Markdown
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
             <ul class="articles">
-                
-    
+
+
         <li class="chapter " data-level="2.6.1" data-path="../syntax/markdown.html">
-            
+
                 <a href="../syntax/markdown.html#headings">
-            
-                    
+
+
                     Headings
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.6.2" data-path="../syntax/markdown.html">
-            
+
                 <a href="../syntax/markdown.html#paragraphs">
-            
-                    
+
+
                     Paragraphs
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.6.3" data-path="../syntax/markdown.html">
-            
+
                 <a href="../syntax/markdown.html#lists">
-            
-                    
+
+
                     Lists
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.6.4" data-path="../syntax/markdown.html">
-            
+
                 <a href="../syntax/markdown.html#links">
-            
-                    
+
+
                     Links
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.6.5" data-path="../syntax/markdown.html">
-            
+
                 <a href="../syntax/markdown.html#images">
-            
-                    
+
+
                     Images
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.6.6" data-path="../syntax/markdown.html">
-            
+
                 <a href="../syntax/markdown.html#blockquotes">
-            
-                    
+
+
                     Blockquotes
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.6.7" data-path="../syntax/markdown.html">
-            
+
                 <a href="../syntax/markdown.html#tables">
-            
-                    
+
+
                     Tables
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.6.8" data-path="../syntax/markdown.html">
-            
+
                 <a href="../syntax/markdown.html#code">
-            
-                    
+
+
                     Code
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.6.9" data-path="../syntax/markdown.html">
-            
+
                 <a href="../syntax/markdown.html#html">
-            
-                    
+
+
                     HTML
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.6.10" data-path="../syntax/markdown.html">
-            
+
                 <a href="../syntax/markdown.html#footnotes">
-            
-                    
+
+
                     Footnotes
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
 
             </ul>
-            
+
         </li>
-    
+
         <li class="chapter " data-level="2.7" data-path="../syntax/asciidoc.html">
-            
+
                 <a href="../syntax/asciidoc.html">
-            
-                    
+
+
                     AsciiDoc
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.8" data-path="../ebook.html">
-            
+
                 <a href="../ebook.html">
-            
-                    
+
+
                     eBook and PDF
-            
+
                 </a>
-            
 
-            
+
+
         </li>
-    
 
-    
-        
+
+
+
         <li class="header">Customization</li>
-        
-        
-    
+
+
+
         <li class="chapter " data-level="3.1" data-path="../templating/">
-            
+
                 <a href="../templating/">
-            
-                    
+
+
                     Templating
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
             <ul class="articles">
-                
-    
+
+
         <li class="chapter " data-level="3.1.1" data-path="../templating/conrefs.html">
-            
+
                 <a href="../templating/conrefs.html">
-            
-                    
+
+
                     Content References
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="3.1.2" data-path="../templating/variables.html">
-            
+
                 <a href="../templating/variables.html">
-            
-                    
+
+
                     Variables
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="3.1.3" data-path="../templating/builtin.html">
-            
+
                 <a href="../templating/builtin.html">
-            
-                    
+
+
                     Builtin
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
 
             </ul>
-            
+
         </li>
-    
+
         <li class="chapter " data-level="3.2" data-path="./">
-            
+
                 <a href="./">
-            
-                    
+
+
                     Plugins
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
             <ul class="articles">
-                
-    
+
+
         <li class="chapter " data-level="3.2.1" data-path="create.html">
-            
+
                 <a href="create.html">
-            
-                    
+
+
                     Create a plugin
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="3.2.2" data-path="hooks.html">
-            
+
                 <a href="hooks.html">
-            
-                    
+
+
                     Hooks
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter active" data-level="3.2.3" data-path="blocks.html">
-            
+
                 <a href="blocks.html">
-            
-                    
+
+
                     Blocks
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="3.2.4" data-path="filters.html">
-            
+
                 <a href="filters.html">
-            
-                    
+
+
                     Filters
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="3.2.5" data-path="api.html">
-            
+
                 <a href="api.html">
-            
-                    
+
+
                     API & Context
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="3.2.6" data-path="testing.html">
-            
-                <a href="testing.html">
-            
-                    
-                    Test your plugin
-            
-                </a>
-            
 
-            
+                <a href="testing.html">
+
+
+                    Test your plugin
+
+                </a>
+
+
+
         </li>
-    
+
 
             </ul>
-            
+
         </li>
-    
+
         <li class="chapter " data-level="3.3" data-path="../themes/">
-            
+
                 <a href="../themes/">
-            
-                    
+
+
                     Theming
-            
+
                 </a>
-            
 
-            
+
+
         </li>
-    
 
-    
-        
+
+
+
         <li class="divider"></li>
-        
-        
-    
+
+
+
         <li class="chapter " data-level="4.1" data-path="../faq.html">
-            
+
                 <a href="../faq.html">
-            
-                    
+
+
                     FAQ
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="4.2" data-path="../examples.md">
-            
+
                 <span>
-            
-                    
+
+
                     Examples
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="4.3" >
-            
+
                 <a target="_blank" href="https://github.com/honkit/honkit/blob/master/CHANGELOG.md">
-            
-                    
+
+
                     Release notes
-            
+
                 </a>
-            
 
-            
+
+
         </li>
-    
 
-    
-        
+
+
+
         <li class="divider"></li>
-        
-        
-    
+
+
+
         <li class="chapter " data-level="5.1" data-path="../encoding.html">
-            
+
                 <a href="../encoding.html">
-            
-                    
+
+
                     Encoding
-            
+
                 </a>
-            
 
-            
+
+
         </li>
-    
 
-    
+
+
 
     <li class="divider"></li>
 
@@ -8990,18 +8990,18 @@ exports[`HonKit snapshots: plugins/blocks.html 1`] = `
 
 
                 </nav>
-            
-        
+
+
     </div>
 
     <div class="book-body">
-        
+
             <div class="body-inner">
-                
-                    
+
+
 
 <div class="book-header" role="navigation">
-    
+
 
     <!-- Title -->
     <h1>
@@ -9015,12 +9015,12 @@ exports[`HonKit snapshots: plugins/blocks.html 1`] = `
 
                     <div class="page-wrapper" tabindex="-1" role="main">
                         <div class="page-inner">
-                            
+
 <div id="book-search-results">
     <div class="search-noresults">
-    
+
                                 <section class="normal markdown-section">
-                                
+
 
                                 <h1 id="extend-blocks">Extend Blocks</h1>
 <p>Extending <a href="../GLOSSARY.html#templating" class="glossary-term" title="HonKit uses the Nunjucks templating language to process pages and theme&apos;s templates.">templating</a> blocks is the best way to provide extra functionalities to authors.</p>
@@ -9065,64 +9065,64 @@ This is the body of the block.
     Body of sub-block 1
 {% endmyTag %}
 </code></pre>
-                                
+
 <hr>
 <div class="btn-group btn-group-justified">
-    
+
     <a class="btn" href="hooks.html"><b>Previous:</b> Hooks</a>
-    
-    
+
+
     <a class="btn" href="filters.html"><b>Next:</b> Filters</a>
-    
+
 </div>
 
                                 </section>
-                            
+
     </div>
     <div class="search-results">
         <div class="has-results">
-            
+
             <h1 class="search-results-title"><span class='search-results-count'></span> results matching "<span class='search-query'></span>"</h1>
             <ul class="search-results-list"></ul>
-            
+
         </div>
         <div class="no-results">
-            
+
             <h1 class="search-results-title">No results matching "<span class='search-query'></span>"</h1>
-            
+
         </div>
     </div>
 </div>
 
                         </div>
                     </div>
-                
+
             </div>
 
-            
-                
+
+
                 <a href="hooks.html" class="navigation navigation-prev " aria-label="Previous page: Hooks">
                     <i class="fa fa-angle-left"></i>
                 </a>
-                
-                
+
+
                 <a href="filters.html" class="navigation navigation-next " aria-label="Next page: Filters">
                     <i class="fa fa-angle-right"></i>
                 </a>
-                
-            
-        
+
+
+
     </div>
 
     <script>
         var gitbook = gitbook || [];
         gitbook.push(function() {
-            
+
         });
     </script>
 </div>
 
-        
+
     <noscript>
         <style>
             .honkit-cloak {
@@ -9169,27 +9169,27 @@ This is the body of the block.
     </script>
     <script src="../gitbook/gitbook.js"></script>
     <script src="../gitbook/theme.js"></script>
-    
-        
+
+
         <script src="../gitbook/gitbook-plugin-search/search-engine.js"></script>
-        
-    
-        
+
+
+
         <script src="../gitbook/gitbook-plugin-search/search.js"></script>
-        
-    
-        
+
+
+
         <script src="../gitbook/gitbook-plugin-lunr/lunr.min.js"></script>
-        
-    
-        
+
+
+
         <script src="../gitbook/gitbook-plugin-lunr/search-lunr.js"></script>
-        
-    
-        
+
+
+
         <script src="../gitbook/gitbook-plugin-fontsettings/fontsettings.js"></script>
-        
-    
+
+
 
     </body>
 </html>
@@ -9215,50 +9215,50 @@ exports[`HonKit snapshots: plugins/create.html 1`] = `
         <title>Create a plugin · HonKit Documentation</title>
         <meta http-equiv="X-UA-Compatible" content="IE=edge" />
         <meta name="description" content="">
-        
-        
-        
-        
-    
+
+
+
+
+
     <link rel="stylesheet" href="../gitbook/style.css">
 
-    
-            
-                
+
+
+
                 <link rel="stylesheet" href="../gitbook/@honkit/honkit-plugin-highlight/website.css">
-                
-            
-                
+
+
+
                 <link rel="stylesheet" href="../gitbook/gitbook-plugin-search/search.css">
-                
-            
-                
+
+
+
                 <link rel="stylesheet" href="../gitbook/gitbook-plugin-fontsettings/website.css">
-                
-            
-        
 
-    
 
-    
-        
+
+
+
+
+
+
         <link rel="stylesheet" href="../styles/website.css">
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
 
-        
-    
-    
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
     <meta name="HandheldFriendly" content="true"/>
     <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no">
     <meta name="apple-mobile-web-app-capable" content="yes">
@@ -9266,557 +9266,557 @@ exports[`HonKit snapshots: plugins/create.html 1`] = `
     <link rel="apple-touch-icon-precomposed" sizes="152x152" href="../gitbook/images/apple-touch-icon-precomposed-152.png">
     <link rel="shortcut icon" href="../gitbook/images/favicon.ico" type="image/x-icon">
 
-    
+
     <link rel="next" href="hooks.html" />
-    
-    
+
+
     <link rel="prev" href="./" />
-    
+
 
     </head>
     <body>
-        
+
 <div class="book honkit-cloak">
     <div class="book-summary">
-        
-            
+
+
 <div id="book-search-input" role="search">
     <input type="text" placeholder="Type to search" />
 </div>
 
-            
+
                 <nav role="navigation">
-                
+
 
 
 <ul class="summary">
-    
-    
 
-    
 
-    
-        
+
+
+
+
+
         <li class="header">Getting Started</li>
-        
-        
-    
+
+
+
         <li class="chapter " data-level="1.1" data-path="../">
-            
+
                 <a href="../">
-            
-                    
+
+
                     About this documentation
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="1.2" data-path="../setup.html">
-            
+
                 <a href="../setup.html">
-            
-                    
+
+
                     Installation and Setup
-            
+
                 </a>
-            
 
-            
+
+
         </li>
-    
 
-    
-        
+
+
+
         <li class="header">Your Content</li>
-        
-        
-    
+
+
+
         <li class="chapter " data-level="2.1" data-path="../structure.html">
-            
+
                 <a href="../structure.html">
-            
-                    
+
+
                     Directory structure
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.2" data-path="../pages.html">
-            
+
                 <a href="../pages.html">
-            
-                    
+
+
                     Pages and Summary
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.3" data-path="../config.html">
-            
+
                 <a href="../config.html">
-            
-                    
+
+
                     Configuration
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.4" data-path="../lexicon.html">
-            
+
                 <a href="../lexicon.html">
-            
-                    
+
+
                     Glossary
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.5" data-path="../languages.html">
-            
+
                 <a href="../languages.html">
-            
-                    
+
+
                     Multi-Lingual
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.6" data-path="../syntax/markdown.html">
-            
+
                 <a href="../syntax/markdown.html">
-            
-                    
+
+
                     Markdown
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
             <ul class="articles">
-                
-    
+
+
         <li class="chapter " data-level="2.6.1" data-path="../syntax/markdown.html">
-            
+
                 <a href="../syntax/markdown.html#headings">
-            
-                    
+
+
                     Headings
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.6.2" data-path="../syntax/markdown.html">
-            
+
                 <a href="../syntax/markdown.html#paragraphs">
-            
-                    
+
+
                     Paragraphs
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.6.3" data-path="../syntax/markdown.html">
-            
+
                 <a href="../syntax/markdown.html#lists">
-            
-                    
+
+
                     Lists
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.6.4" data-path="../syntax/markdown.html">
-            
+
                 <a href="../syntax/markdown.html#links">
-            
-                    
+
+
                     Links
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.6.5" data-path="../syntax/markdown.html">
-            
+
                 <a href="../syntax/markdown.html#images">
-            
-                    
+
+
                     Images
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.6.6" data-path="../syntax/markdown.html">
-            
+
                 <a href="../syntax/markdown.html#blockquotes">
-            
-                    
+
+
                     Blockquotes
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.6.7" data-path="../syntax/markdown.html">
-            
+
                 <a href="../syntax/markdown.html#tables">
-            
-                    
+
+
                     Tables
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.6.8" data-path="../syntax/markdown.html">
-            
+
                 <a href="../syntax/markdown.html#code">
-            
-                    
+
+
                     Code
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.6.9" data-path="../syntax/markdown.html">
-            
+
                 <a href="../syntax/markdown.html#html">
-            
-                    
+
+
                     HTML
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.6.10" data-path="../syntax/markdown.html">
-            
+
                 <a href="../syntax/markdown.html#footnotes">
-            
-                    
+
+
                     Footnotes
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
 
             </ul>
-            
+
         </li>
-    
+
         <li class="chapter " data-level="2.7" data-path="../syntax/asciidoc.html">
-            
+
                 <a href="../syntax/asciidoc.html">
-            
-                    
+
+
                     AsciiDoc
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.8" data-path="../ebook.html">
-            
+
                 <a href="../ebook.html">
-            
-                    
+
+
                     eBook and PDF
-            
+
                 </a>
-            
 
-            
+
+
         </li>
-    
 
-    
-        
+
+
+
         <li class="header">Customization</li>
-        
-        
-    
+
+
+
         <li class="chapter " data-level="3.1" data-path="../templating/">
-            
+
                 <a href="../templating/">
-            
-                    
+
+
                     Templating
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
             <ul class="articles">
-                
-    
+
+
         <li class="chapter " data-level="3.1.1" data-path="../templating/conrefs.html">
-            
+
                 <a href="../templating/conrefs.html">
-            
-                    
+
+
                     Content References
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="3.1.2" data-path="../templating/variables.html">
-            
+
                 <a href="../templating/variables.html">
-            
-                    
+
+
                     Variables
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="3.1.3" data-path="../templating/builtin.html">
-            
+
                 <a href="../templating/builtin.html">
-            
-                    
+
+
                     Builtin
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
 
             </ul>
-            
+
         </li>
-    
+
         <li class="chapter " data-level="3.2" data-path="./">
-            
+
                 <a href="./">
-            
-                    
+
+
                     Plugins
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
             <ul class="articles">
-                
-    
+
+
         <li class="chapter active" data-level="3.2.1" data-path="create.html">
-            
+
                 <a href="create.html">
-            
-                    
+
+
                     Create a plugin
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="3.2.2" data-path="hooks.html">
-            
+
                 <a href="hooks.html">
-            
-                    
+
+
                     Hooks
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="3.2.3" data-path="blocks.html">
-            
+
                 <a href="blocks.html">
-            
-                    
+
+
                     Blocks
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="3.2.4" data-path="filters.html">
-            
+
                 <a href="filters.html">
-            
-                    
+
+
                     Filters
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="3.2.5" data-path="api.html">
-            
+
                 <a href="api.html">
-            
-                    
+
+
                     API & Context
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="3.2.6" data-path="testing.html">
-            
-                <a href="testing.html">
-            
-                    
-                    Test your plugin
-            
-                </a>
-            
 
-            
+                <a href="testing.html">
+
+
+                    Test your plugin
+
+                </a>
+
+
+
         </li>
-    
+
 
             </ul>
-            
+
         </li>
-    
+
         <li class="chapter " data-level="3.3" data-path="../themes/">
-            
+
                 <a href="../themes/">
-            
-                    
+
+
                     Theming
-            
+
                 </a>
-            
 
-            
+
+
         </li>
-    
 
-    
-        
+
+
+
         <li class="divider"></li>
-        
-        
-    
+
+
+
         <li class="chapter " data-level="4.1" data-path="../faq.html">
-            
+
                 <a href="../faq.html">
-            
-                    
+
+
                     FAQ
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="4.2" data-path="../examples.md">
-            
+
                 <span>
-            
-                    
+
+
                     Examples
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="4.3" >
-            
+
                 <a target="_blank" href="https://github.com/honkit/honkit/blob/master/CHANGELOG.md">
-            
-                    
+
+
                     Release notes
-            
+
                 </a>
-            
 
-            
+
+
         </li>
-    
 
-    
-        
+
+
+
         <li class="divider"></li>
-        
-        
-    
+
+
+
         <li class="chapter " data-level="5.1" data-path="../encoding.html">
-            
+
                 <a href="../encoding.html">
-            
-                    
+
+
                     Encoding
-            
+
                 </a>
-            
 
-            
+
+
         </li>
-    
 
-    
+
+
 
     <li class="divider"></li>
 
@@ -9829,18 +9829,18 @@ exports[`HonKit snapshots: plugins/create.html 1`] = `
 
 
                 </nav>
-            
-        
+
+
     </div>
 
     <div class="book-body">
-        
+
             <div class="body-inner">
-                
-                    
+
+
 
 <div class="book-header" role="navigation">
-    
+
 
     <!-- Title -->
     <h1>
@@ -9854,12 +9854,12 @@ exports[`HonKit snapshots: plugins/create.html 1`] = `
 
                     <div class="page-wrapper" tabindex="-1" role="main">
                         <div class="page-inner">
-                            
+
 <div id="book-search-results">
     <div class="search-noresults">
-    
+
                                 <section class="normal markdown-section">
-                                
+
 
                                 <h1 id="create-and-publish-a-plugin">Create and publish a plugin</h1>
 <p>A <a href="../GLOSSARY.html#honkit" class="glossary-term" title="Honkit is a command line tool for building beautiful books using GitHub/Git and Markdown (or AsciiDoc).">HonKit</a> plugin is a node package published on NPM that follow a defined convention.</p>
@@ -9919,64 +9919,64 @@ exports[`HonKit snapshots: plugins/create.html 1`] = `
     ]
 }
 </code></pre>
-                                
+
 <hr>
 <div class="btn-group btn-group-justified">
-    
+
     <a class="btn" href="./"><b>Previous:</b> Plugins</a>
-    
-    
+
+
     <a class="btn" href="hooks.html"><b>Next:</b> Hooks</a>
-    
+
 </div>
 
                                 </section>
-                            
+
     </div>
     <div class="search-results">
         <div class="has-results">
-            
+
             <h1 class="search-results-title"><span class='search-results-count'></span> results matching "<span class='search-query'></span>"</h1>
             <ul class="search-results-list"></ul>
-            
+
         </div>
         <div class="no-results">
-            
+
             <h1 class="search-results-title">No results matching "<span class='search-query'></span>"</h1>
-            
+
         </div>
     </div>
 </div>
 
                         </div>
                     </div>
-                
+
             </div>
 
-            
-                
+
+
                 <a href="./" class="navigation navigation-prev " aria-label="Previous page: Plugins">
                     <i class="fa fa-angle-left"></i>
                 </a>
-                
-                
+
+
                 <a href="hooks.html" class="navigation navigation-next " aria-label="Next page: Hooks">
                     <i class="fa fa-angle-right"></i>
                 </a>
-                
-            
-        
+
+
+
     </div>
 
     <script>
         var gitbook = gitbook || [];
         gitbook.push(function() {
-            
+
         });
     </script>
 </div>
 
-        
+
     <noscript>
         <style>
             .honkit-cloak {
@@ -10023,27 +10023,27 @@ exports[`HonKit snapshots: plugins/create.html 1`] = `
     </script>
     <script src="../gitbook/gitbook.js"></script>
     <script src="../gitbook/theme.js"></script>
-    
-        
+
+
         <script src="../gitbook/gitbook-plugin-search/search-engine.js"></script>
-        
-    
-        
+
+
+
         <script src="../gitbook/gitbook-plugin-search/search.js"></script>
-        
-    
-        
+
+
+
         <script src="../gitbook/gitbook-plugin-lunr/lunr.min.js"></script>
-        
-    
-        
+
+
+
         <script src="../gitbook/gitbook-plugin-lunr/search-lunr.js"></script>
-        
-    
-        
+
+
+
         <script src="../gitbook/gitbook-plugin-fontsettings/fontsettings.js"></script>
-        
-    
+
+
 
     </body>
 </html>
@@ -10069,50 +10069,50 @@ exports[`HonKit snapshots: plugins/filters.html 1`] = `
         <title>Filters · HonKit Documentation</title>
         <meta http-equiv="X-UA-Compatible" content="IE=edge" />
         <meta name="description" content="">
-        
-        
-        
-        
-    
+
+
+
+
+
     <link rel="stylesheet" href="../gitbook/style.css">
 
-    
-            
-                
+
+
+
                 <link rel="stylesheet" href="../gitbook/@honkit/honkit-plugin-highlight/website.css">
-                
-            
-                
+
+
+
                 <link rel="stylesheet" href="../gitbook/gitbook-plugin-search/search.css">
-                
-            
-                
+
+
+
                 <link rel="stylesheet" href="../gitbook/gitbook-plugin-fontsettings/website.css">
-                
-            
-        
 
-    
 
-    
-        
+
+
+
+
+
+
         <link rel="stylesheet" href="../styles/website.css">
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
 
-        
-    
-    
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
     <meta name="HandheldFriendly" content="true"/>
     <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no">
     <meta name="apple-mobile-web-app-capable" content="yes">
@@ -10120,557 +10120,557 @@ exports[`HonKit snapshots: plugins/filters.html 1`] = `
     <link rel="apple-touch-icon-precomposed" sizes="152x152" href="../gitbook/images/apple-touch-icon-precomposed-152.png">
     <link rel="shortcut icon" href="../gitbook/images/favicon.ico" type="image/x-icon">
 
-    
+
     <link rel="next" href="api.html" />
-    
-    
+
+
     <link rel="prev" href="blocks.html" />
-    
+
 
     </head>
     <body>
-        
+
 <div class="book honkit-cloak">
     <div class="book-summary">
-        
-            
+
+
 <div id="book-search-input" role="search">
     <input type="text" placeholder="Type to search" />
 </div>
 
-            
+
                 <nav role="navigation">
-                
+
 
 
 <ul class="summary">
-    
-    
 
-    
 
-    
-        
+
+
+
+
+
         <li class="header">Getting Started</li>
-        
-        
-    
+
+
+
         <li class="chapter " data-level="1.1" data-path="../">
-            
+
                 <a href="../">
-            
-                    
+
+
                     About this documentation
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="1.2" data-path="../setup.html">
-            
+
                 <a href="../setup.html">
-            
-                    
+
+
                     Installation and Setup
-            
+
                 </a>
-            
 
-            
+
+
         </li>
-    
 
-    
-        
+
+
+
         <li class="header">Your Content</li>
-        
-        
-    
+
+
+
         <li class="chapter " data-level="2.1" data-path="../structure.html">
-            
+
                 <a href="../structure.html">
-            
-                    
+
+
                     Directory structure
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.2" data-path="../pages.html">
-            
+
                 <a href="../pages.html">
-            
-                    
+
+
                     Pages and Summary
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.3" data-path="../config.html">
-            
+
                 <a href="../config.html">
-            
-                    
+
+
                     Configuration
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.4" data-path="../lexicon.html">
-            
+
                 <a href="../lexicon.html">
-            
-                    
+
+
                     Glossary
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.5" data-path="../languages.html">
-            
+
                 <a href="../languages.html">
-            
-                    
+
+
                     Multi-Lingual
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.6" data-path="../syntax/markdown.html">
-            
+
                 <a href="../syntax/markdown.html">
-            
-                    
+
+
                     Markdown
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
             <ul class="articles">
-                
-    
+
+
         <li class="chapter " data-level="2.6.1" data-path="../syntax/markdown.html">
-            
+
                 <a href="../syntax/markdown.html#headings">
-            
-                    
+
+
                     Headings
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.6.2" data-path="../syntax/markdown.html">
-            
+
                 <a href="../syntax/markdown.html#paragraphs">
-            
-                    
+
+
                     Paragraphs
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.6.3" data-path="../syntax/markdown.html">
-            
+
                 <a href="../syntax/markdown.html#lists">
-            
-                    
+
+
                     Lists
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.6.4" data-path="../syntax/markdown.html">
-            
+
                 <a href="../syntax/markdown.html#links">
-            
-                    
+
+
                     Links
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.6.5" data-path="../syntax/markdown.html">
-            
+
                 <a href="../syntax/markdown.html#images">
-            
-                    
+
+
                     Images
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.6.6" data-path="../syntax/markdown.html">
-            
+
                 <a href="../syntax/markdown.html#blockquotes">
-            
-                    
+
+
                     Blockquotes
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.6.7" data-path="../syntax/markdown.html">
-            
+
                 <a href="../syntax/markdown.html#tables">
-            
-                    
+
+
                     Tables
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.6.8" data-path="../syntax/markdown.html">
-            
+
                 <a href="../syntax/markdown.html#code">
-            
-                    
+
+
                     Code
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.6.9" data-path="../syntax/markdown.html">
-            
+
                 <a href="../syntax/markdown.html#html">
-            
-                    
+
+
                     HTML
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.6.10" data-path="../syntax/markdown.html">
-            
+
                 <a href="../syntax/markdown.html#footnotes">
-            
-                    
+
+
                     Footnotes
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
 
             </ul>
-            
+
         </li>
-    
+
         <li class="chapter " data-level="2.7" data-path="../syntax/asciidoc.html">
-            
+
                 <a href="../syntax/asciidoc.html">
-            
-                    
+
+
                     AsciiDoc
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.8" data-path="../ebook.html">
-            
+
                 <a href="../ebook.html">
-            
-                    
+
+
                     eBook and PDF
-            
+
                 </a>
-            
 
-            
+
+
         </li>
-    
 
-    
-        
+
+
+
         <li class="header">Customization</li>
-        
-        
-    
+
+
+
         <li class="chapter " data-level="3.1" data-path="../templating/">
-            
+
                 <a href="../templating/">
-            
-                    
+
+
                     Templating
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
             <ul class="articles">
-                
-    
+
+
         <li class="chapter " data-level="3.1.1" data-path="../templating/conrefs.html">
-            
+
                 <a href="../templating/conrefs.html">
-            
-                    
+
+
                     Content References
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="3.1.2" data-path="../templating/variables.html">
-            
+
                 <a href="../templating/variables.html">
-            
-                    
+
+
                     Variables
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="3.1.3" data-path="../templating/builtin.html">
-            
+
                 <a href="../templating/builtin.html">
-            
-                    
+
+
                     Builtin
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
 
             </ul>
-            
+
         </li>
-    
+
         <li class="chapter " data-level="3.2" data-path="./">
-            
+
                 <a href="./">
-            
-                    
+
+
                     Plugins
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
             <ul class="articles">
-                
-    
+
+
         <li class="chapter " data-level="3.2.1" data-path="create.html">
-            
+
                 <a href="create.html">
-            
-                    
+
+
                     Create a plugin
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="3.2.2" data-path="hooks.html">
-            
+
                 <a href="hooks.html">
-            
-                    
+
+
                     Hooks
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="3.2.3" data-path="blocks.html">
-            
+
                 <a href="blocks.html">
-            
-                    
+
+
                     Blocks
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter active" data-level="3.2.4" data-path="filters.html">
-            
+
                 <a href="filters.html">
-            
-                    
+
+
                     Filters
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="3.2.5" data-path="api.html">
-            
+
                 <a href="api.html">
-            
-                    
+
+
                     API & Context
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="3.2.6" data-path="testing.html">
-            
-                <a href="testing.html">
-            
-                    
-                    Test your plugin
-            
-                </a>
-            
 
-            
+                <a href="testing.html">
+
+
+                    Test your plugin
+
+                </a>
+
+
+
         </li>
-    
+
 
             </ul>
-            
+
         </li>
-    
+
         <li class="chapter " data-level="3.3" data-path="../themes/">
-            
+
                 <a href="../themes/">
-            
-                    
+
+
                     Theming
-            
+
                 </a>
-            
 
-            
+
+
         </li>
-    
 
-    
-        
+
+
+
         <li class="divider"></li>
-        
-        
-    
+
+
+
         <li class="chapter " data-level="4.1" data-path="../faq.html">
-            
+
                 <a href="../faq.html">
-            
-                    
+
+
                     FAQ
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="4.2" data-path="../examples.md">
-            
+
                 <span>
-            
-                    
+
+
                     Examples
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="4.3" >
-            
+
                 <a target="_blank" href="https://github.com/honkit/honkit/blob/master/CHANGELOG.md">
-            
-                    
+
+
                     Release notes
-            
+
                 </a>
-            
 
-            
+
+
         </li>
-    
 
-    
-        
+
+
+
         <li class="divider"></li>
-        
-        
-    
+
+
+
         <li class="chapter " data-level="5.1" data-path="../encoding.html">
-            
+
                 <a href="../encoding.html">
-            
-                    
+
+
                     Encoding
-            
+
                 </a>
-            
 
-            
+
+
         </li>
-    
 
-    
+
+
 
     <li class="divider"></li>
 
@@ -10683,18 +10683,18 @@ exports[`HonKit snapshots: plugins/filters.html 1`] = `
 
 
                 </nav>
-            
-        
+
+
     </div>
 
     <div class="book-body">
-        
+
             <div class="body-inner">
-                
-                    
+
+
 
 <div class="book-header" role="navigation">
-    
+
 
     <!-- Title -->
     <h1>
@@ -10708,12 +10708,12 @@ exports[`HonKit snapshots: plugins/filters.html 1`] = `
 
                     <div class="page-wrapper" tabindex="-1" role="main">
                         <div class="page-inner">
-                            
+
 <div id="book-search-results">
     <div class="search-noresults">
-    
+
                                 <section class="normal markdown-section">
-                                
+
 
                                 <h1 id="extend-filters">Extend Filters</h1>
 <p>Filters are essentially functions that can be applied to variables. They are called with a pipe operator (<code>|</code>) and can take arguments.</p>
@@ -10752,64 +10752,64 @@ Refer to <a href="api.html">Context and APIs</a> to learn more about <code>this<
 };
 </code></pre>
 
-                                
+
 <hr>
 <div class="btn-group btn-group-justified">
-    
+
     <a class="btn" href="blocks.html"><b>Previous:</b> Blocks</a>
-    
-    
+
+
     <a class="btn" href="api.html"><b>Next:</b> API & Context</a>
-    
+
 </div>
 
                                 </section>
-                            
+
     </div>
     <div class="search-results">
         <div class="has-results">
-            
+
             <h1 class="search-results-title"><span class='search-results-count'></span> results matching "<span class='search-query'></span>"</h1>
             <ul class="search-results-list"></ul>
-            
+
         </div>
         <div class="no-results">
-            
+
             <h1 class="search-results-title">No results matching "<span class='search-query'></span>"</h1>
-            
+
         </div>
     </div>
 </div>
 
                         </div>
                     </div>
-                
+
             </div>
 
-            
-                
+
+
                 <a href="blocks.html" class="navigation navigation-prev " aria-label="Previous page: Blocks">
                     <i class="fa fa-angle-left"></i>
                 </a>
-                
-                
+
+
                 <a href="api.html" class="navigation navigation-next " aria-label="Next page: API & Context">
                     <i class="fa fa-angle-right"></i>
                 </a>
-                
-            
-        
+
+
+
     </div>
 
     <script>
         var gitbook = gitbook || [];
         gitbook.push(function() {
-            
+
         });
     </script>
 </div>
 
-        
+
     <noscript>
         <style>
             .honkit-cloak {
@@ -10856,27 +10856,27 @@ Refer to <a href="api.html">Context and APIs</a> to learn more about <code>this<
     </script>
     <script src="../gitbook/gitbook.js"></script>
     <script src="../gitbook/theme.js"></script>
-    
-        
+
+
         <script src="../gitbook/gitbook-plugin-search/search-engine.js"></script>
-        
-    
-        
+
+
+
         <script src="../gitbook/gitbook-plugin-search/search.js"></script>
-        
-    
-        
+
+
+
         <script src="../gitbook/gitbook-plugin-lunr/lunr.min.js"></script>
-        
-    
-        
+
+
+
         <script src="../gitbook/gitbook-plugin-lunr/search-lunr.js"></script>
-        
-    
-        
+
+
+
         <script src="../gitbook/gitbook-plugin-fontsettings/fontsettings.js"></script>
-        
-    
+
+
 
     </body>
 </html>
@@ -10902,50 +10902,50 @@ exports[`HonKit snapshots: plugins/hooks.html 1`] = `
         <title>Hooks · HonKit Documentation</title>
         <meta http-equiv="X-UA-Compatible" content="IE=edge" />
         <meta name="description" content="">
-        
-        
-        
-        
-    
+
+
+
+
+
     <link rel="stylesheet" href="../gitbook/style.css">
 
-    
-            
-                
+
+
+
                 <link rel="stylesheet" href="../gitbook/@honkit/honkit-plugin-highlight/website.css">
-                
-            
-                
+
+
+
                 <link rel="stylesheet" href="../gitbook/gitbook-plugin-search/search.css">
-                
-            
-                
+
+
+
                 <link rel="stylesheet" href="../gitbook/gitbook-plugin-fontsettings/website.css">
-                
-            
-        
 
-    
 
-    
-        
+
+
+
+
+
+
         <link rel="stylesheet" href="../styles/website.css">
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
 
-        
-    
-    
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
     <meta name="HandheldFriendly" content="true"/>
     <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no">
     <meta name="apple-mobile-web-app-capable" content="yes">
@@ -10953,557 +10953,557 @@ exports[`HonKit snapshots: plugins/hooks.html 1`] = `
     <link rel="apple-touch-icon-precomposed" sizes="152x152" href="../gitbook/images/apple-touch-icon-precomposed-152.png">
     <link rel="shortcut icon" href="../gitbook/images/favicon.ico" type="image/x-icon">
 
-    
+
     <link rel="next" href="blocks.html" />
-    
-    
+
+
     <link rel="prev" href="create.html" />
-    
+
 
     </head>
     <body>
-        
+
 <div class="book honkit-cloak">
     <div class="book-summary">
-        
-            
+
+
 <div id="book-search-input" role="search">
     <input type="text" placeholder="Type to search" />
 </div>
 
-            
+
                 <nav role="navigation">
-                
+
 
 
 <ul class="summary">
-    
-    
 
-    
 
-    
-        
+
+
+
+
+
         <li class="header">Getting Started</li>
-        
-        
-    
+
+
+
         <li class="chapter " data-level="1.1" data-path="../">
-            
+
                 <a href="../">
-            
-                    
+
+
                     About this documentation
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="1.2" data-path="../setup.html">
-            
+
                 <a href="../setup.html">
-            
-                    
+
+
                     Installation and Setup
-            
+
                 </a>
-            
 
-            
+
+
         </li>
-    
 
-    
-        
+
+
+
         <li class="header">Your Content</li>
-        
-        
-    
+
+
+
         <li class="chapter " data-level="2.1" data-path="../structure.html">
-            
+
                 <a href="../structure.html">
-            
-                    
+
+
                     Directory structure
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.2" data-path="../pages.html">
-            
+
                 <a href="../pages.html">
-            
-                    
+
+
                     Pages and Summary
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.3" data-path="../config.html">
-            
+
                 <a href="../config.html">
-            
-                    
+
+
                     Configuration
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.4" data-path="../lexicon.html">
-            
+
                 <a href="../lexicon.html">
-            
-                    
+
+
                     Glossary
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.5" data-path="../languages.html">
-            
+
                 <a href="../languages.html">
-            
-                    
+
+
                     Multi-Lingual
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.6" data-path="../syntax/markdown.html">
-            
+
                 <a href="../syntax/markdown.html">
-            
-                    
+
+
                     Markdown
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
             <ul class="articles">
-                
-    
+
+
         <li class="chapter " data-level="2.6.1" data-path="../syntax/markdown.html">
-            
+
                 <a href="../syntax/markdown.html#headings">
-            
-                    
+
+
                     Headings
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.6.2" data-path="../syntax/markdown.html">
-            
+
                 <a href="../syntax/markdown.html#paragraphs">
-            
-                    
+
+
                     Paragraphs
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.6.3" data-path="../syntax/markdown.html">
-            
+
                 <a href="../syntax/markdown.html#lists">
-            
-                    
+
+
                     Lists
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.6.4" data-path="../syntax/markdown.html">
-            
+
                 <a href="../syntax/markdown.html#links">
-            
-                    
+
+
                     Links
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.6.5" data-path="../syntax/markdown.html">
-            
+
                 <a href="../syntax/markdown.html#images">
-            
-                    
+
+
                     Images
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.6.6" data-path="../syntax/markdown.html">
-            
+
                 <a href="../syntax/markdown.html#blockquotes">
-            
-                    
+
+
                     Blockquotes
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.6.7" data-path="../syntax/markdown.html">
-            
+
                 <a href="../syntax/markdown.html#tables">
-            
-                    
+
+
                     Tables
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.6.8" data-path="../syntax/markdown.html">
-            
+
                 <a href="../syntax/markdown.html#code">
-            
-                    
+
+
                     Code
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.6.9" data-path="../syntax/markdown.html">
-            
+
                 <a href="../syntax/markdown.html#html">
-            
-                    
+
+
                     HTML
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.6.10" data-path="../syntax/markdown.html">
-            
+
                 <a href="../syntax/markdown.html#footnotes">
-            
-                    
+
+
                     Footnotes
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
 
             </ul>
-            
+
         </li>
-    
+
         <li class="chapter " data-level="2.7" data-path="../syntax/asciidoc.html">
-            
+
                 <a href="../syntax/asciidoc.html">
-            
-                    
+
+
                     AsciiDoc
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.8" data-path="../ebook.html">
-            
+
                 <a href="../ebook.html">
-            
-                    
+
+
                     eBook and PDF
-            
+
                 </a>
-            
 
-            
+
+
         </li>
-    
 
-    
-        
+
+
+
         <li class="header">Customization</li>
-        
-        
-    
+
+
+
         <li class="chapter " data-level="3.1" data-path="../templating/">
-            
+
                 <a href="../templating/">
-            
-                    
+
+
                     Templating
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
             <ul class="articles">
-                
-    
+
+
         <li class="chapter " data-level="3.1.1" data-path="../templating/conrefs.html">
-            
+
                 <a href="../templating/conrefs.html">
-            
-                    
+
+
                     Content References
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="3.1.2" data-path="../templating/variables.html">
-            
+
                 <a href="../templating/variables.html">
-            
-                    
+
+
                     Variables
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="3.1.3" data-path="../templating/builtin.html">
-            
+
                 <a href="../templating/builtin.html">
-            
-                    
+
+
                     Builtin
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
 
             </ul>
-            
+
         </li>
-    
+
         <li class="chapter " data-level="3.2" data-path="./">
-            
+
                 <a href="./">
-            
-                    
+
+
                     Plugins
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
             <ul class="articles">
-                
-    
+
+
         <li class="chapter " data-level="3.2.1" data-path="create.html">
-            
+
                 <a href="create.html">
-            
-                    
+
+
                     Create a plugin
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter active" data-level="3.2.2" data-path="hooks.html">
-            
+
                 <a href="hooks.html">
-            
-                    
+
+
                     Hooks
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="3.2.3" data-path="blocks.html">
-            
+
                 <a href="blocks.html">
-            
-                    
+
+
                     Blocks
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="3.2.4" data-path="filters.html">
-            
+
                 <a href="filters.html">
-            
-                    
+
+
                     Filters
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="3.2.5" data-path="api.html">
-            
+
                 <a href="api.html">
-            
-                    
+
+
                     API & Context
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="3.2.6" data-path="testing.html">
-            
-                <a href="testing.html">
-            
-                    
-                    Test your plugin
-            
-                </a>
-            
 
-            
+                <a href="testing.html">
+
+
+                    Test your plugin
+
+                </a>
+
+
+
         </li>
-    
+
 
             </ul>
-            
+
         </li>
-    
+
         <li class="chapter " data-level="3.3" data-path="../themes/">
-            
+
                 <a href="../themes/">
-            
-                    
+
+
                     Theming
-            
+
                 </a>
-            
 
-            
+
+
         </li>
-    
 
-    
-        
+
+
+
         <li class="divider"></li>
-        
-        
-    
+
+
+
         <li class="chapter " data-level="4.1" data-path="../faq.html">
-            
+
                 <a href="../faq.html">
-            
-                    
+
+
                     FAQ
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="4.2" data-path="../examples.md">
-            
+
                 <span>
-            
-                    
+
+
                     Examples
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="4.3" >
-            
+
                 <a target="_blank" href="https://github.com/honkit/honkit/blob/master/CHANGELOG.md">
-            
-                    
+
+
                     Release notes
-            
+
                 </a>
-            
 
-            
+
+
         </li>
-    
 
-    
-        
+
+
+
         <li class="divider"></li>
-        
-        
-    
+
+
+
         <li class="chapter " data-level="5.1" data-path="../encoding.html">
-            
+
                 <a href="../encoding.html">
-            
-                    
+
+
                     Encoding
-            
+
                 </a>
-            
 
-            
+
+
         </li>
-    
 
-    
+
+
 
     <li class="divider"></li>
 
@@ -11516,18 +11516,18 @@ exports[`HonKit snapshots: plugins/hooks.html 1`] = `
 
 
                 </nav>
-            
-        
+
+
     </div>
 
     <div class="book-body">
-        
+
             <div class="body-inner">
-                
-                    
+
+
 
 <div class="book-header" role="navigation">
-    
+
 
     <!-- Title -->
     <h1>
@@ -11541,12 +11541,12 @@ exports[`HonKit snapshots: plugins/hooks.html 1`] = `
 
                     <div class="page-wrapper" tabindex="-1" role="main">
                         <div class="page-inner">
-                            
+
 <div id="book-search-results">
     <div class="search-noresults">
-    
+
                                 <section class="normal markdown-section">
-                                
+
 
                                 <h1 id="hooks">Hooks</h1>
 <p>Hooks is a method of augmenting or altering the behavior of the process, with custom callbacks.</p>
@@ -11655,64 +11655,64 @@ exports[`HonKit snapshots: plugins/hooks.html 1`] = `
 }
 </code></pre>
 
-                                
+
 <hr>
 <div class="btn-group btn-group-justified">
-    
+
     <a class="btn" href="create.html"><b>Previous:</b> Create a plugin</a>
-    
-    
+
+
     <a class="btn" href="blocks.html"><b>Next:</b> Blocks</a>
-    
+
 </div>
 
                                 </section>
-                            
+
     </div>
     <div class="search-results">
         <div class="has-results">
-            
+
             <h1 class="search-results-title"><span class='search-results-count'></span> results matching "<span class='search-query'></span>"</h1>
             <ul class="search-results-list"></ul>
-            
+
         </div>
         <div class="no-results">
-            
+
             <h1 class="search-results-title">No results matching "<span class='search-query'></span>"</h1>
-            
+
         </div>
     </div>
 </div>
 
                         </div>
                     </div>
-                
+
             </div>
 
-            
-                
+
+
                 <a href="create.html" class="navigation navigation-prev " aria-label="Previous page: Create a plugin">
                     <i class="fa fa-angle-left"></i>
                 </a>
-                
-                
+
+
                 <a href="blocks.html" class="navigation navigation-next " aria-label="Next page: Blocks">
                     <i class="fa fa-angle-right"></i>
                 </a>
-                
-            
-        
+
+
+
     </div>
 
     <script>
         var gitbook = gitbook || [];
         gitbook.push(function() {
-            
+
         });
     </script>
 </div>
 
-        
+
     <noscript>
         <style>
             .honkit-cloak {
@@ -11759,27 +11759,27 @@ exports[`HonKit snapshots: plugins/hooks.html 1`] = `
     </script>
     <script src="../gitbook/gitbook.js"></script>
     <script src="../gitbook/theme.js"></script>
-    
-        
+
+
         <script src="../gitbook/gitbook-plugin-search/search-engine.js"></script>
-        
-    
-        
+
+
+
         <script src="../gitbook/gitbook-plugin-search/search.js"></script>
-        
-    
-        
+
+
+
         <script src="../gitbook/gitbook-plugin-lunr/lunr.min.js"></script>
-        
-    
-        
+
+
+
         <script src="../gitbook/gitbook-plugin-lunr/search-lunr.js"></script>
-        
-    
-        
+
+
+
         <script src="../gitbook/gitbook-plugin-fontsettings/fontsettings.js"></script>
-        
-    
+
+
 
     </body>
 </html>
@@ -11805,50 +11805,50 @@ exports[`HonKit snapshots: plugins/index.html 1`] = `
         <title>Plugins · HonKit Documentation</title>
         <meta http-equiv="X-UA-Compatible" content="IE=edge" />
         <meta name="description" content="">
-        
-        
-        
-        
-    
+
+
+
+
+
     <link rel="stylesheet" href="../gitbook/style.css">
 
-    
-            
-                
+
+
+
                 <link rel="stylesheet" href="../gitbook/@honkit/honkit-plugin-highlight/website.css">
-                
-            
-                
+
+
+
                 <link rel="stylesheet" href="../gitbook/gitbook-plugin-search/search.css">
-                
-            
-                
+
+
+
                 <link rel="stylesheet" href="../gitbook/gitbook-plugin-fontsettings/website.css">
-                
-            
-        
 
-    
 
-    
-        
+
+
+
+
+
+
         <link rel="stylesheet" href="../styles/website.css">
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
 
-        
-    
-    
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
     <meta name="HandheldFriendly" content="true"/>
     <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no">
     <meta name="apple-mobile-web-app-capable" content="yes">
@@ -11856,557 +11856,557 @@ exports[`HonKit snapshots: plugins/index.html 1`] = `
     <link rel="apple-touch-icon-precomposed" sizes="152x152" href="../gitbook/images/apple-touch-icon-precomposed-152.png">
     <link rel="shortcut icon" href="../gitbook/images/favicon.ico" type="image/x-icon">
 
-    
+
     <link rel="next" href="create.html" />
-    
-    
+
+
     <link rel="prev" href="../templating/builtin.html" />
-    
+
 
     </head>
     <body>
-        
+
 <div class="book honkit-cloak">
     <div class="book-summary">
-        
-            
+
+
 <div id="book-search-input" role="search">
     <input type="text" placeholder="Type to search" />
 </div>
 
-            
+
                 <nav role="navigation">
-                
+
 
 
 <ul class="summary">
-    
-    
 
-    
 
-    
-        
+
+
+
+
+
         <li class="header">Getting Started</li>
-        
-        
-    
+
+
+
         <li class="chapter " data-level="1.1" data-path="../">
-            
+
                 <a href="../">
-            
-                    
+
+
                     About this documentation
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="1.2" data-path="../setup.html">
-            
+
                 <a href="../setup.html">
-            
-                    
+
+
                     Installation and Setup
-            
+
                 </a>
-            
 
-            
+
+
         </li>
-    
 
-    
-        
+
+
+
         <li class="header">Your Content</li>
-        
-        
-    
+
+
+
         <li class="chapter " data-level="2.1" data-path="../structure.html">
-            
+
                 <a href="../structure.html">
-            
-                    
+
+
                     Directory structure
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.2" data-path="../pages.html">
-            
+
                 <a href="../pages.html">
-            
-                    
+
+
                     Pages and Summary
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.3" data-path="../config.html">
-            
+
                 <a href="../config.html">
-            
-                    
+
+
                     Configuration
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.4" data-path="../lexicon.html">
-            
+
                 <a href="../lexicon.html">
-            
-                    
+
+
                     Glossary
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.5" data-path="../languages.html">
-            
+
                 <a href="../languages.html">
-            
-                    
+
+
                     Multi-Lingual
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.6" data-path="../syntax/markdown.html">
-            
+
                 <a href="../syntax/markdown.html">
-            
-                    
+
+
                     Markdown
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
             <ul class="articles">
-                
-    
+
+
         <li class="chapter " data-level="2.6.1" data-path="../syntax/markdown.html">
-            
+
                 <a href="../syntax/markdown.html#headings">
-            
-                    
+
+
                     Headings
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.6.2" data-path="../syntax/markdown.html">
-            
+
                 <a href="../syntax/markdown.html#paragraphs">
-            
-                    
+
+
                     Paragraphs
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.6.3" data-path="../syntax/markdown.html">
-            
+
                 <a href="../syntax/markdown.html#lists">
-            
-                    
+
+
                     Lists
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.6.4" data-path="../syntax/markdown.html">
-            
+
                 <a href="../syntax/markdown.html#links">
-            
-                    
+
+
                     Links
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.6.5" data-path="../syntax/markdown.html">
-            
+
                 <a href="../syntax/markdown.html#images">
-            
-                    
+
+
                     Images
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.6.6" data-path="../syntax/markdown.html">
-            
+
                 <a href="../syntax/markdown.html#blockquotes">
-            
-                    
+
+
                     Blockquotes
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.6.7" data-path="../syntax/markdown.html">
-            
+
                 <a href="../syntax/markdown.html#tables">
-            
-                    
+
+
                     Tables
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.6.8" data-path="../syntax/markdown.html">
-            
+
                 <a href="../syntax/markdown.html#code">
-            
-                    
+
+
                     Code
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.6.9" data-path="../syntax/markdown.html">
-            
+
                 <a href="../syntax/markdown.html#html">
-            
-                    
+
+
                     HTML
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.6.10" data-path="../syntax/markdown.html">
-            
+
                 <a href="../syntax/markdown.html#footnotes">
-            
-                    
+
+
                     Footnotes
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
 
             </ul>
-            
+
         </li>
-    
+
         <li class="chapter " data-level="2.7" data-path="../syntax/asciidoc.html">
-            
+
                 <a href="../syntax/asciidoc.html">
-            
-                    
+
+
                     AsciiDoc
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.8" data-path="../ebook.html">
-            
+
                 <a href="../ebook.html">
-            
-                    
+
+
                     eBook and PDF
-            
+
                 </a>
-            
 
-            
+
+
         </li>
-    
 
-    
-        
+
+
+
         <li class="header">Customization</li>
-        
-        
-    
+
+
+
         <li class="chapter " data-level="3.1" data-path="../templating/">
-            
+
                 <a href="../templating/">
-            
-                    
+
+
                     Templating
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
             <ul class="articles">
-                
-    
+
+
         <li class="chapter " data-level="3.1.1" data-path="../templating/conrefs.html">
-            
+
                 <a href="../templating/conrefs.html">
-            
-                    
+
+
                     Content References
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="3.1.2" data-path="../templating/variables.html">
-            
+
                 <a href="../templating/variables.html">
-            
-                    
+
+
                     Variables
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="3.1.3" data-path="../templating/builtin.html">
-            
+
                 <a href="../templating/builtin.html">
-            
-                    
+
+
                     Builtin
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
 
             </ul>
-            
+
         </li>
-    
+
         <li class="chapter active" data-level="3.2" data-path="./">
-            
+
                 <a href="./">
-            
-                    
+
+
                     Plugins
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
             <ul class="articles">
-                
-    
+
+
         <li class="chapter " data-level="3.2.1" data-path="create.html">
-            
+
                 <a href="create.html">
-            
-                    
+
+
                     Create a plugin
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="3.2.2" data-path="hooks.html">
-            
+
                 <a href="hooks.html">
-            
-                    
+
+
                     Hooks
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="3.2.3" data-path="blocks.html">
-            
+
                 <a href="blocks.html">
-            
-                    
+
+
                     Blocks
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="3.2.4" data-path="filters.html">
-            
+
                 <a href="filters.html">
-            
-                    
+
+
                     Filters
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="3.2.5" data-path="api.html">
-            
+
                 <a href="api.html">
-            
-                    
+
+
                     API & Context
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="3.2.6" data-path="testing.html">
-            
-                <a href="testing.html">
-            
-                    
-                    Test your plugin
-            
-                </a>
-            
 
-            
+                <a href="testing.html">
+
+
+                    Test your plugin
+
+                </a>
+
+
+
         </li>
-    
+
 
             </ul>
-            
+
         </li>
-    
+
         <li class="chapter " data-level="3.3" data-path="../themes/">
-            
+
                 <a href="../themes/">
-            
-                    
+
+
                     Theming
-            
+
                 </a>
-            
 
-            
+
+
         </li>
-    
 
-    
-        
+
+
+
         <li class="divider"></li>
-        
-        
-    
+
+
+
         <li class="chapter " data-level="4.1" data-path="../faq.html">
-            
+
                 <a href="../faq.html">
-            
-                    
+
+
                     FAQ
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="4.2" data-path="../examples.md">
-            
+
                 <span>
-            
-                    
+
+
                     Examples
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="4.3" >
-            
+
                 <a target="_blank" href="https://github.com/honkit/honkit/blob/master/CHANGELOG.md">
-            
-                    
+
+
                     Release notes
-            
+
                 </a>
-            
 
-            
+
+
         </li>
-    
 
-    
-        
+
+
+
         <li class="divider"></li>
-        
-        
-    
+
+
+
         <li class="chapter " data-level="5.1" data-path="../encoding.html">
-            
+
                 <a href="../encoding.html">
-            
-                    
+
+
                     Encoding
-            
+
                 </a>
-            
 
-            
+
+
         </li>
-    
 
-    
+
+
 
     <li class="divider"></li>
 
@@ -12419,18 +12419,18 @@ exports[`HonKit snapshots: plugins/index.html 1`] = `
 
 
                 </nav>
-            
-        
+
+
     </div>
 
     <div class="book-body">
-        
+
             <div class="body-inner">
-                
-                    
+
+
 
 <div class="book-header" role="navigation">
-    
+
 
     <!-- Title -->
     <h1>
@@ -12444,12 +12444,12 @@ exports[`HonKit snapshots: plugins/index.html 1`] = `
 
                     <div class="page-wrapper" tabindex="-1" role="main">
                         <div class="page-inner">
-                            
+
 <div id="book-search-results">
     <div class="search-noresults">
-    
+
                                 <section class="normal markdown-section">
-                                
+
 
                                 <h1 id="plugins">Plugins</h1>
 <p><a href="../GLOSSARY.html#plugins" class="glossary-term" title="Plugins are the best way to extend HonKit functionalities (ebook and website).">Plugins</a> are the best way to extend <a href="../GLOSSARY.html#honkit" class="glossary-term" title="Honkit is a command line tool for building beautiful books using GitHub/Git and Markdown (or AsciiDoc).">HonKit</a> functionalities (ebook and website). There exist <a href="../GLOSSARY.html#plugins" class="glossary-term" title="Plugins are the best way to extend HonKit functionalities (ebook and website).">plugins</a> to do a lot of things: bring math formulas display support, track visits using Google Analytic, etc.</p>
@@ -12465,64 +12465,64 @@ exports[`HonKit snapshots: plugins/index.html 1`] = `
 <h3 id="configuring-plugins">Configuring plugins</h3>
 <p><a href="../GLOSSARY.html#plugins" class="glossary-term" title="Plugins are the best way to extend HonKit functionalities (ebook and website).">Plugins</a> specific configurations are stored in <code>pluginsConfig</code>. You have to refer to the documentation of the plugin itself for details about the available options.</p>
 
-                                
+
 <hr>
 <div class="btn-group btn-group-justified">
-    
+
     <a class="btn" href="../templating/builtin.html"><b>Previous:</b> Builtin</a>
-    
-    
+
+
     <a class="btn" href="create.html"><b>Next:</b> Create a plugin</a>
-    
+
 </div>
 
                                 </section>
-                            
+
     </div>
     <div class="search-results">
         <div class="has-results">
-            
+
             <h1 class="search-results-title"><span class='search-results-count'></span> results matching "<span class='search-query'></span>"</h1>
             <ul class="search-results-list"></ul>
-            
+
         </div>
         <div class="no-results">
-            
+
             <h1 class="search-results-title">No results matching "<span class='search-query'></span>"</h1>
-            
+
         </div>
     </div>
 </div>
 
                         </div>
                     </div>
-                
+
             </div>
 
-            
-                
+
+
                 <a href="../templating/builtin.html" class="navigation navigation-prev " aria-label="Previous page: Builtin">
                     <i class="fa fa-angle-left"></i>
                 </a>
-                
-                
+
+
                 <a href="create.html" class="navigation navigation-next " aria-label="Next page: Create a plugin">
                     <i class="fa fa-angle-right"></i>
                 </a>
-                
-            
-        
+
+
+
     </div>
 
     <script>
         var gitbook = gitbook || [];
         gitbook.push(function() {
-            
+
         });
     </script>
 </div>
 
-        
+
     <noscript>
         <style>
             .honkit-cloak {
@@ -12569,27 +12569,27 @@ exports[`HonKit snapshots: plugins/index.html 1`] = `
     </script>
     <script src="../gitbook/gitbook.js"></script>
     <script src="../gitbook/theme.js"></script>
-    
-        
+
+
         <script src="../gitbook/gitbook-plugin-search/search-engine.js"></script>
-        
-    
-        
+
+
+
         <script src="../gitbook/gitbook-plugin-search/search.js"></script>
-        
-    
-        
+
+
+
         <script src="../gitbook/gitbook-plugin-lunr/lunr.min.js"></script>
-        
-    
-        
+
+
+
         <script src="../gitbook/gitbook-plugin-lunr/search-lunr.js"></script>
-        
-    
-        
+
+
+
         <script src="../gitbook/gitbook-plugin-fontsettings/fontsettings.js"></script>
-        
-    
+
+
 
     </body>
 </html>
@@ -12615,50 +12615,50 @@ exports[`HonKit snapshots: plugins/testing.html 1`] = `
         <title>Test your plugin · HonKit Documentation</title>
         <meta http-equiv="X-UA-Compatible" content="IE=edge" />
         <meta name="description" content="">
-        
-        
-        
-        
-    
+
+
+
+
+
     <link rel="stylesheet" href="../gitbook/style.css">
 
-    
-            
-                
+
+
+
                 <link rel="stylesheet" href="../gitbook/@honkit/honkit-plugin-highlight/website.css">
-                
-            
-                
+
+
+
                 <link rel="stylesheet" href="../gitbook/gitbook-plugin-search/search.css">
-                
-            
-                
+
+
+
                 <link rel="stylesheet" href="../gitbook/gitbook-plugin-fontsettings/website.css">
-                
-            
-        
 
-    
 
-    
-        
+
+
+
+
+
+
         <link rel="stylesheet" href="../styles/website.css">
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
 
-        
-    
-    
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
     <meta name="HandheldFriendly" content="true"/>
     <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no">
     <meta name="apple-mobile-web-app-capable" content="yes">
@@ -12666,557 +12666,557 @@ exports[`HonKit snapshots: plugins/testing.html 1`] = `
     <link rel="apple-touch-icon-precomposed" sizes="152x152" href="../gitbook/images/apple-touch-icon-precomposed-152.png">
     <link rel="shortcut icon" href="../gitbook/images/favicon.ico" type="image/x-icon">
 
-    
+
     <link rel="next" href="../themes/" />
-    
-    
+
+
     <link rel="prev" href="api.html" />
-    
+
 
     </head>
     <body>
-        
+
 <div class="book honkit-cloak">
     <div class="book-summary">
-        
-            
+
+
 <div id="book-search-input" role="search">
     <input type="text" placeholder="Type to search" />
 </div>
 
-            
+
                 <nav role="navigation">
-                
+
 
 
 <ul class="summary">
-    
-    
 
-    
 
-    
-        
+
+
+
+
+
         <li class="header">Getting Started</li>
-        
-        
-    
+
+
+
         <li class="chapter " data-level="1.1" data-path="../">
-            
+
                 <a href="../">
-            
-                    
+
+
                     About this documentation
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="1.2" data-path="../setup.html">
-            
+
                 <a href="../setup.html">
-            
-                    
+
+
                     Installation and Setup
-            
+
                 </a>
-            
 
-            
+
+
         </li>
-    
 
-    
-        
+
+
+
         <li class="header">Your Content</li>
-        
-        
-    
+
+
+
         <li class="chapter " data-level="2.1" data-path="../structure.html">
-            
+
                 <a href="../structure.html">
-            
-                    
+
+
                     Directory structure
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.2" data-path="../pages.html">
-            
+
                 <a href="../pages.html">
-            
-                    
+
+
                     Pages and Summary
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.3" data-path="../config.html">
-            
+
                 <a href="../config.html">
-            
-                    
+
+
                     Configuration
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.4" data-path="../lexicon.html">
-            
+
                 <a href="../lexicon.html">
-            
-                    
+
+
                     Glossary
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.5" data-path="../languages.html">
-            
+
                 <a href="../languages.html">
-            
-                    
+
+
                     Multi-Lingual
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.6" data-path="../syntax/markdown.html">
-            
+
                 <a href="../syntax/markdown.html">
-            
-                    
+
+
                     Markdown
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
             <ul class="articles">
-                
-    
+
+
         <li class="chapter " data-level="2.6.1" data-path="../syntax/markdown.html">
-            
+
                 <a href="../syntax/markdown.html#headings">
-            
-                    
+
+
                     Headings
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.6.2" data-path="../syntax/markdown.html">
-            
+
                 <a href="../syntax/markdown.html#paragraphs">
-            
-                    
+
+
                     Paragraphs
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.6.3" data-path="../syntax/markdown.html">
-            
+
                 <a href="../syntax/markdown.html#lists">
-            
-                    
+
+
                     Lists
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.6.4" data-path="../syntax/markdown.html">
-            
+
                 <a href="../syntax/markdown.html#links">
-            
-                    
+
+
                     Links
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.6.5" data-path="../syntax/markdown.html">
-            
+
                 <a href="../syntax/markdown.html#images">
-            
-                    
+
+
                     Images
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.6.6" data-path="../syntax/markdown.html">
-            
+
                 <a href="../syntax/markdown.html#blockquotes">
-            
-                    
+
+
                     Blockquotes
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.6.7" data-path="../syntax/markdown.html">
-            
+
                 <a href="../syntax/markdown.html#tables">
-            
-                    
+
+
                     Tables
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.6.8" data-path="../syntax/markdown.html">
-            
+
                 <a href="../syntax/markdown.html#code">
-            
-                    
+
+
                     Code
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.6.9" data-path="../syntax/markdown.html">
-            
+
                 <a href="../syntax/markdown.html#html">
-            
-                    
+
+
                     HTML
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.6.10" data-path="../syntax/markdown.html">
-            
+
                 <a href="../syntax/markdown.html#footnotes">
-            
-                    
+
+
                     Footnotes
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
 
             </ul>
-            
+
         </li>
-    
+
         <li class="chapter " data-level="2.7" data-path="../syntax/asciidoc.html">
-            
+
                 <a href="../syntax/asciidoc.html">
-            
-                    
+
+
                     AsciiDoc
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.8" data-path="../ebook.html">
-            
+
                 <a href="../ebook.html">
-            
-                    
+
+
                     eBook and PDF
-            
+
                 </a>
-            
 
-            
+
+
         </li>
-    
 
-    
-        
+
+
+
         <li class="header">Customization</li>
-        
-        
-    
+
+
+
         <li class="chapter " data-level="3.1" data-path="../templating/">
-            
+
                 <a href="../templating/">
-            
-                    
+
+
                     Templating
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
             <ul class="articles">
-                
-    
+
+
         <li class="chapter " data-level="3.1.1" data-path="../templating/conrefs.html">
-            
+
                 <a href="../templating/conrefs.html">
-            
-                    
+
+
                     Content References
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="3.1.2" data-path="../templating/variables.html">
-            
+
                 <a href="../templating/variables.html">
-            
-                    
+
+
                     Variables
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="3.1.3" data-path="../templating/builtin.html">
-            
+
                 <a href="../templating/builtin.html">
-            
-                    
+
+
                     Builtin
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
 
             </ul>
-            
+
         </li>
-    
+
         <li class="chapter " data-level="3.2" data-path="./">
-            
+
                 <a href="./">
-            
-                    
+
+
                     Plugins
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
             <ul class="articles">
-                
-    
+
+
         <li class="chapter " data-level="3.2.1" data-path="create.html">
-            
+
                 <a href="create.html">
-            
-                    
+
+
                     Create a plugin
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="3.2.2" data-path="hooks.html">
-            
+
                 <a href="hooks.html">
-            
-                    
+
+
                     Hooks
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="3.2.3" data-path="blocks.html">
-            
+
                 <a href="blocks.html">
-            
-                    
+
+
                     Blocks
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="3.2.4" data-path="filters.html">
-            
+
                 <a href="filters.html">
-            
-                    
+
+
                     Filters
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="3.2.5" data-path="api.html">
-            
+
                 <a href="api.html">
-            
-                    
+
+
                     API & Context
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter active" data-level="3.2.6" data-path="testing.html">
-            
-                <a href="testing.html">
-            
-                    
-                    Test your plugin
-            
-                </a>
-            
 
-            
+                <a href="testing.html">
+
+
+                    Test your plugin
+
+                </a>
+
+
+
         </li>
-    
+
 
             </ul>
-            
+
         </li>
-    
+
         <li class="chapter " data-level="3.3" data-path="../themes/">
-            
+
                 <a href="../themes/">
-            
-                    
+
+
                     Theming
-            
+
                 </a>
-            
 
-            
+
+
         </li>
-    
 
-    
-        
+
+
+
         <li class="divider"></li>
-        
-        
-    
+
+
+
         <li class="chapter " data-level="4.1" data-path="../faq.html">
-            
+
                 <a href="../faq.html">
-            
-                    
+
+
                     FAQ
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="4.2" data-path="../examples.md">
-            
+
                 <span>
-            
-                    
+
+
                     Examples
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="4.3" >
-            
+
                 <a target="_blank" href="https://github.com/honkit/honkit/blob/master/CHANGELOG.md">
-            
-                    
+
+
                     Release notes
-            
+
                 </a>
-            
 
-            
+
+
         </li>
-    
 
-    
-        
+
+
+
         <li class="divider"></li>
-        
-        
-    
+
+
+
         <li class="chapter " data-level="5.1" data-path="../encoding.html">
-            
+
                 <a href="../encoding.html">
-            
-                    
+
+
                     Encoding
-            
+
                 </a>
-            
 
-            
+
+
         </li>
-    
 
-    
+
+
 
     <li class="divider"></li>
 
@@ -13229,18 +13229,18 @@ exports[`HonKit snapshots: plugins/testing.html 1`] = `
 
 
                 </nav>
-            
-        
+
+
     </div>
 
     <div class="book-body">
-        
+
             <div class="body-inner">
-                
-                    
+
+
 
 <div class="book-header" role="navigation">
-    
+
 
     <!-- Title -->
     <h1>
@@ -13254,12 +13254,12 @@ exports[`HonKit snapshots: plugins/testing.html 1`] = `
 
                     <div class="page-wrapper" tabindex="-1" role="main">
                         <div class="page-inner">
-                            
+
 <div id="book-search-results">
     <div class="search-noresults">
-    
+
                                 <section class="normal markdown-section">
-                                
+
 
                                 <h1 id="testing-your-plugin">Testing your plugin</h1>
 <h3 id="testing-your-plugin-locally">Testing your plugin locally</h3>
@@ -13271,64 +13271,64 @@ exports[`HonKit snapshots: plugins/testing.html 1`] = `
 </code></pre><h3 id="unit-testing-on-travis">Unit testing on Travis</h3>
 <p><a href="https://github.com/todvora/gitbook-tester" target="_blank">gitbook-tester</a> makes it easy to write <strong>Node.js/Mocha</strong> unit tests for your <a href="../GLOSSARY.html#plugins" class="glossary-term" title="Plugins are the best way to extend HonKit functionalities (ebook and website).">plugins</a>. Using <a href="https://travis.org" target="_blank">Travis.org</a>, tests can be run on each commits/tags.</p>
 
-                                
+
 <hr>
 <div class="btn-group btn-group-justified">
-    
+
     <a class="btn" href="api.html"><b>Previous:</b> API & Context</a>
-    
-    
+
+
     <a class="btn" href="../themes/"><b>Next:</b> Theming</a>
-    
+
 </div>
 
                                 </section>
-                            
+
     </div>
     <div class="search-results">
         <div class="has-results">
-            
+
             <h1 class="search-results-title"><span class='search-results-count'></span> results matching "<span class='search-query'></span>"</h1>
             <ul class="search-results-list"></ul>
-            
+
         </div>
         <div class="no-results">
-            
+
             <h1 class="search-results-title">No results matching "<span class='search-query'></span>"</h1>
-            
+
         </div>
     </div>
 </div>
 
                         </div>
                     </div>
-                
+
             </div>
 
-            
-                
+
+
                 <a href="api.html" class="navigation navigation-prev " aria-label="Previous page: API & Context">
                     <i class="fa fa-angle-left"></i>
                 </a>
-                
-                
+
+
                 <a href="../themes/" class="navigation navigation-next " aria-label="Next page: Theming">
                     <i class="fa fa-angle-right"></i>
                 </a>
-                
-            
-        
+
+
+
     </div>
 
     <script>
         var gitbook = gitbook || [];
         gitbook.push(function() {
-            
+
         });
     </script>
 </div>
 
-        
+
     <noscript>
         <style>
             .honkit-cloak {
@@ -13375,27 +13375,27 @@ exports[`HonKit snapshots: plugins/testing.html 1`] = `
     </script>
     <script src="../gitbook/gitbook.js"></script>
     <script src="../gitbook/theme.js"></script>
-    
-        
+
+
         <script src="../gitbook/gitbook-plugin-search/search-engine.js"></script>
-        
-    
-        
+
+
+
         <script src="../gitbook/gitbook-plugin-search/search.js"></script>
-        
-    
-        
+
+
+
         <script src="../gitbook/gitbook-plugin-lunr/lunr.min.js"></script>
-        
-    
-        
+
+
+
         <script src="../gitbook/gitbook-plugin-lunr/search-lunr.js"></script>
-        
-    
-        
+
+
+
         <script src="../gitbook/gitbook-plugin-fontsettings/fontsettings.js"></script>
-        
-    
+
+
 
     </body>
 </html>
@@ -13421,50 +13421,50 @@ exports[`HonKit snapshots: setup.html 1`] = `
         <title>Installation and Setup · HonKit Documentation</title>
         <meta http-equiv="X-UA-Compatible" content="IE=edge" />
         <meta name="description" content="">
-        
-        
-        
-        
-    
+
+
+
+
+
     <link rel="stylesheet" href="gitbook/style.css">
 
-    
-            
-                
+
+
+
                 <link rel="stylesheet" href="gitbook/@honkit/honkit-plugin-highlight/website.css">
-                
-            
-                
+
+
+
                 <link rel="stylesheet" href="gitbook/gitbook-plugin-search/search.css">
-                
-            
-                
+
+
+
                 <link rel="stylesheet" href="gitbook/gitbook-plugin-fontsettings/website.css">
-                
-            
-        
 
-    
 
-    
-        
+
+
+
+
+
+
         <link rel="stylesheet" href="styles/website.css">
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
 
-        
-    
-    
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
     <meta name="HandheldFriendly" content="true"/>
     <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no">
     <meta name="apple-mobile-web-app-capable" content="yes">
@@ -13472,557 +13472,557 @@ exports[`HonKit snapshots: setup.html 1`] = `
     <link rel="apple-touch-icon-precomposed" sizes="152x152" href="gitbook/images/apple-touch-icon-precomposed-152.png">
     <link rel="shortcut icon" href="gitbook/images/favicon.ico" type="image/x-icon">
 
-    
+
     <link rel="next" href="structure.html" />
-    
-    
+
+
     <link rel="prev" href="./" />
-    
+
 
     </head>
     <body>
-        
+
 <div class="book honkit-cloak">
     <div class="book-summary">
-        
-            
+
+
 <div id="book-search-input" role="search">
     <input type="text" placeholder="Type to search" />
 </div>
 
-            
+
                 <nav role="navigation">
-                
+
 
 
 <ul class="summary">
-    
-    
 
-    
 
-    
-        
+
+
+
+
+
         <li class="header">Getting Started</li>
-        
-        
-    
+
+
+
         <li class="chapter " data-level="1.1" data-path="./">
-            
+
                 <a href="./">
-            
-                    
+
+
                     About this documentation
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter active" data-level="1.2" data-path="setup.html">
-            
+
                 <a href="setup.html">
-            
-                    
+
+
                     Installation and Setup
-            
+
                 </a>
-            
 
-            
+
+
         </li>
-    
 
-    
-        
+
+
+
         <li class="header">Your Content</li>
-        
-        
-    
+
+
+
         <li class="chapter " data-level="2.1" data-path="structure.html">
-            
+
                 <a href="structure.html">
-            
-                    
+
+
                     Directory structure
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.2" data-path="pages.html">
-            
+
                 <a href="pages.html">
-            
-                    
+
+
                     Pages and Summary
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.3" data-path="config.html">
-            
+
                 <a href="config.html">
-            
-                    
+
+
                     Configuration
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.4" data-path="lexicon.html">
-            
+
                 <a href="lexicon.html">
-            
-                    
+
+
                     Glossary
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.5" data-path="languages.html">
-            
+
                 <a href="languages.html">
-            
-                    
+
+
                     Multi-Lingual
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.6" data-path="syntax/markdown.html">
-            
+
                 <a href="syntax/markdown.html">
-            
-                    
+
+
                     Markdown
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
             <ul class="articles">
-                
-    
+
+
         <li class="chapter " data-level="2.6.1" data-path="syntax/markdown.html">
-            
+
                 <a href="syntax/markdown.html#headings">
-            
-                    
+
+
                     Headings
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.6.2" data-path="syntax/markdown.html">
-            
+
                 <a href="syntax/markdown.html#paragraphs">
-            
-                    
+
+
                     Paragraphs
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.6.3" data-path="syntax/markdown.html">
-            
+
                 <a href="syntax/markdown.html#lists">
-            
-                    
+
+
                     Lists
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.6.4" data-path="syntax/markdown.html">
-            
+
                 <a href="syntax/markdown.html#links">
-            
-                    
+
+
                     Links
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.6.5" data-path="syntax/markdown.html">
-            
+
                 <a href="syntax/markdown.html#images">
-            
-                    
+
+
                     Images
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.6.6" data-path="syntax/markdown.html">
-            
+
                 <a href="syntax/markdown.html#blockquotes">
-            
-                    
+
+
                     Blockquotes
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.6.7" data-path="syntax/markdown.html">
-            
+
                 <a href="syntax/markdown.html#tables">
-            
-                    
+
+
                     Tables
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.6.8" data-path="syntax/markdown.html">
-            
+
                 <a href="syntax/markdown.html#code">
-            
-                    
+
+
                     Code
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.6.9" data-path="syntax/markdown.html">
-            
+
                 <a href="syntax/markdown.html#html">
-            
-                    
+
+
                     HTML
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.6.10" data-path="syntax/markdown.html">
-            
+
                 <a href="syntax/markdown.html#footnotes">
-            
-                    
+
+
                     Footnotes
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
 
             </ul>
-            
+
         </li>
-    
+
         <li class="chapter " data-level="2.7" data-path="syntax/asciidoc.html">
-            
+
                 <a href="syntax/asciidoc.html">
-            
-                    
+
+
                     AsciiDoc
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.8" data-path="ebook.html">
-            
+
                 <a href="ebook.html">
-            
-                    
+
+
                     eBook and PDF
-            
+
                 </a>
-            
 
-            
+
+
         </li>
-    
 
-    
-        
+
+
+
         <li class="header">Customization</li>
-        
-        
-    
+
+
+
         <li class="chapter " data-level="3.1" data-path="templating/">
-            
+
                 <a href="templating/">
-            
-                    
+
+
                     Templating
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
             <ul class="articles">
-                
-    
+
+
         <li class="chapter " data-level="3.1.1" data-path="templating/conrefs.html">
-            
+
                 <a href="templating/conrefs.html">
-            
-                    
+
+
                     Content References
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="3.1.2" data-path="templating/variables.html">
-            
+
                 <a href="templating/variables.html">
-            
-                    
+
+
                     Variables
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="3.1.3" data-path="templating/builtin.html">
-            
+
                 <a href="templating/builtin.html">
-            
-                    
+
+
                     Builtin
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
 
             </ul>
-            
+
         </li>
-    
+
         <li class="chapter " data-level="3.2" data-path="plugins/">
-            
+
                 <a href="plugins/">
-            
-                    
+
+
                     Plugins
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
             <ul class="articles">
-                
-    
+
+
         <li class="chapter " data-level="3.2.1" data-path="plugins/create.html">
-            
+
                 <a href="plugins/create.html">
-            
-                    
+
+
                     Create a plugin
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="3.2.2" data-path="plugins/hooks.html">
-            
+
                 <a href="plugins/hooks.html">
-            
-                    
+
+
                     Hooks
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="3.2.3" data-path="plugins/blocks.html">
-            
+
                 <a href="plugins/blocks.html">
-            
-                    
+
+
                     Blocks
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="3.2.4" data-path="plugins/filters.html">
-            
+
                 <a href="plugins/filters.html">
-            
-                    
+
+
                     Filters
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="3.2.5" data-path="plugins/api.html">
-            
+
                 <a href="plugins/api.html">
-            
-                    
+
+
                     API & Context
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="3.2.6" data-path="plugins/testing.html">
-            
-                <a href="plugins/testing.html">
-            
-                    
-                    Test your plugin
-            
-                </a>
-            
 
-            
+                <a href="plugins/testing.html">
+
+
+                    Test your plugin
+
+                </a>
+
+
+
         </li>
-    
+
 
             </ul>
-            
+
         </li>
-    
+
         <li class="chapter " data-level="3.3" data-path="themes/">
-            
+
                 <a href="themes/">
-            
-                    
+
+
                     Theming
-            
+
                 </a>
-            
 
-            
+
+
         </li>
-    
 
-    
-        
+
+
+
         <li class="divider"></li>
-        
-        
-    
+
+
+
         <li class="chapter " data-level="4.1" data-path="faq.html">
-            
+
                 <a href="faq.html">
-            
-                    
+
+
                     FAQ
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="4.2" data-path="examples.md">
-            
+
                 <span>
-            
-                    
+
+
                     Examples
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="4.3" >
-            
+
                 <a target="_blank" href="https://github.com/honkit/honkit/blob/master/CHANGELOG.md">
-            
-                    
+
+
                     Release notes
-            
+
                 </a>
-            
 
-            
+
+
         </li>
-    
 
-    
-        
+
+
+
         <li class="divider"></li>
-        
-        
-    
+
+
+
         <li class="chapter " data-level="5.1" data-path="encoding.html">
-            
+
                 <a href="encoding.html">
-            
-                    
+
+
                     Encoding
-            
+
                 </a>
-            
 
-            
+
+
         </li>
-    
 
-    
+
+
 
     <li class="divider"></li>
 
@@ -14035,18 +14035,18 @@ exports[`HonKit snapshots: setup.html 1`] = `
 
 
                 </nav>
-            
-        
+
+
     </div>
 
     <div class="book-body">
-        
+
             <div class="body-inner">
-                
-                    
+
+
 
 <div class="book-header" role="navigation">
-    
+
 
     <!-- Title -->
     <h1>
@@ -14060,12 +14060,12 @@ exports[`HonKit snapshots: setup.html 1`] = `
 
                     <div class="page-wrapper" tabindex="-1" role="main">
                         <div class="page-inner">
-                            
+
 <div id="book-search-results">
     <div class="search-noresults">
-    
+
                                 <section class="normal markdown-section">
-                                
+
 
                                 <h1 id="setup-and-installation-of-honkit">Setup and Installation of HonKit</h1>
 <p>Getting <a href="GLOSSARY.html#honkit" class="glossary-term" title="Honkit is a command line tool for building beautiful books using GitHub/Git and Markdown (or AsciiDoc).">HonKit</a> installed and ready-to-go should only take a few minutes.</p>
@@ -14102,7 +14102,7 @@ $ yarn add honkit --dev
   },
 </code></pre>
 <p>After this configuration, you can use <code>npm run</code> command.</p>
-<pre><code># Build 
+<pre><code># Build
 npm run build
 # Start to server
 npm run serve
@@ -14110,64 +14110,64 @@ npm run serve
 <p>You can use the options <code>--log=debug</code> and <code>--debug</code> to get better error messages (with stack trace). For example:</p>
 <pre><code>$ honkit build ./ --log=debug --debug
 </code></pre>
-                                
+
 <hr>
 <div class="btn-group btn-group-justified">
-    
+
     <a class="btn" href="./"><b>Previous:</b> About this documentation</a>
-    
-    
+
+
     <a class="btn" href="structure.html"><b>Next:</b> Directory structure</a>
-    
+
 </div>
 
                                 </section>
-                            
+
     </div>
     <div class="search-results">
         <div class="has-results">
-            
+
             <h1 class="search-results-title"><span class='search-results-count'></span> results matching "<span class='search-query'></span>"</h1>
             <ul class="search-results-list"></ul>
-            
+
         </div>
         <div class="no-results">
-            
+
             <h1 class="search-results-title">No results matching "<span class='search-query'></span>"</h1>
-            
+
         </div>
     </div>
 </div>
 
                         </div>
                     </div>
-                
+
             </div>
 
-            
-                
+
+
                 <a href="./" class="navigation navigation-prev " aria-label="Previous page: About this documentation">
                     <i class="fa fa-angle-left"></i>
                 </a>
-                
-                
+
+
                 <a href="structure.html" class="navigation navigation-next " aria-label="Next page: Directory structure">
                     <i class="fa fa-angle-right"></i>
                 </a>
-                
-            
-        
+
+
+
     </div>
 
     <script>
         var gitbook = gitbook || [];
         gitbook.push(function() {
-            
+
         });
     </script>
 </div>
 
-        
+
     <noscript>
         <style>
             .honkit-cloak {
@@ -14214,27 +14214,27 @@ npm run serve
     </script>
     <script src="gitbook/gitbook.js"></script>
     <script src="gitbook/theme.js"></script>
-    
-        
+
+
         <script src="gitbook/gitbook-plugin-search/search-engine.js"></script>
-        
-    
-        
+
+
+
         <script src="gitbook/gitbook-plugin-search/search.js"></script>
-        
-    
-        
+
+
+
         <script src="gitbook/gitbook-plugin-lunr/lunr.min.js"></script>
-        
-    
-        
+
+
+
         <script src="gitbook/gitbook-plugin-lunr/search-lunr.js"></script>
-        
-    
-        
+
+
+
         <script src="gitbook/gitbook-plugin-fontsettings/fontsettings.js"></script>
-        
-    
+
+
 
     </body>
 </html>
@@ -14260,50 +14260,50 @@ exports[`HonKit snapshots: structure.html 1`] = `
         <title>Directory structure · HonKit Documentation</title>
         <meta http-equiv="X-UA-Compatible" content="IE=edge" />
         <meta name="description" content="">
-        
-        
-        
-        
-    
+
+
+
+
+
     <link rel="stylesheet" href="gitbook/style.css">
 
-    
-            
-                
+
+
+
                 <link rel="stylesheet" href="gitbook/@honkit/honkit-plugin-highlight/website.css">
-                
-            
-                
+
+
+
                 <link rel="stylesheet" href="gitbook/gitbook-plugin-search/search.css">
-                
-            
-                
+
+
+
                 <link rel="stylesheet" href="gitbook/gitbook-plugin-fontsettings/website.css">
-                
-            
-        
 
-    
 
-    
-        
+
+
+
+
+
+
         <link rel="stylesheet" href="styles/website.css">
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
 
-        
-    
-    
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
     <meta name="HandheldFriendly" content="true"/>
     <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no">
     <meta name="apple-mobile-web-app-capable" content="yes">
@@ -14311,557 +14311,557 @@ exports[`HonKit snapshots: structure.html 1`] = `
     <link rel="apple-touch-icon-precomposed" sizes="152x152" href="gitbook/images/apple-touch-icon-precomposed-152.png">
     <link rel="shortcut icon" href="gitbook/images/favicon.ico" type="image/x-icon">
 
-    
+
     <link rel="next" href="pages.html" />
-    
-    
+
+
     <link rel="prev" href="setup.html" />
-    
+
 
     </head>
     <body>
-        
+
 <div class="book honkit-cloak">
     <div class="book-summary">
-        
-            
+
+
 <div id="book-search-input" role="search">
     <input type="text" placeholder="Type to search" />
 </div>
 
-            
+
                 <nav role="navigation">
-                
+
 
 
 <ul class="summary">
-    
-    
 
-    
 
-    
-        
+
+
+
+
+
         <li class="header">Getting Started</li>
-        
-        
-    
+
+
+
         <li class="chapter " data-level="1.1" data-path="./">
-            
+
                 <a href="./">
-            
-                    
+
+
                     About this documentation
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="1.2" data-path="setup.html">
-            
+
                 <a href="setup.html">
-            
-                    
+
+
                     Installation and Setup
-            
+
                 </a>
-            
 
-            
+
+
         </li>
-    
 
-    
-        
+
+
+
         <li class="header">Your Content</li>
-        
-        
-    
+
+
+
         <li class="chapter active" data-level="2.1" data-path="structure.html">
-            
+
                 <a href="structure.html">
-            
-                    
+
+
                     Directory structure
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.2" data-path="pages.html">
-            
+
                 <a href="pages.html">
-            
-                    
+
+
                     Pages and Summary
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.3" data-path="config.html">
-            
+
                 <a href="config.html">
-            
-                    
+
+
                     Configuration
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.4" data-path="lexicon.html">
-            
+
                 <a href="lexicon.html">
-            
-                    
+
+
                     Glossary
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.5" data-path="languages.html">
-            
+
                 <a href="languages.html">
-            
-                    
+
+
                     Multi-Lingual
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.6" data-path="syntax/markdown.html">
-            
+
                 <a href="syntax/markdown.html">
-            
-                    
+
+
                     Markdown
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
             <ul class="articles">
-                
-    
+
+
         <li class="chapter " data-level="2.6.1" data-path="syntax/markdown.html">
-            
+
                 <a href="syntax/markdown.html#headings">
-            
-                    
+
+
                     Headings
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.6.2" data-path="syntax/markdown.html">
-            
+
                 <a href="syntax/markdown.html#paragraphs">
-            
-                    
+
+
                     Paragraphs
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.6.3" data-path="syntax/markdown.html">
-            
+
                 <a href="syntax/markdown.html#lists">
-            
-                    
+
+
                     Lists
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.6.4" data-path="syntax/markdown.html">
-            
+
                 <a href="syntax/markdown.html#links">
-            
-                    
+
+
                     Links
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.6.5" data-path="syntax/markdown.html">
-            
+
                 <a href="syntax/markdown.html#images">
-            
-                    
+
+
                     Images
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.6.6" data-path="syntax/markdown.html">
-            
+
                 <a href="syntax/markdown.html#blockquotes">
-            
-                    
+
+
                     Blockquotes
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.6.7" data-path="syntax/markdown.html">
-            
+
                 <a href="syntax/markdown.html#tables">
-            
-                    
+
+
                     Tables
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.6.8" data-path="syntax/markdown.html">
-            
+
                 <a href="syntax/markdown.html#code">
-            
-                    
+
+
                     Code
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.6.9" data-path="syntax/markdown.html">
-            
+
                 <a href="syntax/markdown.html#html">
-            
-                    
+
+
                     HTML
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.6.10" data-path="syntax/markdown.html">
-            
+
                 <a href="syntax/markdown.html#footnotes">
-            
-                    
+
+
                     Footnotes
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
 
             </ul>
-            
+
         </li>
-    
+
         <li class="chapter " data-level="2.7" data-path="syntax/asciidoc.html">
-            
+
                 <a href="syntax/asciidoc.html">
-            
-                    
+
+
                     AsciiDoc
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.8" data-path="ebook.html">
-            
+
                 <a href="ebook.html">
-            
-                    
+
+
                     eBook and PDF
-            
+
                 </a>
-            
 
-            
+
+
         </li>
-    
 
-    
-        
+
+
+
         <li class="header">Customization</li>
-        
-        
-    
+
+
+
         <li class="chapter " data-level="3.1" data-path="templating/">
-            
+
                 <a href="templating/">
-            
-                    
+
+
                     Templating
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
             <ul class="articles">
-                
-    
+
+
         <li class="chapter " data-level="3.1.1" data-path="templating/conrefs.html">
-            
+
                 <a href="templating/conrefs.html">
-            
-                    
+
+
                     Content References
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="3.1.2" data-path="templating/variables.html">
-            
+
                 <a href="templating/variables.html">
-            
-                    
+
+
                     Variables
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="3.1.3" data-path="templating/builtin.html">
-            
+
                 <a href="templating/builtin.html">
-            
-                    
+
+
                     Builtin
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
 
             </ul>
-            
+
         </li>
-    
+
         <li class="chapter " data-level="3.2" data-path="plugins/">
-            
+
                 <a href="plugins/">
-            
-                    
+
+
                     Plugins
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
             <ul class="articles">
-                
-    
+
+
         <li class="chapter " data-level="3.2.1" data-path="plugins/create.html">
-            
+
                 <a href="plugins/create.html">
-            
-                    
+
+
                     Create a plugin
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="3.2.2" data-path="plugins/hooks.html">
-            
+
                 <a href="plugins/hooks.html">
-            
-                    
+
+
                     Hooks
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="3.2.3" data-path="plugins/blocks.html">
-            
+
                 <a href="plugins/blocks.html">
-            
-                    
+
+
                     Blocks
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="3.2.4" data-path="plugins/filters.html">
-            
+
                 <a href="plugins/filters.html">
-            
-                    
+
+
                     Filters
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="3.2.5" data-path="plugins/api.html">
-            
+
                 <a href="plugins/api.html">
-            
-                    
+
+
                     API & Context
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="3.2.6" data-path="plugins/testing.html">
-            
-                <a href="plugins/testing.html">
-            
-                    
-                    Test your plugin
-            
-                </a>
-            
 
-            
+                <a href="plugins/testing.html">
+
+
+                    Test your plugin
+
+                </a>
+
+
+
         </li>
-    
+
 
             </ul>
-            
+
         </li>
-    
+
         <li class="chapter " data-level="3.3" data-path="themes/">
-            
+
                 <a href="themes/">
-            
-                    
+
+
                     Theming
-            
+
                 </a>
-            
 
-            
+
+
         </li>
-    
 
-    
-        
+
+
+
         <li class="divider"></li>
-        
-        
-    
+
+
+
         <li class="chapter " data-level="4.1" data-path="faq.html">
-            
+
                 <a href="faq.html">
-            
-                    
+
+
                     FAQ
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="4.2" data-path="examples.md">
-            
+
                 <span>
-            
-                    
+
+
                     Examples
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="4.3" >
-            
+
                 <a target="_blank" href="https://github.com/honkit/honkit/blob/master/CHANGELOG.md">
-            
-                    
+
+
                     Release notes
-            
+
                 </a>
-            
 
-            
+
+
         </li>
-    
 
-    
-        
+
+
+
         <li class="divider"></li>
-        
-        
-    
+
+
+
         <li class="chapter " data-level="5.1" data-path="encoding.html">
-            
+
                 <a href="encoding.html">
-            
-                    
+
+
                     Encoding
-            
+
                 </a>
-            
 
-            
+
+
         </li>
-    
 
-    
+
+
 
     <li class="divider"></li>
 
@@ -14874,18 +14874,18 @@ exports[`HonKit snapshots: structure.html 1`] = `
 
 
                 </nav>
-            
-        
+
+
     </div>
 
     <div class="book-body">
-        
+
             <div class="body-inner">
-                
-                    
+
+
 
 <div class="book-header" role="navigation">
-    
+
 
     <!-- Title -->
     <h1>
@@ -14899,12 +14899,12 @@ exports[`HonKit snapshots: structure.html 1`] = `
 
                     <div class="page-wrapper" tabindex="-1" role="main">
                         <div class="page-inner">
-                            
+
 <div id="book-search-results">
     <div class="search-noresults">
-    
+
                                 <section class="normal markdown-section">
-                                
+
 
                                 <h1 id="directory-structure">Directory Structure</h1>
 <p><a href="GLOSSARY.html#honkit" class="glossary-term" title="Honkit is a command line tool for building beautiful books using GitHub/Git and Markdown (or AsciiDoc).">HonKit</a> uses a simple directory structure. All Markdown/Asciidoc files listed in the <a href="pages.html">SUMMARY</a> will be transformed as HTML. Multi-Lingual books have a slightly <a href="languages.html">different structure</a>.</p>
@@ -14970,64 +14970,64 @@ bin/*
     &quot;root&quot;: &quot;./docs&quot;
 }
 </code></pre>
-                                
+
 <hr>
 <div class="btn-group btn-group-justified">
-    
+
     <a class="btn" href="setup.html"><b>Previous:</b> Installation and Setup</a>
-    
-    
+
+
     <a class="btn" href="pages.html"><b>Next:</b> Pages and Summary</a>
-    
+
 </div>
 
                                 </section>
-                            
+
     </div>
     <div class="search-results">
         <div class="has-results">
-            
+
             <h1 class="search-results-title"><span class='search-results-count'></span> results matching "<span class='search-query'></span>"</h1>
             <ul class="search-results-list"></ul>
-            
+
         </div>
         <div class="no-results">
-            
+
             <h1 class="search-results-title">No results matching "<span class='search-query'></span>"</h1>
-            
+
         </div>
     </div>
 </div>
 
                         </div>
                     </div>
-                
+
             </div>
 
-            
-                
+
+
                 <a href="setup.html" class="navigation navigation-prev " aria-label="Previous page: Installation and Setup">
                     <i class="fa fa-angle-left"></i>
                 </a>
-                
-                
+
+
                 <a href="pages.html" class="navigation navigation-next " aria-label="Next page: Pages and Summary">
                     <i class="fa fa-angle-right"></i>
                 </a>
-                
-            
-        
+
+
+
     </div>
 
     <script>
         var gitbook = gitbook || [];
         gitbook.push(function() {
-            
+
         });
     </script>
 </div>
 
-        
+
     <noscript>
         <style>
             .honkit-cloak {
@@ -15074,27 +15074,27 @@ bin/*
     </script>
     <script src="gitbook/gitbook.js"></script>
     <script src="gitbook/theme.js"></script>
-    
-        
+
+
         <script src="gitbook/gitbook-plugin-search/search-engine.js"></script>
-        
-    
-        
+
+
+
         <script src="gitbook/gitbook-plugin-search/search.js"></script>
-        
-    
-        
+
+
+
         <script src="gitbook/gitbook-plugin-lunr/lunr.min.js"></script>
-        
-    
-        
+
+
+
         <script src="gitbook/gitbook-plugin-lunr/search-lunr.js"></script>
-        
-    
-        
+
+
+
         <script src="gitbook/gitbook-plugin-fontsettings/fontsettings.js"></script>
-        
-    
+
+
 
     </body>
 </html>
@@ -15120,50 +15120,50 @@ exports[`HonKit snapshots: syntax/asciidoc.html 1`] = `
         <title>AsciiDoc · HonKit Documentation</title>
         <meta http-equiv="X-UA-Compatible" content="IE=edge" />
         <meta name="description" content="">
-        
-        
-        
-        
-    
+
+
+
+
+
     <link rel="stylesheet" href="../gitbook/style.css">
 
-    
-            
-                
+
+
+
                 <link rel="stylesheet" href="../gitbook/@honkit/honkit-plugin-highlight/website.css">
-                
-            
-                
+
+
+
                 <link rel="stylesheet" href="../gitbook/gitbook-plugin-search/search.css">
-                
-            
-                
+
+
+
                 <link rel="stylesheet" href="../gitbook/gitbook-plugin-fontsettings/website.css">
-                
-            
-        
 
-    
 
-    
-        
+
+
+
+
+
+
         <link rel="stylesheet" href="../styles/website.css">
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
 
-        
-    
-    
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
     <meta name="HandheldFriendly" content="true"/>
     <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no">
     <meta name="apple-mobile-web-app-capable" content="yes">
@@ -15171,557 +15171,557 @@ exports[`HonKit snapshots: syntax/asciidoc.html 1`] = `
     <link rel="apple-touch-icon-precomposed" sizes="152x152" href="../gitbook/images/apple-touch-icon-precomposed-152.png">
     <link rel="shortcut icon" href="../gitbook/images/favicon.ico" type="image/x-icon">
 
-    
+
     <link rel="next" href="../ebook.html" />
-    
-    
+
+
     <link rel="prev" href="markdown.html" />
-    
+
 
     </head>
     <body>
-        
+
 <div class="book honkit-cloak">
     <div class="book-summary">
-        
-            
+
+
 <div id="book-search-input" role="search">
     <input type="text" placeholder="Type to search" />
 </div>
 
-            
+
                 <nav role="navigation">
-                
+
 
 
 <ul class="summary">
-    
-    
 
-    
 
-    
-        
+
+
+
+
+
         <li class="header">Getting Started</li>
-        
-        
-    
+
+
+
         <li class="chapter " data-level="1.1" data-path="../">
-            
+
                 <a href="../">
-            
-                    
+
+
                     About this documentation
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="1.2" data-path="../setup.html">
-            
+
                 <a href="../setup.html">
-            
-                    
+
+
                     Installation and Setup
-            
+
                 </a>
-            
 
-            
+
+
         </li>
-    
 
-    
-        
+
+
+
         <li class="header">Your Content</li>
-        
-        
-    
+
+
+
         <li class="chapter " data-level="2.1" data-path="../structure.html">
-            
+
                 <a href="../structure.html">
-            
-                    
+
+
                     Directory structure
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.2" data-path="../pages.html">
-            
+
                 <a href="../pages.html">
-            
-                    
+
+
                     Pages and Summary
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.3" data-path="../config.html">
-            
+
                 <a href="../config.html">
-            
-                    
+
+
                     Configuration
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.4" data-path="../lexicon.html">
-            
+
                 <a href="../lexicon.html">
-            
-                    
+
+
                     Glossary
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.5" data-path="../languages.html">
-            
+
                 <a href="../languages.html">
-            
-                    
+
+
                     Multi-Lingual
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.6" data-path="markdown.html">
-            
+
                 <a href="markdown.html">
-            
-                    
+
+
                     Markdown
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
             <ul class="articles">
-                
-    
+
+
         <li class="chapter " data-level="2.6.1" data-path="markdown.html">
-            
+
                 <a href="markdown.html#headings">
-            
-                    
+
+
                     Headings
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.6.2" data-path="markdown.html">
-            
+
                 <a href="markdown.html#paragraphs">
-            
-                    
+
+
                     Paragraphs
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.6.3" data-path="markdown.html">
-            
+
                 <a href="markdown.html#lists">
-            
-                    
+
+
                     Lists
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.6.4" data-path="markdown.html">
-            
+
                 <a href="markdown.html#links">
-            
-                    
+
+
                     Links
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.6.5" data-path="markdown.html">
-            
+
                 <a href="markdown.html#images">
-            
-                    
+
+
                     Images
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.6.6" data-path="markdown.html">
-            
+
                 <a href="markdown.html#blockquotes">
-            
-                    
+
+
                     Blockquotes
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.6.7" data-path="markdown.html">
-            
+
                 <a href="markdown.html#tables">
-            
-                    
+
+
                     Tables
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.6.8" data-path="markdown.html">
-            
+
                 <a href="markdown.html#code">
-            
-                    
+
+
                     Code
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.6.9" data-path="markdown.html">
-            
+
                 <a href="markdown.html#html">
-            
-                    
+
+
                     HTML
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.6.10" data-path="markdown.html">
-            
+
                 <a href="markdown.html#footnotes">
-            
-                    
+
+
                     Footnotes
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
 
             </ul>
-            
+
         </li>
-    
+
         <li class="chapter active" data-level="2.7" data-path="asciidoc.html">
-            
+
                 <a href="asciidoc.html">
-            
-                    
+
+
                     AsciiDoc
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.8" data-path="../ebook.html">
-            
+
                 <a href="../ebook.html">
-            
-                    
+
+
                     eBook and PDF
-            
+
                 </a>
-            
 
-            
+
+
         </li>
-    
 
-    
-        
+
+
+
         <li class="header">Customization</li>
-        
-        
-    
+
+
+
         <li class="chapter " data-level="3.1" data-path="../templating/">
-            
+
                 <a href="../templating/">
-            
-                    
+
+
                     Templating
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
             <ul class="articles">
-                
-    
+
+
         <li class="chapter " data-level="3.1.1" data-path="../templating/conrefs.html">
-            
+
                 <a href="../templating/conrefs.html">
-            
-                    
+
+
                     Content References
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="3.1.2" data-path="../templating/variables.html">
-            
+
                 <a href="../templating/variables.html">
-            
-                    
+
+
                     Variables
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="3.1.3" data-path="../templating/builtin.html">
-            
+
                 <a href="../templating/builtin.html">
-            
-                    
+
+
                     Builtin
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
 
             </ul>
-            
+
         </li>
-    
+
         <li class="chapter " data-level="3.2" data-path="../plugins/">
-            
+
                 <a href="../plugins/">
-            
-                    
+
+
                     Plugins
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
             <ul class="articles">
-                
-    
+
+
         <li class="chapter " data-level="3.2.1" data-path="../plugins/create.html">
-            
+
                 <a href="../plugins/create.html">
-            
-                    
+
+
                     Create a plugin
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="3.2.2" data-path="../plugins/hooks.html">
-            
+
                 <a href="../plugins/hooks.html">
-            
-                    
+
+
                     Hooks
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="3.2.3" data-path="../plugins/blocks.html">
-            
+
                 <a href="../plugins/blocks.html">
-            
-                    
+
+
                     Blocks
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="3.2.4" data-path="../plugins/filters.html">
-            
+
                 <a href="../plugins/filters.html">
-            
-                    
+
+
                     Filters
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="3.2.5" data-path="../plugins/api.html">
-            
+
                 <a href="../plugins/api.html">
-            
-                    
+
+
                     API & Context
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="3.2.6" data-path="../plugins/testing.html">
-            
-                <a href="../plugins/testing.html">
-            
-                    
-                    Test your plugin
-            
-                </a>
-            
 
-            
+                <a href="../plugins/testing.html">
+
+
+                    Test your plugin
+
+                </a>
+
+
+
         </li>
-    
+
 
             </ul>
-            
+
         </li>
-    
+
         <li class="chapter " data-level="3.3" data-path="../themes/">
-            
+
                 <a href="../themes/">
-            
-                    
+
+
                     Theming
-            
+
                 </a>
-            
 
-            
+
+
         </li>
-    
 
-    
-        
+
+
+
         <li class="divider"></li>
-        
-        
-    
+
+
+
         <li class="chapter " data-level="4.1" data-path="../faq.html">
-            
+
                 <a href="../faq.html">
-            
-                    
+
+
                     FAQ
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="4.2" data-path="../examples.md">
-            
+
                 <span>
-            
-                    
+
+
                     Examples
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="4.3" >
-            
+
                 <a target="_blank" href="https://github.com/honkit/honkit/blob/master/CHANGELOG.md">
-            
-                    
+
+
                     Release notes
-            
+
                 </a>
-            
 
-            
+
+
         </li>
-    
 
-    
-        
+
+
+
         <li class="divider"></li>
-        
-        
-    
+
+
+
         <li class="chapter " data-level="5.1" data-path="../encoding.html">
-            
+
                 <a href="../encoding.html">
-            
-                    
+
+
                     Encoding
-            
+
                 </a>
-            
 
-            
+
+
         </li>
-    
 
-    
+
+
 
     <li class="divider"></li>
 
@@ -15734,18 +15734,18 @@ exports[`HonKit snapshots: syntax/asciidoc.html 1`] = `
 
 
                 </nav>
-            
-        
+
+
     </div>
 
     <div class="book-body">
-        
+
             <div class="body-inner">
-                
-                    
+
+
 
 <div class="book-header" role="navigation">
-    
+
 
     <!-- Title -->
     <h1>
@@ -15759,12 +15759,12 @@ exports[`HonKit snapshots: syntax/asciidoc.html 1`] = `
 
                     <div class="page-wrapper" tabindex="-1" role="main">
                         <div class="page-inner">
-                            
+
 <div id="book-search-results">
     <div class="search-noresults">
-    
+
                                 <section class="normal markdown-section">
-                                
+
 
                                 <h1 id="asciidoc">AsciiDoc</h1>
 <p>Since version <code>2.0.0</code>, <a href="../GLOSSARY.html#honkit" class="glossary-term" title="Honkit is a command line tool for building beautiful books using GitHub/Git and Markdown (or AsciiDoc).">HonKit</a> can also accept AsciiDoc as an input format.</p>
@@ -15812,64 +15812,64 @@ his personal homepage (PHP originally stood for &quot;Personal Home Page&quot;
 but now stands for &quot;PHP: Hypertext Preprocessor&quot;).
 </code></pre>
 
-                                
+
 <hr>
 <div class="btn-group btn-group-justified">
-    
+
     <a class="btn" href="markdown.html"><b>Previous:</b> Markdown</a>
-    
-    
+
+
     <a class="btn" href="../ebook.html"><b>Next:</b> eBook and PDF</a>
-    
+
 </div>
 
                                 </section>
-                            
+
     </div>
     <div class="search-results">
         <div class="has-results">
-            
+
             <h1 class="search-results-title"><span class='search-results-count'></span> results matching "<span class='search-query'></span>"</h1>
             <ul class="search-results-list"></ul>
-            
+
         </div>
         <div class="no-results">
-            
+
             <h1 class="search-results-title">No results matching "<span class='search-query'></span>"</h1>
-            
+
         </div>
     </div>
 </div>
 
                         </div>
                     </div>
-                
+
             </div>
 
-            
-                
+
+
                 <a href="markdown.html" class="navigation navigation-prev " aria-label="Previous page: Markdown">
                     <i class="fa fa-angle-left"></i>
                 </a>
-                
-                
+
+
                 <a href="../ebook.html" class="navigation navigation-next " aria-label="Next page: eBook and PDF">
                     <i class="fa fa-angle-right"></i>
                 </a>
-                
-            
-        
+
+
+
     </div>
 
     <script>
         var gitbook = gitbook || [];
         gitbook.push(function() {
-            
+
         });
     </script>
 </div>
 
-        
+
     <noscript>
         <style>
             .honkit-cloak {
@@ -15916,27 +15916,27 @@ but now stands for &quot;PHP: Hypertext Preprocessor&quot;).
     </script>
     <script src="../gitbook/gitbook.js"></script>
     <script src="../gitbook/theme.js"></script>
-    
-        
+
+
         <script src="../gitbook/gitbook-plugin-search/search-engine.js"></script>
-        
-    
-        
+
+
+
         <script src="../gitbook/gitbook-plugin-search/search.js"></script>
-        
-    
-        
+
+
+
         <script src="../gitbook/gitbook-plugin-lunr/lunr.min.js"></script>
-        
-    
-        
+
+
+
         <script src="../gitbook/gitbook-plugin-lunr/search-lunr.js"></script>
-        
-    
-        
+
+
+
         <script src="../gitbook/gitbook-plugin-fontsettings/fontsettings.js"></script>
-        
-    
+
+
 
     </body>
 </html>
@@ -15962,50 +15962,50 @@ exports[`HonKit snapshots: syntax/markdown.html 1`] = `
         <title>Markdown · HonKit Documentation</title>
         <meta http-equiv="X-UA-Compatible" content="IE=edge" />
         <meta name="description" content="">
-        
-        
-        
-        
-    
+
+
+
+
+
     <link rel="stylesheet" href="../gitbook/style.css">
 
-    
-            
-                
+
+
+
                 <link rel="stylesheet" href="../gitbook/@honkit/honkit-plugin-highlight/website.css">
-                
-            
-                
+
+
+
                 <link rel="stylesheet" href="../gitbook/gitbook-plugin-search/search.css">
-                
-            
-                
+
+
+
                 <link rel="stylesheet" href="../gitbook/gitbook-plugin-fontsettings/website.css">
-                
-            
-        
 
-    
 
-    
-        
+
+
+
+
+
+
         <link rel="stylesheet" href="../styles/website.css">
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
 
-        
-    
-    
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
     <meta name="HandheldFriendly" content="true"/>
     <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no">
     <meta name="apple-mobile-web-app-capable" content="yes">
@@ -16013,557 +16013,557 @@ exports[`HonKit snapshots: syntax/markdown.html 1`] = `
     <link rel="apple-touch-icon-precomposed" sizes="152x152" href="../gitbook/images/apple-touch-icon-precomposed-152.png">
     <link rel="shortcut icon" href="../gitbook/images/favicon.ico" type="image/x-icon">
 
-    
+
     <link rel="next" href="asciidoc.html" />
-    
-    
+
+
     <link rel="prev" href="../languages.html" />
-    
+
 
     </head>
     <body>
-        
+
 <div class="book honkit-cloak">
     <div class="book-summary">
-        
-            
+
+
 <div id="book-search-input" role="search">
     <input type="text" placeholder="Type to search" />
 </div>
 
-            
+
                 <nav role="navigation">
-                
+
 
 
 <ul class="summary">
-    
-    
 
-    
 
-    
-        
+
+
+
+
+
         <li class="header">Getting Started</li>
-        
-        
-    
+
+
+
         <li class="chapter " data-level="1.1" data-path="../">
-            
+
                 <a href="../">
-            
-                    
+
+
                     About this documentation
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="1.2" data-path="../setup.html">
-            
+
                 <a href="../setup.html">
-            
-                    
+
+
                     Installation and Setup
-            
+
                 </a>
-            
 
-            
+
+
         </li>
-    
 
-    
-        
+
+
+
         <li class="header">Your Content</li>
-        
-        
-    
+
+
+
         <li class="chapter " data-level="2.1" data-path="../structure.html">
-            
+
                 <a href="../structure.html">
-            
-                    
+
+
                     Directory structure
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.2" data-path="../pages.html">
-            
+
                 <a href="../pages.html">
-            
-                    
+
+
                     Pages and Summary
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.3" data-path="../config.html">
-            
+
                 <a href="../config.html">
-            
-                    
+
+
                     Configuration
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.4" data-path="../lexicon.html">
-            
+
                 <a href="../lexicon.html">
-            
-                    
+
+
                     Glossary
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.5" data-path="../languages.html">
-            
+
                 <a href="../languages.html">
-            
-                    
+
+
                     Multi-Lingual
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter active" data-level="2.6" data-path="markdown.html">
-            
+
                 <a href="markdown.html">
-            
-                    
+
+
                     Markdown
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
             <ul class="articles">
-                
-    
+
+
         <li class="chapter " data-level="2.6.1" data-path="markdown.html">
-            
+
                 <a href="markdown.html#headings">
-            
-                    
+
+
                     Headings
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.6.2" data-path="markdown.html">
-            
+
                 <a href="markdown.html#paragraphs">
-            
-                    
+
+
                     Paragraphs
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.6.3" data-path="markdown.html">
-            
+
                 <a href="markdown.html#lists">
-            
-                    
+
+
                     Lists
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.6.4" data-path="markdown.html">
-            
+
                 <a href="markdown.html#links">
-            
-                    
+
+
                     Links
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.6.5" data-path="markdown.html">
-            
+
                 <a href="markdown.html#images">
-            
-                    
+
+
                     Images
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.6.6" data-path="markdown.html">
-            
+
                 <a href="markdown.html#blockquotes">
-            
-                    
+
+
                     Blockquotes
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.6.7" data-path="markdown.html">
-            
+
                 <a href="markdown.html#tables">
-            
-                    
+
+
                     Tables
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.6.8" data-path="markdown.html">
-            
+
                 <a href="markdown.html#code">
-            
-                    
+
+
                     Code
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.6.9" data-path="markdown.html">
-            
+
                 <a href="markdown.html#html">
-            
-                    
+
+
                     HTML
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.6.10" data-path="markdown.html">
-            
+
                 <a href="markdown.html#footnotes">
-            
-                    
+
+
                     Footnotes
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
 
             </ul>
-            
+
         </li>
-    
+
         <li class="chapter " data-level="2.7" data-path="asciidoc.html">
-            
+
                 <a href="asciidoc.html">
-            
-                    
+
+
                     AsciiDoc
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.8" data-path="../ebook.html">
-            
+
                 <a href="../ebook.html">
-            
-                    
+
+
                     eBook and PDF
-            
+
                 </a>
-            
 
-            
+
+
         </li>
-    
 
-    
-        
+
+
+
         <li class="header">Customization</li>
-        
-        
-    
+
+
+
         <li class="chapter " data-level="3.1" data-path="../templating/">
-            
+
                 <a href="../templating/">
-            
-                    
+
+
                     Templating
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
             <ul class="articles">
-                
-    
+
+
         <li class="chapter " data-level="3.1.1" data-path="../templating/conrefs.html">
-            
+
                 <a href="../templating/conrefs.html">
-            
-                    
+
+
                     Content References
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="3.1.2" data-path="../templating/variables.html">
-            
+
                 <a href="../templating/variables.html">
-            
-                    
+
+
                     Variables
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="3.1.3" data-path="../templating/builtin.html">
-            
+
                 <a href="../templating/builtin.html">
-            
-                    
+
+
                     Builtin
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
 
             </ul>
-            
+
         </li>
-    
+
         <li class="chapter " data-level="3.2" data-path="../plugins/">
-            
+
                 <a href="../plugins/">
-            
-                    
+
+
                     Plugins
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
             <ul class="articles">
-                
-    
+
+
         <li class="chapter " data-level="3.2.1" data-path="../plugins/create.html">
-            
+
                 <a href="../plugins/create.html">
-            
-                    
+
+
                     Create a plugin
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="3.2.2" data-path="../plugins/hooks.html">
-            
+
                 <a href="../plugins/hooks.html">
-            
-                    
+
+
                     Hooks
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="3.2.3" data-path="../plugins/blocks.html">
-            
+
                 <a href="../plugins/blocks.html">
-            
-                    
+
+
                     Blocks
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="3.2.4" data-path="../plugins/filters.html">
-            
+
                 <a href="../plugins/filters.html">
-            
-                    
+
+
                     Filters
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="3.2.5" data-path="../plugins/api.html">
-            
+
                 <a href="../plugins/api.html">
-            
-                    
+
+
                     API & Context
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="3.2.6" data-path="../plugins/testing.html">
-            
-                <a href="../plugins/testing.html">
-            
-                    
-                    Test your plugin
-            
-                </a>
-            
 
-            
+                <a href="../plugins/testing.html">
+
+
+                    Test your plugin
+
+                </a>
+
+
+
         </li>
-    
+
 
             </ul>
-            
+
         </li>
-    
+
         <li class="chapter " data-level="3.3" data-path="../themes/">
-            
+
                 <a href="../themes/">
-            
-                    
+
+
                     Theming
-            
+
                 </a>
-            
 
-            
+
+
         </li>
-    
 
-    
-        
+
+
+
         <li class="divider"></li>
-        
-        
-    
+
+
+
         <li class="chapter " data-level="4.1" data-path="../faq.html">
-            
+
                 <a href="../faq.html">
-            
-                    
+
+
                     FAQ
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="4.2" data-path="../examples.md">
-            
+
                 <span>
-            
-                    
+
+
                     Examples
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="4.3" >
-            
+
                 <a target="_blank" href="https://github.com/honkit/honkit/blob/master/CHANGELOG.md">
-            
-                    
+
+
                     Release notes
-            
+
                 </a>
-            
 
-            
+
+
         </li>
-    
 
-    
-        
+
+
+
         <li class="divider"></li>
-        
-        
-    
+
+
+
         <li class="chapter " data-level="5.1" data-path="../encoding.html">
-            
+
                 <a href="../encoding.html">
-            
-                    
+
+
                     Encoding
-            
+
                 </a>
-            
 
-            
+
+
         </li>
-    
 
-    
+
+
 
     <li class="divider"></li>
 
@@ -16576,18 +16576,18 @@ exports[`HonKit snapshots: syntax/markdown.html 1`] = `
 
 
                 </nav>
-            
-        
+
+
     </div>
 
     <div class="book-body">
-        
+
             <div class="body-inner">
-                
-                    
+
+
 
 <div class="book-header" role="navigation">
-    
+
 
     <!-- Title -->
     <h1>
@@ -16601,12 +16601,12 @@ exports[`HonKit snapshots: syntax/markdown.html 1`] = `
 
                     <div class="page-wrapper" tabindex="-1" role="main">
                         <div class="page-inner">
-                            
+
 <div id="book-search-results">
     <div class="search-noresults">
-    
+
                                 <section class="normal markdown-section">
-                                
+
 
                                 <h1 id="markdown">Markdown</h1>
 <p>Most of the examples from this documentation are in Markdown. Markdown is default parser for <a href="../GLOSSARY.html#honkit" class="glossary-term" title="Honkit is a command line tool for building beautiful books using GitHub/Git and Markdown (or AsciiDoc).">HonKit</a>, but one can also opt for the <a href="asciidoc.html">AsciiDoc syntax</a>.</p>
@@ -16744,64 +16744,64 @@ Asterisks
 <p>You can tell <a href="../GLOSSARY.html#honkit" class="glossary-term" title="Honkit is a command line tool for building beautiful books using GitHub/Git and Markdown (or AsciiDoc).">HonKit</a> to ignore (or escape) Markdown formatting by using <code>\\</code> before the Markdown character.</p>
 <pre><code>Let&apos;s rename \\*our-new-project\\* to \\*our-old-project\\*.
 </code></pre>
-                                
+
 <hr>
 <div class="btn-group btn-group-justified">
-    
+
     <a class="btn" href="../languages.html"><b>Previous:</b> Multi-Lingual</a>
-    
-    
+
+
     <a class="btn" href="asciidoc.html"><b>Next:</b> AsciiDoc</a>
-    
+
 </div>
 
                                 </section>
-                            
+
     </div>
     <div class="search-results">
         <div class="has-results">
-            
+
             <h1 class="search-results-title"><span class='search-results-count'></span> results matching "<span class='search-query'></span>"</h1>
             <ul class="search-results-list"></ul>
-            
+
         </div>
         <div class="no-results">
-            
+
             <h1 class="search-results-title">No results matching "<span class='search-query'></span>"</h1>
-            
+
         </div>
     </div>
 </div>
 
                         </div>
                     </div>
-                
+
             </div>
 
-            
-                
+
+
                 <a href="../languages.html" class="navigation navigation-prev " aria-label="Previous page: Multi-Lingual">
                     <i class="fa fa-angle-left"></i>
                 </a>
-                
-                
+
+
                 <a href="asciidoc.html" class="navigation navigation-next " aria-label="Next page: AsciiDoc">
                     <i class="fa fa-angle-right"></i>
                 </a>
-                
-            
-        
+
+
+
     </div>
 
     <script>
         var gitbook = gitbook || [];
         gitbook.push(function() {
-            
+
         });
     </script>
 </div>
 
-        
+
     <noscript>
         <style>
             .honkit-cloak {
@@ -16848,27 +16848,27 @@ Asterisks
     </script>
     <script src="../gitbook/gitbook.js"></script>
     <script src="../gitbook/theme.js"></script>
-    
-        
+
+
         <script src="../gitbook/gitbook-plugin-search/search-engine.js"></script>
-        
-    
-        
+
+
+
         <script src="../gitbook/gitbook-plugin-search/search.js"></script>
-        
-    
-        
+
+
+
         <script src="../gitbook/gitbook-plugin-lunr/lunr.min.js"></script>
-        
-    
-        
+
+
+
         <script src="../gitbook/gitbook-plugin-lunr/search-lunr.js"></script>
-        
-    
-        
+
+
+
         <script src="../gitbook/gitbook-plugin-fontsettings/fontsettings.js"></script>
-        
-    
+
+
 
     </body>
 </html>
@@ -16894,50 +16894,50 @@ exports[`HonKit snapshots: templating/builtin.html 1`] = `
         <title>Builtin · HonKit Documentation</title>
         <meta http-equiv="X-UA-Compatible" content="IE=edge" />
         <meta name="description" content="">
-        
-        
-        
-        
-    
+
+
+
+
+
     <link rel="stylesheet" href="../gitbook/style.css">
 
-    
-            
-                
+
+
+
                 <link rel="stylesheet" href="../gitbook/@honkit/honkit-plugin-highlight/website.css">
-                
-            
-                
+
+
+
                 <link rel="stylesheet" href="../gitbook/gitbook-plugin-search/search.css">
-                
-            
-                
+
+
+
                 <link rel="stylesheet" href="../gitbook/gitbook-plugin-fontsettings/website.css">
-                
-            
-        
 
-    
 
-    
-        
+
+
+
+
+
+
         <link rel="stylesheet" href="../styles/website.css">
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
 
-        
-    
-    
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
     <meta name="HandheldFriendly" content="true"/>
     <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no">
     <meta name="apple-mobile-web-app-capable" content="yes">
@@ -16945,557 +16945,557 @@ exports[`HonKit snapshots: templating/builtin.html 1`] = `
     <link rel="apple-touch-icon-precomposed" sizes="152x152" href="../gitbook/images/apple-touch-icon-precomposed-152.png">
     <link rel="shortcut icon" href="../gitbook/images/favicon.ico" type="image/x-icon">
 
-    
+
     <link rel="next" href="../plugins/" />
-    
-    
+
+
     <link rel="prev" href="variables.html" />
-    
+
 
     </head>
     <body>
-        
+
 <div class="book honkit-cloak">
     <div class="book-summary">
-        
-            
+
+
 <div id="book-search-input" role="search">
     <input type="text" placeholder="Type to search" />
 </div>
 
-            
+
                 <nav role="navigation">
-                
+
 
 
 <ul class="summary">
-    
-    
 
-    
 
-    
-        
+
+
+
+
+
         <li class="header">Getting Started</li>
-        
-        
-    
+
+
+
         <li class="chapter " data-level="1.1" data-path="../">
-            
+
                 <a href="../">
-            
-                    
+
+
                     About this documentation
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="1.2" data-path="../setup.html">
-            
+
                 <a href="../setup.html">
-            
-                    
+
+
                     Installation and Setup
-            
+
                 </a>
-            
 
-            
+
+
         </li>
-    
 
-    
-        
+
+
+
         <li class="header">Your Content</li>
-        
-        
-    
+
+
+
         <li class="chapter " data-level="2.1" data-path="../structure.html">
-            
+
                 <a href="../structure.html">
-            
-                    
+
+
                     Directory structure
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.2" data-path="../pages.html">
-            
+
                 <a href="../pages.html">
-            
-                    
+
+
                     Pages and Summary
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.3" data-path="../config.html">
-            
+
                 <a href="../config.html">
-            
-                    
+
+
                     Configuration
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.4" data-path="../lexicon.html">
-            
+
                 <a href="../lexicon.html">
-            
-                    
+
+
                     Glossary
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.5" data-path="../languages.html">
-            
+
                 <a href="../languages.html">
-            
-                    
+
+
                     Multi-Lingual
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.6" data-path="../syntax/markdown.html">
-            
+
                 <a href="../syntax/markdown.html">
-            
-                    
+
+
                     Markdown
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
             <ul class="articles">
-                
-    
+
+
         <li class="chapter " data-level="2.6.1" data-path="../syntax/markdown.html">
-            
+
                 <a href="../syntax/markdown.html#headings">
-            
-                    
+
+
                     Headings
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.6.2" data-path="../syntax/markdown.html">
-            
+
                 <a href="../syntax/markdown.html#paragraphs">
-            
-                    
+
+
                     Paragraphs
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.6.3" data-path="../syntax/markdown.html">
-            
+
                 <a href="../syntax/markdown.html#lists">
-            
-                    
+
+
                     Lists
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.6.4" data-path="../syntax/markdown.html">
-            
+
                 <a href="../syntax/markdown.html#links">
-            
-                    
+
+
                     Links
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.6.5" data-path="../syntax/markdown.html">
-            
+
                 <a href="../syntax/markdown.html#images">
-            
-                    
+
+
                     Images
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.6.6" data-path="../syntax/markdown.html">
-            
+
                 <a href="../syntax/markdown.html#blockquotes">
-            
-                    
+
+
                     Blockquotes
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.6.7" data-path="../syntax/markdown.html">
-            
+
                 <a href="../syntax/markdown.html#tables">
-            
-                    
+
+
                     Tables
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.6.8" data-path="../syntax/markdown.html">
-            
+
                 <a href="../syntax/markdown.html#code">
-            
-                    
+
+
                     Code
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.6.9" data-path="../syntax/markdown.html">
-            
+
                 <a href="../syntax/markdown.html#html">
-            
-                    
+
+
                     HTML
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.6.10" data-path="../syntax/markdown.html">
-            
+
                 <a href="../syntax/markdown.html#footnotes">
-            
-                    
+
+
                     Footnotes
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
 
             </ul>
-            
+
         </li>
-    
+
         <li class="chapter " data-level="2.7" data-path="../syntax/asciidoc.html">
-            
+
                 <a href="../syntax/asciidoc.html">
-            
-                    
+
+
                     AsciiDoc
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.8" data-path="../ebook.html">
-            
+
                 <a href="../ebook.html">
-            
-                    
+
+
                     eBook and PDF
-            
+
                 </a>
-            
 
-            
+
+
         </li>
-    
 
-    
-        
+
+
+
         <li class="header">Customization</li>
-        
-        
-    
+
+
+
         <li class="chapter " data-level="3.1" data-path="./">
-            
+
                 <a href="./">
-            
-                    
+
+
                     Templating
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
             <ul class="articles">
-                
-    
+
+
         <li class="chapter " data-level="3.1.1" data-path="conrefs.html">
-            
+
                 <a href="conrefs.html">
-            
-                    
+
+
                     Content References
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="3.1.2" data-path="variables.html">
-            
+
                 <a href="variables.html">
-            
-                    
+
+
                     Variables
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter active" data-level="3.1.3" data-path="builtin.html">
-            
+
                 <a href="builtin.html">
-            
-                    
+
+
                     Builtin
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
 
             </ul>
-            
+
         </li>
-    
+
         <li class="chapter " data-level="3.2" data-path="../plugins/">
-            
+
                 <a href="../plugins/">
-            
-                    
+
+
                     Plugins
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
             <ul class="articles">
-                
-    
+
+
         <li class="chapter " data-level="3.2.1" data-path="../plugins/create.html">
-            
+
                 <a href="../plugins/create.html">
-            
-                    
+
+
                     Create a plugin
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="3.2.2" data-path="../plugins/hooks.html">
-            
+
                 <a href="../plugins/hooks.html">
-            
-                    
+
+
                     Hooks
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="3.2.3" data-path="../plugins/blocks.html">
-            
+
                 <a href="../plugins/blocks.html">
-            
-                    
+
+
                     Blocks
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="3.2.4" data-path="../plugins/filters.html">
-            
+
                 <a href="../plugins/filters.html">
-            
-                    
+
+
                     Filters
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="3.2.5" data-path="../plugins/api.html">
-            
+
                 <a href="../plugins/api.html">
-            
-                    
+
+
                     API & Context
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="3.2.6" data-path="../plugins/testing.html">
-            
-                <a href="../plugins/testing.html">
-            
-                    
-                    Test your plugin
-            
-                </a>
-            
 
-            
+                <a href="../plugins/testing.html">
+
+
+                    Test your plugin
+
+                </a>
+
+
+
         </li>
-    
+
 
             </ul>
-            
+
         </li>
-    
+
         <li class="chapter " data-level="3.3" data-path="../themes/">
-            
+
                 <a href="../themes/">
-            
-                    
+
+
                     Theming
-            
+
                 </a>
-            
 
-            
+
+
         </li>
-    
 
-    
-        
+
+
+
         <li class="divider"></li>
-        
-        
-    
+
+
+
         <li class="chapter " data-level="4.1" data-path="../faq.html">
-            
+
                 <a href="../faq.html">
-            
-                    
+
+
                     FAQ
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="4.2" data-path="../examples.md">
-            
+
                 <span>
-            
-                    
+
+
                     Examples
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="4.3" >
-            
+
                 <a target="_blank" href="https://github.com/honkit/honkit/blob/master/CHANGELOG.md">
-            
-                    
+
+
                     Release notes
-            
+
                 </a>
-            
 
-            
+
+
         </li>
-    
 
-    
-        
+
+
+
         <li class="divider"></li>
-        
-        
-    
+
+
+
         <li class="chapter " data-level="5.1" data-path="../encoding.html">
-            
+
                 <a href="../encoding.html">
-            
-                    
+
+
                     Encoding
-            
+
                 </a>
-            
 
-            
+
+
         </li>
-    
 
-    
+
+
 
     <li class="divider"></li>
 
@@ -17508,18 +17508,18 @@ exports[`HonKit snapshots: templating/builtin.html 1`] = `
 
 
                 </nav>
-            
-        
+
+
     </div>
 
     <div class="book-body">
-        
+
             <div class="body-inner">
-                
-                    
+
+
 
 <div class="book-header" role="navigation">
-    
+
 
     <!-- Title -->
     <h1>
@@ -17533,12 +17533,12 @@ exports[`HonKit snapshots: templating/builtin.html 1`] = `
 
                     <div class="page-wrapper" tabindex="-1" role="main">
                         <div class="page-inner">
-                            
+
 <div id="book-search-results">
     <div class="search-noresults">
-    
+
                                 <section class="normal markdown-section">
-                                
+
 
                                 <h1 id="builtin-templating-helpers">Builtin Templating Helpers</h1>
 <p><a href="../GLOSSARY.html#honkit" class="glossary-term" title="Honkit is a command line tool for building beautiful books using GitHub/Git and Markdown (or AsciiDoc).">HonKit</a> provides a serie of builtin filters and blocks to help you write templates.</p>
@@ -17552,64 +17552,64 @@ Render inline markdown</p>
 <p><code>{% asciidoc %}AsciiDoc string{% endasciidoc %}</code>
 Render inline asciidoc</p>
 
-                                
+
 <hr>
 <div class="btn-group btn-group-justified">
-    
+
     <a class="btn" href="variables.html"><b>Previous:</b> Variables</a>
-    
-    
+
+
     <a class="btn" href="../plugins/"><b>Next:</b> Plugins</a>
-    
+
 </div>
 
                                 </section>
-                            
+
     </div>
     <div class="search-results">
         <div class="has-results">
-            
+
             <h1 class="search-results-title"><span class='search-results-count'></span> results matching "<span class='search-query'></span>"</h1>
             <ul class="search-results-list"></ul>
-            
+
         </div>
         <div class="no-results">
-            
+
             <h1 class="search-results-title">No results matching "<span class='search-query'></span>"</h1>
-            
+
         </div>
     </div>
 </div>
 
                         </div>
                     </div>
-                
+
             </div>
 
-            
-                
+
+
                 <a href="variables.html" class="navigation navigation-prev " aria-label="Previous page: Variables">
                     <i class="fa fa-angle-left"></i>
                 </a>
-                
-                
+
+
                 <a href="../plugins/" class="navigation navigation-next " aria-label="Next page: Plugins">
                     <i class="fa fa-angle-right"></i>
                 </a>
-                
-            
-        
+
+
+
     </div>
 
     <script>
         var gitbook = gitbook || [];
         gitbook.push(function() {
-            
+
         });
     </script>
 </div>
 
-        
+
     <noscript>
         <style>
             .honkit-cloak {
@@ -17656,27 +17656,27 @@ Render inline asciidoc</p>
     </script>
     <script src="../gitbook/gitbook.js"></script>
     <script src="../gitbook/theme.js"></script>
-    
-        
+
+
         <script src="../gitbook/gitbook-plugin-search/search-engine.js"></script>
-        
-    
-        
+
+
+
         <script src="../gitbook/gitbook-plugin-search/search.js"></script>
-        
-    
-        
+
+
+
         <script src="../gitbook/gitbook-plugin-lunr/lunr.min.js"></script>
-        
-    
-        
+
+
+
         <script src="../gitbook/gitbook-plugin-lunr/search-lunr.js"></script>
-        
-    
-        
+
+
+
         <script src="../gitbook/gitbook-plugin-fontsettings/fontsettings.js"></script>
-        
-    
+
+
 
     </body>
 </html>
@@ -17702,50 +17702,50 @@ exports[`HonKit snapshots: templating/conrefs.html 1`] = `
         <title>Content References · HonKit Documentation</title>
         <meta http-equiv="X-UA-Compatible" content="IE=edge" />
         <meta name="description" content="">
-        
-        
-        
-        
-    
+
+
+
+
+
     <link rel="stylesheet" href="../gitbook/style.css">
 
-    
-            
-                
+
+
+
                 <link rel="stylesheet" href="../gitbook/@honkit/honkit-plugin-highlight/website.css">
-                
-            
-                
+
+
+
                 <link rel="stylesheet" href="../gitbook/gitbook-plugin-search/search.css">
-                
-            
-                
+
+
+
                 <link rel="stylesheet" href="../gitbook/gitbook-plugin-fontsettings/website.css">
-                
-            
-        
 
-    
 
-    
-        
+
+
+
+
+
+
         <link rel="stylesheet" href="../styles/website.css">
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
 
-        
-    
-    
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
     <meta name="HandheldFriendly" content="true"/>
     <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no">
     <meta name="apple-mobile-web-app-capable" content="yes">
@@ -17753,557 +17753,557 @@ exports[`HonKit snapshots: templating/conrefs.html 1`] = `
     <link rel="apple-touch-icon-precomposed" sizes="152x152" href="../gitbook/images/apple-touch-icon-precomposed-152.png">
     <link rel="shortcut icon" href="../gitbook/images/favicon.ico" type="image/x-icon">
 
-    
+
     <link rel="next" href="variables.html" />
-    
-    
+
+
     <link rel="prev" href="./" />
-    
+
 
     </head>
     <body>
-        
+
 <div class="book honkit-cloak">
     <div class="book-summary">
-        
-            
+
+
 <div id="book-search-input" role="search">
     <input type="text" placeholder="Type to search" />
 </div>
 
-            
+
                 <nav role="navigation">
-                
+
 
 
 <ul class="summary">
-    
-    
 
-    
 
-    
-        
+
+
+
+
+
         <li class="header">Getting Started</li>
-        
-        
-    
+
+
+
         <li class="chapter " data-level="1.1" data-path="../">
-            
+
                 <a href="../">
-            
-                    
+
+
                     About this documentation
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="1.2" data-path="../setup.html">
-            
+
                 <a href="../setup.html">
-            
-                    
+
+
                     Installation and Setup
-            
+
                 </a>
-            
 
-            
+
+
         </li>
-    
 
-    
-        
+
+
+
         <li class="header">Your Content</li>
-        
-        
-    
+
+
+
         <li class="chapter " data-level="2.1" data-path="../structure.html">
-            
+
                 <a href="../structure.html">
-            
-                    
+
+
                     Directory structure
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.2" data-path="../pages.html">
-            
+
                 <a href="../pages.html">
-            
-                    
+
+
                     Pages and Summary
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.3" data-path="../config.html">
-            
+
                 <a href="../config.html">
-            
-                    
+
+
                     Configuration
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.4" data-path="../lexicon.html">
-            
+
                 <a href="../lexicon.html">
-            
-                    
+
+
                     Glossary
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.5" data-path="../languages.html">
-            
+
                 <a href="../languages.html">
-            
-                    
+
+
                     Multi-Lingual
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.6" data-path="../syntax/markdown.html">
-            
+
                 <a href="../syntax/markdown.html">
-            
-                    
+
+
                     Markdown
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
             <ul class="articles">
-                
-    
+
+
         <li class="chapter " data-level="2.6.1" data-path="../syntax/markdown.html">
-            
+
                 <a href="../syntax/markdown.html#headings">
-            
-                    
+
+
                     Headings
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.6.2" data-path="../syntax/markdown.html">
-            
+
                 <a href="../syntax/markdown.html#paragraphs">
-            
-                    
+
+
                     Paragraphs
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.6.3" data-path="../syntax/markdown.html">
-            
+
                 <a href="../syntax/markdown.html#lists">
-            
-                    
+
+
                     Lists
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.6.4" data-path="../syntax/markdown.html">
-            
+
                 <a href="../syntax/markdown.html#links">
-            
-                    
+
+
                     Links
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.6.5" data-path="../syntax/markdown.html">
-            
+
                 <a href="../syntax/markdown.html#images">
-            
-                    
+
+
                     Images
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.6.6" data-path="../syntax/markdown.html">
-            
+
                 <a href="../syntax/markdown.html#blockquotes">
-            
-                    
+
+
                     Blockquotes
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.6.7" data-path="../syntax/markdown.html">
-            
+
                 <a href="../syntax/markdown.html#tables">
-            
-                    
+
+
                     Tables
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.6.8" data-path="../syntax/markdown.html">
-            
+
                 <a href="../syntax/markdown.html#code">
-            
-                    
+
+
                     Code
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.6.9" data-path="../syntax/markdown.html">
-            
+
                 <a href="../syntax/markdown.html#html">
-            
-                    
+
+
                     HTML
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.6.10" data-path="../syntax/markdown.html">
-            
+
                 <a href="../syntax/markdown.html#footnotes">
-            
-                    
+
+
                     Footnotes
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
 
             </ul>
-            
+
         </li>
-    
+
         <li class="chapter " data-level="2.7" data-path="../syntax/asciidoc.html">
-            
+
                 <a href="../syntax/asciidoc.html">
-            
-                    
+
+
                     AsciiDoc
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.8" data-path="../ebook.html">
-            
+
                 <a href="../ebook.html">
-            
-                    
+
+
                     eBook and PDF
-            
+
                 </a>
-            
 
-            
+
+
         </li>
-    
 
-    
-        
+
+
+
         <li class="header">Customization</li>
-        
-        
-    
+
+
+
         <li class="chapter " data-level="3.1" data-path="./">
-            
+
                 <a href="./">
-            
-                    
+
+
                     Templating
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
             <ul class="articles">
-                
-    
+
+
         <li class="chapter active" data-level="3.1.1" data-path="conrefs.html">
-            
+
                 <a href="conrefs.html">
-            
-                    
+
+
                     Content References
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="3.1.2" data-path="variables.html">
-            
+
                 <a href="variables.html">
-            
-                    
+
+
                     Variables
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="3.1.3" data-path="builtin.html">
-            
+
                 <a href="builtin.html">
-            
-                    
+
+
                     Builtin
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
 
             </ul>
-            
+
         </li>
-    
+
         <li class="chapter " data-level="3.2" data-path="../plugins/">
-            
+
                 <a href="../plugins/">
-            
-                    
+
+
                     Plugins
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
             <ul class="articles">
-                
-    
+
+
         <li class="chapter " data-level="3.2.1" data-path="../plugins/create.html">
-            
+
                 <a href="../plugins/create.html">
-            
-                    
+
+
                     Create a plugin
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="3.2.2" data-path="../plugins/hooks.html">
-            
+
                 <a href="../plugins/hooks.html">
-            
-                    
+
+
                     Hooks
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="3.2.3" data-path="../plugins/blocks.html">
-            
+
                 <a href="../plugins/blocks.html">
-            
-                    
+
+
                     Blocks
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="3.2.4" data-path="../plugins/filters.html">
-            
+
                 <a href="../plugins/filters.html">
-            
-                    
+
+
                     Filters
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="3.2.5" data-path="../plugins/api.html">
-            
+
                 <a href="../plugins/api.html">
-            
-                    
+
+
                     API & Context
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="3.2.6" data-path="../plugins/testing.html">
-            
-                <a href="../plugins/testing.html">
-            
-                    
-                    Test your plugin
-            
-                </a>
-            
 
-            
+                <a href="../plugins/testing.html">
+
+
+                    Test your plugin
+
+                </a>
+
+
+
         </li>
-    
+
 
             </ul>
-            
+
         </li>
-    
+
         <li class="chapter " data-level="3.3" data-path="../themes/">
-            
+
                 <a href="../themes/">
-            
-                    
+
+
                     Theming
-            
+
                 </a>
-            
 
-            
+
+
         </li>
-    
 
-    
-        
+
+
+
         <li class="divider"></li>
-        
-        
-    
+
+
+
         <li class="chapter " data-level="4.1" data-path="../faq.html">
-            
+
                 <a href="../faq.html">
-            
-                    
+
+
                     FAQ
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="4.2" data-path="../examples.md">
-            
+
                 <span>
-            
-                    
+
+
                     Examples
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="4.3" >
-            
+
                 <a target="_blank" href="https://github.com/honkit/honkit/blob/master/CHANGELOG.md">
-            
-                    
+
+
                     Release notes
-            
+
                 </a>
-            
 
-            
+
+
         </li>
-    
 
-    
-        
+
+
+
         <li class="divider"></li>
-        
-        
-    
+
+
+
         <li class="chapter " data-level="5.1" data-path="../encoding.html">
-            
+
                 <a href="../encoding.html">
-            
-                    
+
+
                     Encoding
-            
+
                 </a>
-            
 
-            
+
+
         </li>
-    
 
-    
+
+
 
     <li class="divider"></li>
 
@@ -18316,18 +18316,18 @@ exports[`HonKit snapshots: templating/conrefs.html 1`] = `
 
 
                 </nav>
-            
-        
+
+
     </div>
 
     <div class="book-body">
-        
+
             <div class="body-inner">
-                
-                    
+
+
 
 <div class="book-header" role="navigation">
-    
+
 
     <!-- Title -->
     <h1>
@@ -18341,12 +18341,12 @@ exports[`HonKit snapshots: templating/conrefs.html 1`] = `
 
                     <div class="page-wrapper" tabindex="-1" role="main">
                         <div class="page-inner">
-                            
+
 <div id="book-search-results">
     <div class="search-noresults">
-    
+
                                 <section class="normal markdown-section">
-                                
+
 
                                 <h1 id="content-references">Content References</h1>
 <p>Content referencing (conref) is a convenient mechanism to reuse content from other files or books.</p>
@@ -18377,64 +18377,64 @@ This is the default content
 
 {% include &quot;./LICENSE&quot; %}
 </code></pre>
-                                
+
 <hr>
 <div class="btn-group btn-group-justified">
-    
+
     <a class="btn" href="./"><b>Previous:</b> Templating</a>
-    
-    
+
+
     <a class="btn" href="variables.html"><b>Next:</b> Variables</a>
-    
+
 </div>
 
                                 </section>
-                            
+
     </div>
     <div class="search-results">
         <div class="has-results">
-            
+
             <h1 class="search-results-title"><span class='search-results-count'></span> results matching "<span class='search-query'></span>"</h1>
             <ul class="search-results-list"></ul>
-            
+
         </div>
         <div class="no-results">
-            
+
             <h1 class="search-results-title">No results matching "<span class='search-query'></span>"</h1>
-            
+
         </div>
     </div>
 </div>
 
                         </div>
                     </div>
-                
+
             </div>
 
-            
-                
+
+
                 <a href="./" class="navigation navigation-prev " aria-label="Previous page: Templating">
                     <i class="fa fa-angle-left"></i>
                 </a>
-                
-                
+
+
                 <a href="variables.html" class="navigation navigation-next " aria-label="Next page: Variables">
                     <i class="fa fa-angle-right"></i>
                 </a>
-                
-            
-        
+
+
+
     </div>
 
     <script>
         var gitbook = gitbook || [];
         gitbook.push(function() {
-            
+
         });
     </script>
 </div>
 
-        
+
     <noscript>
         <style>
             .honkit-cloak {
@@ -18481,27 +18481,27 @@ This is the default content
     </script>
     <script src="../gitbook/gitbook.js"></script>
     <script src="../gitbook/theme.js"></script>
-    
-        
+
+
         <script src="../gitbook/gitbook-plugin-search/search-engine.js"></script>
-        
-    
-        
+
+
+
         <script src="../gitbook/gitbook-plugin-search/search.js"></script>
-        
-    
-        
+
+
+
         <script src="../gitbook/gitbook-plugin-lunr/lunr.min.js"></script>
-        
-    
-        
+
+
+
         <script src="../gitbook/gitbook-plugin-lunr/search-lunr.js"></script>
-        
-    
-        
+
+
+
         <script src="../gitbook/gitbook-plugin-fontsettings/fontsettings.js"></script>
-        
-    
+
+
 
     </body>
 </html>
@@ -18527,50 +18527,50 @@ exports[`HonKit snapshots: templating/index.html 1`] = `
         <title>Templating · HonKit Documentation</title>
         <meta http-equiv="X-UA-Compatible" content="IE=edge" />
         <meta name="description" content="">
-        
-        
-        
-        
-    
+
+
+
+
+
     <link rel="stylesheet" href="../gitbook/style.css">
 
-    
-            
-                
+
+
+
                 <link rel="stylesheet" href="../gitbook/@honkit/honkit-plugin-highlight/website.css">
-                
-            
-                
+
+
+
                 <link rel="stylesheet" href="../gitbook/gitbook-plugin-search/search.css">
-                
-            
-                
+
+
+
                 <link rel="stylesheet" href="../gitbook/gitbook-plugin-fontsettings/website.css">
-                
-            
-        
 
-    
 
-    
-        
+
+
+
+
+
+
         <link rel="stylesheet" href="../styles/website.css">
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
 
-        
-    
-    
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
     <meta name="HandheldFriendly" content="true"/>
     <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no">
     <meta name="apple-mobile-web-app-capable" content="yes">
@@ -18578,557 +18578,557 @@ exports[`HonKit snapshots: templating/index.html 1`] = `
     <link rel="apple-touch-icon-precomposed" sizes="152x152" href="../gitbook/images/apple-touch-icon-precomposed-152.png">
     <link rel="shortcut icon" href="../gitbook/images/favicon.ico" type="image/x-icon">
 
-    
+
     <link rel="next" href="conrefs.html" />
-    
-    
+
+
     <link rel="prev" href="../ebook.html" />
-    
+
 
     </head>
     <body>
-        
+
 <div class="book honkit-cloak">
     <div class="book-summary">
-        
-            
+
+
 <div id="book-search-input" role="search">
     <input type="text" placeholder="Type to search" />
 </div>
 
-            
+
                 <nav role="navigation">
-                
+
 
 
 <ul class="summary">
-    
-    
 
-    
 
-    
-        
+
+
+
+
+
         <li class="header">Getting Started</li>
-        
-        
-    
+
+
+
         <li class="chapter " data-level="1.1" data-path="../">
-            
+
                 <a href="../">
-            
-                    
+
+
                     About this documentation
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="1.2" data-path="../setup.html">
-            
+
                 <a href="../setup.html">
-            
-                    
+
+
                     Installation and Setup
-            
+
                 </a>
-            
 
-            
+
+
         </li>
-    
 
-    
-        
+
+
+
         <li class="header">Your Content</li>
-        
-        
-    
+
+
+
         <li class="chapter " data-level="2.1" data-path="../structure.html">
-            
+
                 <a href="../structure.html">
-            
-                    
+
+
                     Directory structure
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.2" data-path="../pages.html">
-            
+
                 <a href="../pages.html">
-            
-                    
+
+
                     Pages and Summary
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.3" data-path="../config.html">
-            
+
                 <a href="../config.html">
-            
-                    
+
+
                     Configuration
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.4" data-path="../lexicon.html">
-            
+
                 <a href="../lexicon.html">
-            
-                    
+
+
                     Glossary
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.5" data-path="../languages.html">
-            
+
                 <a href="../languages.html">
-            
-                    
+
+
                     Multi-Lingual
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.6" data-path="../syntax/markdown.html">
-            
+
                 <a href="../syntax/markdown.html">
-            
-                    
+
+
                     Markdown
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
             <ul class="articles">
-                
-    
+
+
         <li class="chapter " data-level="2.6.1" data-path="../syntax/markdown.html">
-            
+
                 <a href="../syntax/markdown.html#headings">
-            
-                    
+
+
                     Headings
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.6.2" data-path="../syntax/markdown.html">
-            
+
                 <a href="../syntax/markdown.html#paragraphs">
-            
-                    
+
+
                     Paragraphs
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.6.3" data-path="../syntax/markdown.html">
-            
+
                 <a href="../syntax/markdown.html#lists">
-            
-                    
+
+
                     Lists
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.6.4" data-path="../syntax/markdown.html">
-            
+
                 <a href="../syntax/markdown.html#links">
-            
-                    
+
+
                     Links
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.6.5" data-path="../syntax/markdown.html">
-            
+
                 <a href="../syntax/markdown.html#images">
-            
-                    
+
+
                     Images
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.6.6" data-path="../syntax/markdown.html">
-            
+
                 <a href="../syntax/markdown.html#blockquotes">
-            
-                    
+
+
                     Blockquotes
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.6.7" data-path="../syntax/markdown.html">
-            
+
                 <a href="../syntax/markdown.html#tables">
-            
-                    
+
+
                     Tables
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.6.8" data-path="../syntax/markdown.html">
-            
+
                 <a href="../syntax/markdown.html#code">
-            
-                    
+
+
                     Code
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.6.9" data-path="../syntax/markdown.html">
-            
+
                 <a href="../syntax/markdown.html#html">
-            
-                    
+
+
                     HTML
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.6.10" data-path="../syntax/markdown.html">
-            
+
                 <a href="../syntax/markdown.html#footnotes">
-            
-                    
+
+
                     Footnotes
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
 
             </ul>
-            
+
         </li>
-    
+
         <li class="chapter " data-level="2.7" data-path="../syntax/asciidoc.html">
-            
+
                 <a href="../syntax/asciidoc.html">
-            
-                    
+
+
                     AsciiDoc
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.8" data-path="../ebook.html">
-            
+
                 <a href="../ebook.html">
-            
-                    
+
+
                     eBook and PDF
-            
+
                 </a>
-            
 
-            
+
+
         </li>
-    
 
-    
-        
+
+
+
         <li class="header">Customization</li>
-        
-        
-    
+
+
+
         <li class="chapter active" data-level="3.1" data-path="./">
-            
+
                 <a href="./">
-            
-                    
+
+
                     Templating
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
             <ul class="articles">
-                
-    
+
+
         <li class="chapter " data-level="3.1.1" data-path="conrefs.html">
-            
+
                 <a href="conrefs.html">
-            
-                    
+
+
                     Content References
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="3.1.2" data-path="variables.html">
-            
+
                 <a href="variables.html">
-            
-                    
+
+
                     Variables
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="3.1.3" data-path="builtin.html">
-            
+
                 <a href="builtin.html">
-            
-                    
+
+
                     Builtin
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
 
             </ul>
-            
+
         </li>
-    
+
         <li class="chapter " data-level="3.2" data-path="../plugins/">
-            
+
                 <a href="../plugins/">
-            
-                    
+
+
                     Plugins
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
             <ul class="articles">
-                
-    
+
+
         <li class="chapter " data-level="3.2.1" data-path="../plugins/create.html">
-            
+
                 <a href="../plugins/create.html">
-            
-                    
+
+
                     Create a plugin
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="3.2.2" data-path="../plugins/hooks.html">
-            
+
                 <a href="../plugins/hooks.html">
-            
-                    
+
+
                     Hooks
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="3.2.3" data-path="../plugins/blocks.html">
-            
+
                 <a href="../plugins/blocks.html">
-            
-                    
+
+
                     Blocks
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="3.2.4" data-path="../plugins/filters.html">
-            
+
                 <a href="../plugins/filters.html">
-            
-                    
+
+
                     Filters
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="3.2.5" data-path="../plugins/api.html">
-            
+
                 <a href="../plugins/api.html">
-            
-                    
+
+
                     API & Context
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="3.2.6" data-path="../plugins/testing.html">
-            
-                <a href="../plugins/testing.html">
-            
-                    
-                    Test your plugin
-            
-                </a>
-            
 
-            
+                <a href="../plugins/testing.html">
+
+
+                    Test your plugin
+
+                </a>
+
+
+
         </li>
-    
+
 
             </ul>
-            
+
         </li>
-    
+
         <li class="chapter " data-level="3.3" data-path="../themes/">
-            
+
                 <a href="../themes/">
-            
-                    
+
+
                     Theming
-            
+
                 </a>
-            
 
-            
+
+
         </li>
-    
 
-    
-        
+
+
+
         <li class="divider"></li>
-        
-        
-    
+
+
+
         <li class="chapter " data-level="4.1" data-path="../faq.html">
-            
+
                 <a href="../faq.html">
-            
-                    
+
+
                     FAQ
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="4.2" data-path="../examples.md">
-            
+
                 <span>
-            
-                    
+
+
                     Examples
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="4.3" >
-            
+
                 <a target="_blank" href="https://github.com/honkit/honkit/blob/master/CHANGELOG.md">
-            
-                    
+
+
                     Release notes
-            
+
                 </a>
-            
 
-            
+
+
         </li>
-    
 
-    
-        
+
+
+
         <li class="divider"></li>
-        
-        
-    
+
+
+
         <li class="chapter " data-level="5.1" data-path="../encoding.html">
-            
+
                 <a href="../encoding.html">
-            
-                    
+
+
                     Encoding
-            
+
                 </a>
-            
 
-            
+
+
         </li>
-    
 
-    
+
+
 
     <li class="divider"></li>
 
@@ -19141,18 +19141,18 @@ exports[`HonKit snapshots: templating/index.html 1`] = `
 
 
                 </nav>
-            
-        
+
+
     </div>
 
     <div class="book-body">
-        
+
             <div class="body-inner">
-                
-                    
+
+
 
 <div class="book-header" role="navigation">
-    
+
 
     <!-- Title -->
     <h1>
@@ -19166,12 +19166,12 @@ exports[`HonKit snapshots: templating/index.html 1`] = `
 
                     <div class="page-wrapper" tabindex="-1" role="main">
                         <div class="page-inner">
-                            
+
 <div id="book-search-results">
     <div class="search-noresults">
-    
+
                                 <section class="normal markdown-section">
-                                
+
 
                                 <h1 id="templating">Templating</h1>
 <p><a href="../GLOSSARY.html#honkit" class="glossary-term" title="Honkit is a command line tool for building beautiful books using GitHub/Git and Markdown (or AsciiDoc).">HonKit</a> uses the <a href="https://mozilla.github.io/nunjucks/" target="_blank">Nunjucks templating language</a> to process pages and theme&apos;s templates.</p>
@@ -19234,64 +19234,64 @@ Current version is </span><span class="hljs-template-variable">{{ softwareVersio
 </span><span class="hljs-template-tag">{% <span class="hljs-name">endraw</span> %}</span><span class="xml">
 </span></code></pre>
 
-                                
+
 <hr>
 <div class="btn-group btn-group-justified">
-    
+
     <a class="btn" href="../ebook.html"><b>Previous:</b> eBook and PDF</a>
-    
-    
+
+
     <a class="btn" href="conrefs.html"><b>Next:</b> Content References</a>
-    
+
 </div>
 
                                 </section>
-                            
+
     </div>
     <div class="search-results">
         <div class="has-results">
-            
+
             <h1 class="search-results-title"><span class='search-results-count'></span> results matching "<span class='search-query'></span>"</h1>
             <ul class="search-results-list"></ul>
-            
+
         </div>
         <div class="no-results">
-            
+
             <h1 class="search-results-title">No results matching "<span class='search-query'></span>"</h1>
-            
+
         </div>
     </div>
 </div>
 
                         </div>
                     </div>
-                
+
             </div>
 
-            
-                
+
+
                 <a href="../ebook.html" class="navigation navigation-prev " aria-label="Previous page: eBook and PDF">
                     <i class="fa fa-angle-left"></i>
                 </a>
-                
-                
+
+
                 <a href="conrefs.html" class="navigation navigation-next " aria-label="Next page: Content References">
                     <i class="fa fa-angle-right"></i>
                 </a>
-                
-            
-        
+
+
+
     </div>
 
     <script>
         var gitbook = gitbook || [];
         gitbook.push(function() {
-            
+
         });
     </script>
 </div>
 
-        
+
     <noscript>
         <style>
             .honkit-cloak {
@@ -19338,27 +19338,27 @@ Current version is </span><span class="hljs-template-variable">{{ softwareVersio
     </script>
     <script src="../gitbook/gitbook.js"></script>
     <script src="../gitbook/theme.js"></script>
-    
-        
+
+
         <script src="../gitbook/gitbook-plugin-search/search-engine.js"></script>
-        
-    
-        
+
+
+
         <script src="../gitbook/gitbook-plugin-search/search.js"></script>
-        
-    
-        
+
+
+
         <script src="../gitbook/gitbook-plugin-lunr/lunr.min.js"></script>
-        
-    
-        
+
+
+
         <script src="../gitbook/gitbook-plugin-lunr/search-lunr.js"></script>
-        
-    
-        
+
+
+
         <script src="../gitbook/gitbook-plugin-fontsettings/fontsettings.js"></script>
-        
-    
+
+
 
     </body>
 </html>
@@ -19384,50 +19384,50 @@ exports[`HonKit snapshots: templating/variables.html 1`] = `
         <title>Variables · HonKit Documentation</title>
         <meta http-equiv="X-UA-Compatible" content="IE=edge" />
         <meta name="description" content="">
-        
-        
-        
-        
-    
+
+
+
+
+
     <link rel="stylesheet" href="../gitbook/style.css">
 
-    
-            
-                
+
+
+
                 <link rel="stylesheet" href="../gitbook/@honkit/honkit-plugin-highlight/website.css">
-                
-            
-                
+
+
+
                 <link rel="stylesheet" href="../gitbook/gitbook-plugin-search/search.css">
-                
-            
-                
+
+
+
                 <link rel="stylesheet" href="../gitbook/gitbook-plugin-fontsettings/website.css">
-                
-            
-        
 
-    
 
-    
-        
+
+
+
+
+
+
         <link rel="stylesheet" href="../styles/website.css">
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
 
-        
-    
-    
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
     <meta name="HandheldFriendly" content="true"/>
     <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no">
     <meta name="apple-mobile-web-app-capable" content="yes">
@@ -19435,557 +19435,557 @@ exports[`HonKit snapshots: templating/variables.html 1`] = `
     <link rel="apple-touch-icon-precomposed" sizes="152x152" href="../gitbook/images/apple-touch-icon-precomposed-152.png">
     <link rel="shortcut icon" href="../gitbook/images/favicon.ico" type="image/x-icon">
 
-    
+
     <link rel="next" href="builtin.html" />
-    
-    
+
+
     <link rel="prev" href="conrefs.html" />
-    
+
 
     </head>
     <body>
-        
+
 <div class="book honkit-cloak">
     <div class="book-summary">
-        
-            
+
+
 <div id="book-search-input" role="search">
     <input type="text" placeholder="Type to search" />
 </div>
 
-            
+
                 <nav role="navigation">
-                
+
 
 
 <ul class="summary">
-    
-    
 
-    
 
-    
-        
+
+
+
+
+
         <li class="header">Getting Started</li>
-        
-        
-    
+
+
+
         <li class="chapter " data-level="1.1" data-path="../">
-            
+
                 <a href="../">
-            
-                    
+
+
                     About this documentation
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="1.2" data-path="../setup.html">
-            
+
                 <a href="../setup.html">
-            
-                    
+
+
                     Installation and Setup
-            
+
                 </a>
-            
 
-            
+
+
         </li>
-    
 
-    
-        
+
+
+
         <li class="header">Your Content</li>
-        
-        
-    
+
+
+
         <li class="chapter " data-level="2.1" data-path="../structure.html">
-            
+
                 <a href="../structure.html">
-            
-                    
+
+
                     Directory structure
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.2" data-path="../pages.html">
-            
+
                 <a href="../pages.html">
-            
-                    
+
+
                     Pages and Summary
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.3" data-path="../config.html">
-            
+
                 <a href="../config.html">
-            
-                    
+
+
                     Configuration
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.4" data-path="../lexicon.html">
-            
+
                 <a href="../lexicon.html">
-            
-                    
+
+
                     Glossary
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.5" data-path="../languages.html">
-            
+
                 <a href="../languages.html">
-            
-                    
+
+
                     Multi-Lingual
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.6" data-path="../syntax/markdown.html">
-            
+
                 <a href="../syntax/markdown.html">
-            
-                    
+
+
                     Markdown
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
             <ul class="articles">
-                
-    
+
+
         <li class="chapter " data-level="2.6.1" data-path="../syntax/markdown.html">
-            
+
                 <a href="../syntax/markdown.html#headings">
-            
-                    
+
+
                     Headings
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.6.2" data-path="../syntax/markdown.html">
-            
+
                 <a href="../syntax/markdown.html#paragraphs">
-            
-                    
+
+
                     Paragraphs
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.6.3" data-path="../syntax/markdown.html">
-            
+
                 <a href="../syntax/markdown.html#lists">
-            
-                    
+
+
                     Lists
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.6.4" data-path="../syntax/markdown.html">
-            
+
                 <a href="../syntax/markdown.html#links">
-            
-                    
+
+
                     Links
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.6.5" data-path="../syntax/markdown.html">
-            
+
                 <a href="../syntax/markdown.html#images">
-            
-                    
+
+
                     Images
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.6.6" data-path="../syntax/markdown.html">
-            
+
                 <a href="../syntax/markdown.html#blockquotes">
-            
-                    
+
+
                     Blockquotes
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.6.7" data-path="../syntax/markdown.html">
-            
+
                 <a href="../syntax/markdown.html#tables">
-            
-                    
+
+
                     Tables
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.6.8" data-path="../syntax/markdown.html">
-            
+
                 <a href="../syntax/markdown.html#code">
-            
-                    
+
+
                     Code
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.6.9" data-path="../syntax/markdown.html">
-            
+
                 <a href="../syntax/markdown.html#html">
-            
-                    
+
+
                     HTML
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.6.10" data-path="../syntax/markdown.html">
-            
+
                 <a href="../syntax/markdown.html#footnotes">
-            
-                    
+
+
                     Footnotes
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
 
             </ul>
-            
+
         </li>
-    
+
         <li class="chapter " data-level="2.7" data-path="../syntax/asciidoc.html">
-            
+
                 <a href="../syntax/asciidoc.html">
-            
-                    
+
+
                     AsciiDoc
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.8" data-path="../ebook.html">
-            
+
                 <a href="../ebook.html">
-            
-                    
+
+
                     eBook and PDF
-            
+
                 </a>
-            
 
-            
+
+
         </li>
-    
 
-    
-        
+
+
+
         <li class="header">Customization</li>
-        
-        
-    
+
+
+
         <li class="chapter " data-level="3.1" data-path="./">
-            
+
                 <a href="./">
-            
-                    
+
+
                     Templating
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
             <ul class="articles">
-                
-    
+
+
         <li class="chapter " data-level="3.1.1" data-path="conrefs.html">
-            
+
                 <a href="conrefs.html">
-            
-                    
+
+
                     Content References
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter active" data-level="3.1.2" data-path="variables.html">
-            
+
                 <a href="variables.html">
-            
-                    
+
+
                     Variables
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="3.1.3" data-path="builtin.html">
-            
+
                 <a href="builtin.html">
-            
-                    
+
+
                     Builtin
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
 
             </ul>
-            
+
         </li>
-    
+
         <li class="chapter " data-level="3.2" data-path="../plugins/">
-            
+
                 <a href="../plugins/">
-            
-                    
+
+
                     Plugins
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
             <ul class="articles">
-                
-    
+
+
         <li class="chapter " data-level="3.2.1" data-path="../plugins/create.html">
-            
+
                 <a href="../plugins/create.html">
-            
-                    
+
+
                     Create a plugin
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="3.2.2" data-path="../plugins/hooks.html">
-            
+
                 <a href="../plugins/hooks.html">
-            
-                    
+
+
                     Hooks
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="3.2.3" data-path="../plugins/blocks.html">
-            
+
                 <a href="../plugins/blocks.html">
-            
-                    
+
+
                     Blocks
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="3.2.4" data-path="../plugins/filters.html">
-            
+
                 <a href="../plugins/filters.html">
-            
-                    
+
+
                     Filters
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="3.2.5" data-path="../plugins/api.html">
-            
+
                 <a href="../plugins/api.html">
-            
-                    
+
+
                     API & Context
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="3.2.6" data-path="../plugins/testing.html">
-            
-                <a href="../plugins/testing.html">
-            
-                    
-                    Test your plugin
-            
-                </a>
-            
 
-            
+                <a href="../plugins/testing.html">
+
+
+                    Test your plugin
+
+                </a>
+
+
+
         </li>
-    
+
 
             </ul>
-            
+
         </li>
-    
+
         <li class="chapter " data-level="3.3" data-path="../themes/">
-            
+
                 <a href="../themes/">
-            
-                    
+
+
                     Theming
-            
+
                 </a>
-            
 
-            
+
+
         </li>
-    
 
-    
-        
+
+
+
         <li class="divider"></li>
-        
-        
-    
+
+
+
         <li class="chapter " data-level="4.1" data-path="../faq.html">
-            
+
                 <a href="../faq.html">
-            
-                    
+
+
                     FAQ
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="4.2" data-path="../examples.md">
-            
+
                 <span>
-            
-                    
+
+
                     Examples
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="4.3" >
-            
+
                 <a target="_blank" href="https://github.com/honkit/honkit/blob/master/CHANGELOG.md">
-            
-                    
+
+
                     Release notes
-            
+
                 </a>
-            
 
-            
+
+
         </li>
-    
 
-    
-        
+
+
+
         <li class="divider"></li>
-        
-        
-    
+
+
+
         <li class="chapter " data-level="5.1" data-path="../encoding.html">
-            
+
                 <a href="../encoding.html">
-            
-                    
+
+
                     Encoding
-            
+
                 </a>
-            
 
-            
+
+
         </li>
-    
 
-    
+
+
 
     <li class="divider"></li>
 
@@ -19998,18 +19998,18 @@ exports[`HonKit snapshots: templating/variables.html 1`] = `
 
 
                 </nav>
-            
-        
+
+
     </div>
 
     <div class="book-body">
-        
+
             <div class="body-inner">
-                
-                    
+
+
 
 <div class="book-header" role="navigation">
-    
+
 
     <!-- Title -->
     <h1>
@@ -20023,12 +20023,12 @@ exports[`HonKit snapshots: templating/variables.html 1`] = `
 
                     <div class="page-wrapper" tabindex="-1" role="main">
                         <div class="page-inner">
-                            
+
 <div id="book-search-results">
     <div class="search-noresults">
-    
+
                                 <section class="normal markdown-section">
-                                
+
 
                                 <h1 id="variables">Variables</h1>
 <p>The following is a reference of the available data during book&apos;s parsing and theme generation.</p>
@@ -20255,64 +20255,64 @@ exports[`HonKit snapshots: templating/variables.html 1`] = `
 </tbody>
 </table>
 
-                                
+
 <hr>
 <div class="btn-group btn-group-justified">
-    
+
     <a class="btn" href="conrefs.html"><b>Previous:</b> Content References</a>
-    
-    
+
+
     <a class="btn" href="builtin.html"><b>Next:</b> Builtin</a>
-    
+
 </div>
 
                                 </section>
-                            
+
     </div>
     <div class="search-results">
         <div class="has-results">
-            
+
             <h1 class="search-results-title"><span class='search-results-count'></span> results matching "<span class='search-query'></span>"</h1>
             <ul class="search-results-list"></ul>
-            
+
         </div>
         <div class="no-results">
-            
+
             <h1 class="search-results-title">No results matching "<span class='search-query'></span>"</h1>
-            
+
         </div>
     </div>
 </div>
 
                         </div>
                     </div>
-                
+
             </div>
 
-            
-                
+
+
                 <a href="conrefs.html" class="navigation navigation-prev " aria-label="Previous page: Content References">
                     <i class="fa fa-angle-left"></i>
                 </a>
-                
-                
+
+
                 <a href="builtin.html" class="navigation navigation-next " aria-label="Next page: Builtin">
                     <i class="fa fa-angle-right"></i>
                 </a>
-                
-            
-        
+
+
+
     </div>
 
     <script>
         var gitbook = gitbook || [];
         gitbook.push(function() {
-            
+
         });
     </script>
 </div>
 
-        
+
     <noscript>
         <style>
             .honkit-cloak {
@@ -20359,27 +20359,27 @@ exports[`HonKit snapshots: templating/variables.html 1`] = `
     </script>
     <script src="../gitbook/gitbook.js"></script>
     <script src="../gitbook/theme.js"></script>
-    
-        
+
+
         <script src="../gitbook/gitbook-plugin-search/search-engine.js"></script>
-        
-    
-        
+
+
+
         <script src="../gitbook/gitbook-plugin-search/search.js"></script>
-        
-    
-        
+
+
+
         <script src="../gitbook/gitbook-plugin-lunr/lunr.min.js"></script>
-        
-    
-        
+
+
+
         <script src="../gitbook/gitbook-plugin-lunr/search-lunr.js"></script>
-        
-    
-        
+
+
+
         <script src="../gitbook/gitbook-plugin-fontsettings/fontsettings.js"></script>
-        
-    
+
+
 
     </body>
 </html>
@@ -20405,50 +20405,50 @@ exports[`HonKit snapshots: themes/index.html 1`] = `
         <title>Theming · HonKit Documentation</title>
         <meta http-equiv="X-UA-Compatible" content="IE=edge" />
         <meta name="description" content="">
-        
-        
-        
-        
-    
+
+
+
+
+
     <link rel="stylesheet" href="../gitbook/style.css">
 
-    
-            
-                
+
+
+
                 <link rel="stylesheet" href="../gitbook/@honkit/honkit-plugin-highlight/website.css">
-                
-            
-                
+
+
+
                 <link rel="stylesheet" href="../gitbook/gitbook-plugin-search/search.css">
-                
-            
-                
+
+
+
                 <link rel="stylesheet" href="../gitbook/gitbook-plugin-fontsettings/website.css">
-                
-            
-        
 
-    
 
-    
-        
+
+
+
+
+
+
         <link rel="stylesheet" href="../styles/website.css">
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
 
-        
-    
-    
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
     <meta name="HandheldFriendly" content="true"/>
     <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no">
     <meta name="apple-mobile-web-app-capable" content="yes">
@@ -20456,557 +20456,557 @@ exports[`HonKit snapshots: themes/index.html 1`] = `
     <link rel="apple-touch-icon-precomposed" sizes="152x152" href="../gitbook/images/apple-touch-icon-precomposed-152.png">
     <link rel="shortcut icon" href="../gitbook/images/favicon.ico" type="image/x-icon">
 
-    
+
     <link rel="next" href="../faq.html" />
-    
-    
+
+
     <link rel="prev" href="../plugins/testing.html" />
-    
+
 
     </head>
     <body>
-        
+
 <div class="book honkit-cloak">
     <div class="book-summary">
-        
-            
+
+
 <div id="book-search-input" role="search">
     <input type="text" placeholder="Type to search" />
 </div>
 
-            
+
                 <nav role="navigation">
-                
+
 
 
 <ul class="summary">
-    
-    
 
-    
 
-    
-        
+
+
+
+
+
         <li class="header">Getting Started</li>
-        
-        
-    
+
+
+
         <li class="chapter " data-level="1.1" data-path="../">
-            
+
                 <a href="../">
-            
-                    
+
+
                     About this documentation
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="1.2" data-path="../setup.html">
-            
+
                 <a href="../setup.html">
-            
-                    
+
+
                     Installation and Setup
-            
+
                 </a>
-            
 
-            
+
+
         </li>
-    
 
-    
-        
+
+
+
         <li class="header">Your Content</li>
-        
-        
-    
+
+
+
         <li class="chapter " data-level="2.1" data-path="../structure.html">
-            
+
                 <a href="../structure.html">
-            
-                    
+
+
                     Directory structure
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.2" data-path="../pages.html">
-            
+
                 <a href="../pages.html">
-            
-                    
+
+
                     Pages and Summary
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.3" data-path="../config.html">
-            
+
                 <a href="../config.html">
-            
-                    
+
+
                     Configuration
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.4" data-path="../lexicon.html">
-            
+
                 <a href="../lexicon.html">
-            
-                    
+
+
                     Glossary
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.5" data-path="../languages.html">
-            
+
                 <a href="../languages.html">
-            
-                    
+
+
                     Multi-Lingual
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.6" data-path="../syntax/markdown.html">
-            
+
                 <a href="../syntax/markdown.html">
-            
-                    
+
+
                     Markdown
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
             <ul class="articles">
-                
-    
+
+
         <li class="chapter " data-level="2.6.1" data-path="../syntax/markdown.html">
-            
+
                 <a href="../syntax/markdown.html#headings">
-            
-                    
+
+
                     Headings
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.6.2" data-path="../syntax/markdown.html">
-            
+
                 <a href="../syntax/markdown.html#paragraphs">
-            
-                    
+
+
                     Paragraphs
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.6.3" data-path="../syntax/markdown.html">
-            
+
                 <a href="../syntax/markdown.html#lists">
-            
-                    
+
+
                     Lists
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.6.4" data-path="../syntax/markdown.html">
-            
+
                 <a href="../syntax/markdown.html#links">
-            
-                    
+
+
                     Links
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.6.5" data-path="../syntax/markdown.html">
-            
+
                 <a href="../syntax/markdown.html#images">
-            
-                    
+
+
                     Images
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.6.6" data-path="../syntax/markdown.html">
-            
+
                 <a href="../syntax/markdown.html#blockquotes">
-            
-                    
+
+
                     Blockquotes
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.6.7" data-path="../syntax/markdown.html">
-            
+
                 <a href="../syntax/markdown.html#tables">
-            
-                    
+
+
                     Tables
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.6.8" data-path="../syntax/markdown.html">
-            
+
                 <a href="../syntax/markdown.html#code">
-            
-                    
+
+
                     Code
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.6.9" data-path="../syntax/markdown.html">
-            
+
                 <a href="../syntax/markdown.html#html">
-            
-                    
+
+
                     HTML
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.6.10" data-path="../syntax/markdown.html">
-            
+
                 <a href="../syntax/markdown.html#footnotes">
-            
-                    
+
+
                     Footnotes
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
 
             </ul>
-            
+
         </li>
-    
+
         <li class="chapter " data-level="2.7" data-path="../syntax/asciidoc.html">
-            
+
                 <a href="../syntax/asciidoc.html">
-            
-                    
+
+
                     AsciiDoc
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="2.8" data-path="../ebook.html">
-            
+
                 <a href="../ebook.html">
-            
-                    
+
+
                     eBook and PDF
-            
+
                 </a>
-            
 
-            
+
+
         </li>
-    
 
-    
-        
+
+
+
         <li class="header">Customization</li>
-        
-        
-    
+
+
+
         <li class="chapter " data-level="3.1" data-path="../templating/">
-            
+
                 <a href="../templating/">
-            
-                    
+
+
                     Templating
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
             <ul class="articles">
-                
-    
+
+
         <li class="chapter " data-level="3.1.1" data-path="../templating/conrefs.html">
-            
+
                 <a href="../templating/conrefs.html">
-            
-                    
+
+
                     Content References
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="3.1.2" data-path="../templating/variables.html">
-            
+
                 <a href="../templating/variables.html">
-            
-                    
+
+
                     Variables
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="3.1.3" data-path="../templating/builtin.html">
-            
+
                 <a href="../templating/builtin.html">
-            
-                    
+
+
                     Builtin
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
 
             </ul>
-            
+
         </li>
-    
+
         <li class="chapter " data-level="3.2" data-path="../plugins/">
-            
+
                 <a href="../plugins/">
-            
-                    
+
+
                     Plugins
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
             <ul class="articles">
-                
-    
+
+
         <li class="chapter " data-level="3.2.1" data-path="../plugins/create.html">
-            
+
                 <a href="../plugins/create.html">
-            
-                    
+
+
                     Create a plugin
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="3.2.2" data-path="../plugins/hooks.html">
-            
+
                 <a href="../plugins/hooks.html">
-            
-                    
+
+
                     Hooks
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="3.2.3" data-path="../plugins/blocks.html">
-            
+
                 <a href="../plugins/blocks.html">
-            
-                    
+
+
                     Blocks
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="3.2.4" data-path="../plugins/filters.html">
-            
+
                 <a href="../plugins/filters.html">
-            
-                    
+
+
                     Filters
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="3.2.5" data-path="../plugins/api.html">
-            
+
                 <a href="../plugins/api.html">
-            
-                    
+
+
                     API & Context
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="3.2.6" data-path="../plugins/testing.html">
-            
-                <a href="../plugins/testing.html">
-            
-                    
-                    Test your plugin
-            
-                </a>
-            
 
-            
+                <a href="../plugins/testing.html">
+
+
+                    Test your plugin
+
+                </a>
+
+
+
         </li>
-    
+
 
             </ul>
-            
+
         </li>
-    
+
         <li class="chapter active" data-level="3.3" data-path="./">
-            
+
                 <a href="./">
-            
-                    
+
+
                     Theming
-            
+
                 </a>
-            
 
-            
+
+
         </li>
-    
 
-    
-        
+
+
+
         <li class="divider"></li>
-        
-        
-    
+
+
+
         <li class="chapter " data-level="4.1" data-path="../faq.html">
-            
+
                 <a href="../faq.html">
-            
-                    
+
+
                     FAQ
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="4.2" data-path="../examples.md">
-            
+
                 <span>
-            
-                    
+
+
                     Examples
-            
-                </a>
-            
 
-            
+                </a>
+
+
+
         </li>
-    
+
         <li class="chapter " data-level="4.3" >
-            
+
                 <a target="_blank" href="https://github.com/honkit/honkit/blob/master/CHANGELOG.md">
-            
-                    
+
+
                     Release notes
-            
+
                 </a>
-            
 
-            
+
+
         </li>
-    
 
-    
-        
+
+
+
         <li class="divider"></li>
-        
-        
-    
+
+
+
         <li class="chapter " data-level="5.1" data-path="../encoding.html">
-            
+
                 <a href="../encoding.html">
-            
-                    
+
+
                     Encoding
-            
+
                 </a>
-            
 
-            
+
+
         </li>
-    
 
-    
+
+
 
     <li class="divider"></li>
 
@@ -21019,18 +21019,18 @@ exports[`HonKit snapshots: themes/index.html 1`] = `
 
 
                 </nav>
-            
-        
+
+
     </div>
 
     <div class="book-body">
-        
+
             <div class="body-inner">
-                
-                    
+
+
 
 <div class="book-header" role="navigation">
-    
+
 
     <!-- Title -->
     <h1>
@@ -21044,12 +21044,12 @@ exports[`HonKit snapshots: themes/index.html 1`] = `
 
                     <div class="page-wrapper" tabindex="-1" role="main">
                         <div class="page-inner">
-                            
+
 <div id="book-search-results">
     <div class="search-noresults">
-    
+
                                 <section class="normal markdown-section">
-                                
+
 
                                 <h1 id="theming">Theming</h1>
 <p>Since version 3.0.0, <a href="../GLOSSARY.html#honkit" class="glossary-term" title="Honkit is a command line tool for building beautiful books using GitHub/Git and Markdown (or AsciiDoc).">HonKit</a> can be easily themed. Books use the <a href="https://github.com/GitbookIO/theme-default" target="_blank">theme-default</a> theme by default.</p>
@@ -21095,64 +21095,64 @@ exports[`HonKit snapshots: themes/index.html 1`] = `
 <h3 id="publish-a-theme">Publish a theme</h3>
 <p>Themes are published as <a href="../GLOSSARY.html#plugins" class="glossary-term" title="Plugins are the best way to extend HonKit functionalities (ebook and website).">plugins</a> (<a href="../plugins/">see related docs</a>) with a <code>theme-</code> prefix. For example the theme <code>awesome</code> will be loaded from the <code>theme-awesome</code> plugin, and then from the <code>honkit-plugin-theme-awesome</code> NPM package.</p>
 
-                                
+
 <hr>
 <div class="btn-group btn-group-justified">
-    
+
     <a class="btn" href="../plugins/testing.html"><b>Previous:</b> Test your plugin</a>
-    
-    
+
+
     <a class="btn" href="../faq.html"><b>Next:</b> FAQ</a>
-    
+
 </div>
 
                                 </section>
-                            
+
     </div>
     <div class="search-results">
         <div class="has-results">
-            
+
             <h1 class="search-results-title"><span class='search-results-count'></span> results matching "<span class='search-query'></span>"</h1>
             <ul class="search-results-list"></ul>
-            
+
         </div>
         <div class="no-results">
-            
+
             <h1 class="search-results-title">No results matching "<span class='search-query'></span>"</h1>
-            
+
         </div>
     </div>
 </div>
 
                         </div>
                     </div>
-                
+
             </div>
 
-            
-                
+
+
                 <a href="../plugins/testing.html" class="navigation navigation-prev " aria-label="Previous page: Test your plugin">
                     <i class="fa fa-angle-left"></i>
                 </a>
-                
-                
+
+
                 <a href="../faq.html" class="navigation navigation-next " aria-label="Next page: FAQ">
                     <i class="fa fa-angle-right"></i>
                 </a>
-                
-            
-        
+
+
+
     </div>
 
     <script>
         var gitbook = gitbook || [];
         gitbook.push(function() {
-            
+
         });
     </script>
 </div>
 
-        
+
     <noscript>
         <style>
             .honkit-cloak {
@@ -21199,27 +21199,27 @@ exports[`HonKit snapshots: themes/index.html 1`] = `
     </script>
     <script src="../gitbook/gitbook.js"></script>
     <script src="../gitbook/theme.js"></script>
-    
-        
+
+
         <script src="../gitbook/gitbook-plugin-search/search-engine.js"></script>
-        
-    
-        
+
+
+
         <script src="../gitbook/gitbook-plugin-search/search.js"></script>
-        
-    
-        
+
+
+
         <script src="../gitbook/gitbook-plugin-lunr/lunr.min.js"></script>
-        
-    
-        
+
+
+
         <script src="../gitbook/gitbook-plugin-lunr/search-lunr.js"></script>
-        
-    
-        
+
+
+
         <script src="../gitbook/gitbook-plugin-fontsettings/fontsettings.js"></script>
-        
-    
+
+
 
     </body>
 </html>

--- a/packages/honkit/src/__tests__/snapshot-asciidoc.ts
+++ b/packages/honkit/src/__tests__/snapshot-asciidoc.ts
@@ -1,9 +1,10 @@
 import path from "path";
 import { iterateDirectoryContents } from "@honkit/internal-test-utils";
 import * as bin from "../bin";
-it("HonKit snapshot", async () => {
-    const bookDir = path.join(__dirname, "__fixtures__/honkit");
-    const outputDir = path.join(__dirname, "__fixtures__/honkit/_book");
+
+it("asciidoc snapshot", async () => {
+    const bookDir = path.join(__dirname, "__fixtures__/asciidoc");
+    const outputDir = path.join(__dirname, "__fixtures__/asciidoc/_book");
     await bin.run([process.argv[0], ".", "build", bookDir, "--reload"]);
     const maskContent = (content) => {
         return content

--- a/packages/honkit/src/__tests__/snapshot-honkit.ts
+++ b/packages/honkit/src/__tests__/snapshot-honkit.ts
@@ -1,7 +1,7 @@
 import path from "path";
 import { iterateDirectoryContents } from "@honkit/internal-test-utils";
 import * as bin from "../bin";
-it("HonKit snapshot", async () => {
+it("HonKit snapshots", async () => {
     const bookDir = path.join(__dirname, "__fixtures__/honkit");
     const outputDir = path.join(__dirname, "__fixtures__/honkit/_book");
     await bin.run([process.argv[0], ".", "build", bookDir, "--reload"]);

--- a/packages/honkit/src/api/encodeGlobal.ts
+++ b/packages/honkit/src/api/encodeGlobal.ts
@@ -12,6 +12,8 @@ import encodeConfig from "./encodeConfig";
 import encodeSummary from "./encodeSummary";
 import encodeNavigation from "./encodeNavigation";
 import encodePage from "./encodePage";
+import { ToHTMLOptions } from "@honkit/html";
+import { ParserOptions } from "../models/parser";
 
 /**
  Encode a global context into a JS object
@@ -99,12 +101,13 @@ function encodeGlobal(output) {
 
          @param {string} type
          @param {string} text
+         @param options
          @return {Promise<String>}
          */
-        renderBlock: function (type, text) {
+        renderBlock: function (type: string, text: string, options: ParserOptions) {
             const parser = parsers.get(type);
 
-            return parser.parsePage(text).get("content");
+            return parser.parsePage(text, options).get("content");
         },
 
         /**
@@ -112,12 +115,13 @@ function encodeGlobal(output) {
 
          @param {string} type
          @param {string} text
+         @param options
          @return {Promise<String>}
          */
-        renderInline: function (type, text) {
+        renderInline: function (type: string, text: string, options: ParserOptions) {
             const parser = parsers.get(type);
 
-            return parser.parseInline(text).get("content");
+            return parser.parseInline(text, options).get("content");
         },
 
         template: {
@@ -132,7 +136,7 @@ function encodeGlobal(output) {
                 const block = blocks.get(name) || defaultBlocks.get(name);
 
                 return Promise(block.applyBlock(blockData, result));
-            },
+            }
         },
 
         output: {
@@ -220,15 +224,15 @@ function encodeGlobal(output) {
                         return fs.copy(inputFile, outputFilePath);
                     });
                 });
-            },
+            }
         },
 
         gitbook: {
-            version: honkit.version,
+            version: honkit.version
         },
         honkit: {
-            version: honkit.version,
-        },
+            version: honkit.version
+        }
     };
 
     // Deprecated properties

--- a/packages/honkit/src/constants/defaultBlocks.ts
+++ b/packages/honkit/src/constants/defaultBlocks.ts
@@ -6,7 +6,7 @@ export default Immutable.Map({
         name: "html",
         process: function (blk) {
             return blk;
-        },
+        }
     }),
 
     code: new TemplateBlock({
@@ -14,18 +14,19 @@ export default Immutable.Map({
         process: function (blk) {
             return {
                 html: false,
-                body: blk.body,
+                body: blk.body
             };
-        },
+        }
     }),
 
     markdown: new TemplateBlock({
         name: "markdown",
         process: function (blk) {
+            console.log("blk", blk); // TODO::::::
             return this.book.renderInline("markdown", blk.body).then((out) => {
                 return { body: out };
             });
-        },
+        }
     }),
 
     asciidoc: new TemplateBlock({
@@ -34,7 +35,7 @@ export default Immutable.Map({
             return this.book.renderInline("asciidoc", blk.body).then((out) => {
                 return { body: out };
             });
-        },
+        }
     }),
 
     markup: new TemplateBlock({
@@ -43,6 +44,6 @@ export default Immutable.Map({
             return this.book.renderInline(this.ctx.file.type, blk.body).then((out) => {
                 return { body: out };
             });
-        },
-    }),
+        }
+    })
 });

--- a/packages/honkit/src/models/file.ts
+++ b/packages/honkit/src/models/file.ts
@@ -9,7 +9,7 @@ class File extends Immutable.Record({
     path: String(),
 
     // Time when file data last modified
-    mtime: Date(),
+    mtime: Date()
 }) {
     getPath(): string {
         return this.get("path");
@@ -55,10 +55,18 @@ class File extends Immutable.Record({
     /**
      Return parser for this file
 
-     @return {Parser}
+     @return {Parsers}
      */
     getParser(): Parser {
         return parsers.getByExt(this.getExtension());
+    }
+
+    /**
+     Return basedirectory of this file
+     @return {string}
+     */
+    getBaseDirectory(): string {
+        return path.dirname(this.getPath());
     }
 
     /**
@@ -71,7 +79,7 @@ class File extends Immutable.Record({
     static createFromStat(filepath: string, stat: fs.Stats): File {
         return new File({
             path: filepath,
-            mtime: stat.mtime,
+            mtime: stat.mtime
         });
     }
 
@@ -82,7 +90,7 @@ class File extends Immutable.Record({
      */
     static createWithFilepath(filepath: string): File {
         return new File({
-            path: filepath,
+            path: filepath
         });
     }
 }

--- a/packages/honkit/src/models/glossary.ts
+++ b/packages/honkit/src/models/glossary.ts
@@ -6,7 +6,7 @@ import parsers from "../parsers";
 
 class Glossary extends Immutable.Record({
     file: new File(),
-    entries: Immutable.OrderedMap(),
+    entries: Immutable.OrderedMap()
 }) {
     getFile() {
         return this.get("file");
@@ -36,12 +36,11 @@ class Glossary extends Immutable.Record({
     toText(parser) {
         const file = this.getFile();
         const entries = this.getEntries();
-
         parser = parser ? parsers.getByExt(parser) : file.getParser();
 
         if (!parser) {
             throw error.FileNotParsableError({
-                filename: file.getPath(),
+                filename: file.getPath()
             });
         }
 
@@ -69,7 +68,7 @@ class Glossary extends Immutable.Record({
     static addEntryByName(glossary: Glossary, name: string, description: string): Glossary {
         const entry = new GlossaryEntry({
             name: name,
-            description: description,
+            description: description
         });
         return Glossary.addEntry(glossary, entry);
     }
@@ -92,7 +91,7 @@ class Glossary extends Immutable.Record({
 
         return new Glossary({
             file: file,
-            entries: Immutable.OrderedMap(entries),
+            entries: Immutable.OrderedMap(entries)
         });
     }
 }

--- a/packages/honkit/src/models/parser.ts
+++ b/packages/honkit/src/models/parser.ts
@@ -1,6 +1,9 @@
 import Immutable from "immutable";
 import Promise from "../utils/promise";
-
+import { Parsers } from "@honkit/html";
+export type ParserOptions = {
+    baseDirectory: string;
+};
 class Parser extends Immutable.Record({
     name: String(),
 
@@ -8,12 +11,12 @@ class Parser extends Immutable.Record({
     extensions: Immutable.List(),
 
     // Parsing functions
-    readme: Function(),
-    langs: Function(),
-    summary: Function(),
-    glossary: Function(),
-    page: Function(),
-    inline: Function(),
+    readme: Function() as Parsers["readme"],
+    langs: Function() as Parsers["langs"],
+    summary: Function() as Parsers["summary"],
+    glossary: Function() as Parsers["glossary"],
+    page: Function() as Parsers["page"],
+    inline: Function() as Parsers["inline"]
 }) {
     getName(): string {
         return this.get("name");
@@ -25,25 +28,25 @@ class Parser extends Immutable.Record({
 
     // PARSE
 
-    parseReadme(content: any) {
+    parseReadme(content: string, options: ParserOptions) {
         const readme = this.get("readme");
 
-        return Promise(readme(content));
+        return Promise(readme(content, options));
     }
 
-    parseSummary(content: any) {
+    parseSummary(content: string, options: ParserOptions) {
         const summary = this.get("summary");
 
         return Promise(summary(content));
     }
 
-    parseGlossary(content: any) {
+    parseGlossary(content: string, options: ParserOptions) {
         const glossary = this.get("glossary");
 
-        return Promise(glossary(content));
+        return Promise(glossary(content, options));
     }
 
-    preparePage(content: any) {
+    preparePage(content: string) {
         const page = this.get("page");
         if (!page.prepare) {
             return Promise(content);
@@ -52,22 +55,22 @@ class Parser extends Immutable.Record({
         return Promise(page.prepare(content));
     }
 
-    parsePage(content: any) {
+    parsePage(content: string, options: ParserOptions) {
         const page = this.get("page");
 
-        return Promise(page(content));
+        return Promise(page(content, options));
     }
 
-    parseInline(content: any) {
+    parseInline(content: string, options: ParserOptions) {
         const inline = this.get("inline");
 
-        return Promise(inline(content));
+        return Promise(inline(content, options));
     }
 
-    parseLanguages(content: any) {
+    parseLanguages(content: string, options: ParserOptions) {
         const langs = this.get("langs");
 
-        return Promise(langs(content));
+        return Promise(langs(content, options));
     }
 
     // TO TEXT
@@ -107,7 +110,7 @@ class Parser extends Immutable.Record({
      @param {string} name
      @param {Array<String>} extensions
      @param {Object} module
-     @return {Parser}
+     @return {Parsers}
      */
     static create(
         name: string,
@@ -122,7 +125,7 @@ class Parser extends Immutable.Record({
             summary: module.summary,
             glossary: module.glossary,
             page: module.page,
-            inline: module.inline,
+            inline: module.inline
         });
     }
 }

--- a/packages/honkit/src/models/templateShortcut.ts
+++ b/packages/honkit/src/models/templateShortcut.ts
@@ -15,7 +15,7 @@ class TemplateShortcut extends Immutable.Record(
         end: String(),
 
         startTag: String(),
-        endTag: String(),
+        endTag: String()
     },
     "TemplateShortcut"
 ) {
@@ -42,7 +42,7 @@ class TemplateShortcut extends Immutable.Record(
     /**
      Test if this shortcut accept a parser
 
-     @param {Parser|String} parser
+     @param {Parsers|String} parser
      @return {boolean}
      */
     acceptParser(parser: Parser | string) {
@@ -69,7 +69,7 @@ class TemplateShortcut extends Immutable.Record(
             start: details.get("start"),
             end: details.get("end"),
             startTag: block.getName(),
-            endTag: block.getEndTag(),
+            endTag: block.getEndTag()
         });
     }
 }

--- a/packages/honkit/src/parse/parseStructureFile.ts
+++ b/packages/honkit/src/parse/parseStructureFile.ts
@@ -1,6 +1,7 @@
 import Promise from "../utils/promise";
 import error from "../utils/error";
 import lookupStructureFile from "./lookupStructureFile";
+import path from "path";
 
 /**
  Parse a ParsableFile using a specific method
@@ -17,22 +18,23 @@ function parseFile(fs, file, type) {
     if (!parser) {
         return Promise.reject(
             error.FileNotParsableError({
-                filename: filepath,
+                filename: filepath
             })
         );
     }
 
+    const baseDirectory = path.dirname(filepath);
     return fs
         .readAsString(filepath)
         .then((content) => {
             if (type === "readme") {
-                return parser.parseReadme(content);
+                return parser.parseReadme(content, { baseDirectory });
             } else if (type === "glossary") {
-                return parser.parseGlossary(content);
+                return parser.parseGlossary(content, { baseDirectory });
             } else if (type === "summary") {
-                return parser.parseSummary(content);
+                return parser.parseSummary(content, { baseDirectory });
             } else if (type === "langs") {
-                return parser.parseLanguages(content);
+                return parser.parseLanguages(content, { baseDirectory });
             } else {
                 throw new Error(`Parsing invalid type "${type}"`);
             }

--- a/packages/honkit/src/parsers.ts
+++ b/packages/honkit/src/parsers.ts
@@ -10,14 +10,14 @@ import Parser from "./models/parser";
 const parsers = Immutable.List([
     Parser.create("markdown", EXTENSIONS_MARKDOWN, markdownParser),
 
-    Parser.create("asciidoc", EXTENSIONS_ASCIIDOC, asciidocParser),
+    Parser.create("asciidoc", EXTENSIONS_ASCIIDOC, asciidocParser)
 ]);
 
 /**
  * Return a specific parser by its name
  *
  * @param {string} name
- * @return {Parser|undefined}
+ * @return {Parsers|undefined}
  */
 function getParser(name) {
     return parsers.find((parser) => {
@@ -29,7 +29,7 @@ function getParser(name) {
  * Return a specific parser according to an extension
  *
  * @param {string} ext
- * @return {Parser|undefined}
+ * @return {Parsers|undefined}
  */
 function getParserByExt(ext) {
     return parsers.find((parser) => {
@@ -41,7 +41,7 @@ function getParserByExt(ext) {
  * Return parser for a file
  *
  * @param {string} ext
- * @return {Parser|undefined}
+ * @return {Parsers|undefined}
  */
 function getParserForFile(filename) {
     return getParserByExt(path.extname(filename));
@@ -58,5 +58,5 @@ export default {
     extensions: extensions,
     get: getParser,
     getByExt: getParserByExt,
-    getForFile: getParserForFile,
+    getForFile: getParserForFile
 };

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,8 +12,8 @@
     // "allowJs": true,                       /* Allow javascript files to be compiled. */
     // "checkJs": true,                       /* Report errors in .js files. */
     // "jsx": "preserve",                     /* Specify JSX code generation: 'preserve', 'react-native', or 'react'. */
-    // "declaration": true,                   /* Generates corresponding '.d.ts' file. */
-    // "declarationMap": true,                /* Generates a sourcemap for each corresponding '.d.ts' file. */
+     "declaration": true,                   /* Generates corresponding '.d.ts' file. */
+     "declarationMap": true,                /* Generates a sourcemap for each corresponding '.d.ts' file. */
     // "sourceMap": true,                     /* Generates corresponding '.map' file. */
     // "outFile": "./",                       /* Concatenate and emit output to single file. */
     // "outDir": "./",                        /* Redirect output structure to the directory. */

--- a/yarn.lock
+++ b/yarn.lock
@@ -324,6 +324,13 @@
   resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
+"@cspotcode/source-map-support@^0.8.0":
+  version "0.8.1"
+  resolved "https://registry.yarnpkg.com/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz#00629c35a688e05a88b1cda684fb9d5e73f000a1"
+  integrity sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==
+  dependencies:
+    "@jridgewell/trace-mapping" "0.3.9"
+
 "@eslint-community/eslint-utils@^4.2.0":
   version "4.4.0"
   resolved "https://registry.yarnpkg.com/@eslint-community/eslint-utils/-/eslint-utils-4.4.0.tgz#a23514e8fb9af1269d5f7788aa556798d61c6b59"
@@ -654,6 +661,11 @@
   resolved "https://registry.yarnpkg.com/@jridgewell/resolve-uri/-/resolve-uri-3.1.0.tgz#2203b118c157721addfe69d47b70465463066d78"
   integrity sha512-F2msla3tad+Mfht5cJq7LSXcdudKTWCVYUgw6pLFOOHSTtZlj6SWNYAp+AhuqLmWdBO2X5hPrLcu8cVP8fy28w==
 
+"@jridgewell/resolve-uri@^3.0.3":
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/@jridgewell/resolve-uri/-/resolve-uri-3.1.1.tgz#c08679063f279615a3326583ba3a90d1d82cc721"
+  integrity sha512-dSYZh7HhCDtCKm4QakX0xFpsRDqjjtZf/kjI/v3T3Nwt5r8/qz/M19F9ySyOqU94SXBmeG9ttTul+YnR4LOxFA==
+
 "@jridgewell/set-array@^1.0.1":
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/@jridgewell/set-array/-/set-array-1.1.2.tgz#7c6cf998d6d20b914c0a55a91ae928ff25965e72"
@@ -668,6 +680,14 @@
   version "1.4.15"
   resolved "https://registry.yarnpkg.com/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.15.tgz#d7c6e6755c78567a951e04ab52ef0fd26de59f32"
   integrity sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg==
+
+"@jridgewell/trace-mapping@0.3.9":
+  version "0.3.9"
+  resolved "https://registry.yarnpkg.com/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz#6534fd5933a53ba7cbf3a17615e273a0d1273ff9"
+  integrity sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==
+  dependencies:
+    "@jridgewell/resolve-uri" "^3.0.3"
+    "@jridgewell/sourcemap-codec" "^1.4.10"
 
 "@jridgewell/trace-mapping@^0.3.12", "@jridgewell/trace-mapping@^0.3.17", "@jridgewell/trace-mapping@^0.3.18", "@jridgewell/trace-mapping@^0.3.9":
   version "0.3.18"
@@ -1053,6 +1073,26 @@
   resolved "https://registry.yarnpkg.com/@tootallnate/once/-/once-2.0.0.tgz#f544a148d3ab35801c1f633a7441fd87c2e484bf"
   integrity sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==
 
+"@tsconfig/node10@^1.0.7":
+  version "1.0.9"
+  resolved "https://registry.yarnpkg.com/@tsconfig/node10/-/node10-1.0.9.tgz#df4907fc07a886922637b15e02d4cebc4c0021b2"
+  integrity sha512-jNsYVVxU8v5g43Erja32laIDHXeoNvFEpX33OK4d6hljo3jDhCBDhx5dhCCTMWUojscpAagGiRkBKxpdl9fxqA==
+
+"@tsconfig/node12@^1.0.7":
+  version "1.0.11"
+  resolved "https://registry.yarnpkg.com/@tsconfig/node12/-/node12-1.0.11.tgz#ee3def1f27d9ed66dac6e46a295cffb0152e058d"
+  integrity sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==
+
+"@tsconfig/node14@^1.0.0":
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/@tsconfig/node14/-/node14-1.0.3.tgz#e4386316284f00b98435bf40f72f75a09dabf6c1"
+  integrity sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==
+
+"@tsconfig/node16@^1.0.2":
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/@tsconfig/node16/-/node16-1.0.4.tgz#0b92dcc0cc1c81f6f306a381f28e31b1a56536e9"
+  integrity sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==
+
 "@tufjs/canonical-json@1.0.0":
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/@tufjs/canonical-json/-/canonical-json-1.0.0.tgz#eade9fd1f537993bc1f0949f3aea276ecc4fab31"
@@ -1274,7 +1314,7 @@ acorn-walk@^7.0.0:
   resolved "https://registry.yarnpkg.com/acorn-walk/-/acorn-walk-7.2.0.tgz#0de889a601203909b0fbe07b8938dc21d2e967bc"
   integrity sha512-OPdCF6GsMIP+Az+aWfAAOEt2/+iVDKE7oy6lJ098aoe59oAmK76qV6Gw60SbZ8jHuG2wH058GF4pLFbYamYrVA==
 
-acorn-walk@^8.0.2:
+acorn-walk@^8.0.2, acorn-walk@^8.1.1:
   version "8.2.0"
   resolved "https://registry.yarnpkg.com/acorn-walk/-/acorn-walk-8.2.0.tgz#741210f2e2426454508853a2f44d0ab83b7f69c1"
   integrity sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==
@@ -1284,7 +1324,7 @@ acorn@^7.0.0:
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-7.4.1.tgz#feaed255973d2e77555b83dbc08851a6c63520fa"
   integrity sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==
 
-acorn@^8.1.0, acorn@^8.8.1, acorn@^8.9.0:
+acorn@^8.1.0, acorn@^8.4.1, acorn@^8.8.1, acorn@^8.9.0:
   version "8.10.0"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.10.0.tgz#8be5b3907a67221a81ab23c7889c4c5526b62ec5"
   integrity sha512-F0SAmZ8iUtS//m8DmCTA0jlh6TDKkHQyK6xc6V4KDTyZKA9dnvX9/3sRTVQrWm79glUAZbnmmNcdYwUIHWVybw==
@@ -1412,6 +1452,11 @@ are-we-there-yet@^3.0.0:
   dependencies:
     delegates "^1.0.0"
     readable-stream "^3.6.0"
+
+arg@^4.1.0:
+  version "4.1.3"
+  resolved "https://registry.yarnpkg.com/arg/-/arg-4.1.3.tgz#269fc7ad5b8e42cb63c896d5666017261c144089"
+  integrity sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==
 
 argparse@^1.0.7:
   version "1.0.10"
@@ -2648,6 +2693,11 @@ create-hmac@^1.1.0, create-hmac@^1.1.4, create-hmac@^1.1.7:
     safe-buffer "^5.0.1"
     sha.js "^2.4.8"
 
+create-require@^1.1.0:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/create-require/-/create-require-1.1.1.tgz#c1d7e8f1e5f6cfc9ff65f9cd352d37348756c333"
+  integrity sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==
+
 cross-env@^7.0.3:
   version "7.0.3"
   resolved "https://registry.yarnpkg.com/cross-env/-/cross-env-7.0.3.tgz#865264b29677dc015ba8418918965dd232fc54cf"
@@ -2957,6 +3007,11 @@ diff@5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/diff/-/diff-5.0.0.tgz#7ed6ad76d859d030787ec35855f5b1daf31d852b"
   integrity sha512-/VTCrvm5Z0JGty/BWHljh+BAiw3IK+2j87NGMu8Nwc/f48WoDAC395uomO9ZD117ZOBaHmkX1oyLvkVM/aIT3w==
+
+diff@^4.0.1:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/diff/-/diff-4.0.2.tgz#60f3aecb89d5fae520c11aa19efc2bb982aade7d"
+  integrity sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==
 
 diffie-hellman@^5.0.0:
   version "5.0.3"
@@ -6096,7 +6151,7 @@ make-dir@^2.1.0:
     pify "^4.0.1"
     semver "^5.6.0"
 
-make-error@1.x:
+make-error@1.x, make-error@^1.1.1:
   version "1.3.6"
   resolved "https://registry.yarnpkg.com/make-error/-/make-error-1.3.6.tgz#2eb2e37ea9b67c4891f684a1394799af484cf7a2"
   integrity sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==
@@ -6482,7 +6537,7 @@ mkdirp@^1.0.3, mkdirp@^1.0.4:
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-1.0.4.tgz#3eb5ed62622756d79a5f0e2a221dfebad75c2f7e"
   integrity sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==
 
-mocha@^10.0.0:
+mocha@^10.2.0:
   version "10.2.0"
   resolved "https://registry.yarnpkg.com/mocha/-/mocha-10.2.0.tgz#1fd4a7c32ba5ac372e03a17eef435bd00e5c68b8"
   integrity sha512-IDY7fl/BecMwFHzoqF2sg/SHHANeBoMMXFlS9r0OXKDssYE1M5O43wUY/9BVPeIvfH2zmEbBfseqN9gBQZzXkg==
@@ -8876,7 +8931,7 @@ try-resolve@^1.0.1:
   resolved "https://registry.yarnpkg.com/try-resolve/-/try-resolve-1.0.1.tgz#cfde6fabd72d63e5797cfaab873abbe8e700e912"
   integrity sha512-yHeaPjCBzVaXwWl5IMUapTaTC2rn/eBYg2fsG2L+CvJd+ttFbk0ylDnpTO3wVhosmE1tQEvcebbBeKLCwScQSQ==
 
-ts-jest@^29.0.1:
+ts-jest@^29.0.1, ts-jest@^29.1.1:
   version "29.1.1"
   resolved "https://registry.yarnpkg.com/ts-jest/-/ts-jest-29.1.1.tgz#f58fe62c63caf7bfcc5cc6472082f79180f0815b"
   integrity sha512-D6xjnnbP17cC85nliwGiL+tpoKN0StpgE0TeOjXQTU6MVCfsB4v7aW05CgQ/1OywGb0x/oy9hHFnN+sczTiRaA==
@@ -8889,6 +8944,25 @@ ts-jest@^29.0.1:
     make-error "1.x"
     semver "^7.5.3"
     yargs-parser "^21.0.1"
+
+ts-node@^10.9.1:
+  version "10.9.1"
+  resolved "https://registry.yarnpkg.com/ts-node/-/ts-node-10.9.1.tgz#e73de9102958af9e1f0b168a6ff320e25adcff4b"
+  integrity sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==
+  dependencies:
+    "@cspotcode/source-map-support" "^0.8.0"
+    "@tsconfig/node10" "^1.0.7"
+    "@tsconfig/node12" "^1.0.7"
+    "@tsconfig/node14" "^1.0.0"
+    "@tsconfig/node16" "^1.0.2"
+    acorn "^8.4.1"
+    acorn-walk "^8.1.1"
+    arg "^4.1.0"
+    create-require "^1.1.0"
+    diff "^4.0.1"
+    make-error "^1.1.1"
+    v8-compile-cache-lib "^3.0.1"
+    yn "3.1.1"
 
 tsconfig-paths@^4.1.2:
   version "4.2.0"
@@ -9193,6 +9267,11 @@ uuid@^9.0.0:
   version "9.0.0"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-9.0.0.tgz#592f550650024a38ceb0c562f2f6aa435761efb5"
   integrity sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg==
+
+v8-compile-cache-lib@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz#6336e8d71965cb3d35a1bbb7868445a7c05264bf"
+  integrity sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==
 
 v8-compile-cache@2.3.0:
   version "2.3.0"
@@ -9588,6 +9667,11 @@ yargs@^17.3.1, yargs@^17.6.2:
     string-width "^4.2.3"
     y18n "^5.0.5"
     yargs-parser "^21.1.1"
+
+yn@3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/yn/-/yn-3.1.1.tgz#1e87401a09d767c1d5eab26a6e4c185182d2eb50"
+  integrity sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==
 
 yocto-queue@^0.1.0:
   version "0.1.0"


### PR DESCRIPTION
`project/src/main.adoc`:

```asciidoc
include::./dir/file.adoc[]
```

Previously, the `include::` path is relative path from working directory.
As a result, the `include::./dir/file.adoc` imported `project/dir/file.adoc`.

In this PR, the `include::` path is relative path from the content file path.
As a result, the `include::./dir/file.adoc` will import `project/src/dir/file.adoc`.

This is a bug fix, but the behaviour is changed and is therefore a BREAKING CHANGE.

- fix #356 
- fix https://github.com/GitbookIO/gitbook/pull/1733