### PR TITLE
fix(honkit): honkit serve should not exit when watched file is deleted

### DIFF
--- a/packages/honkit/src/cli/serve.ts
+++ b/packages/honkit/src/cli/serve.ts
@@ -36,7 +36,8 @@ function startServer(args, kwargs) {
     const hasLiveReloading = kwargs["live"];
     const reload = kwargs["reload"];
     const Generator = Output.getGenerator(kwargs.format);
-    console.log("Starting server ...");
+    const logger = book.getLogger();
+    logger.info.ok("Starting server ...");
     let lastOutput = null;
     return Promise.all([
         server.start(outputFolder, port),
@@ -70,16 +71,15 @@ function startServer(args, kwargs) {
                 // If the file does not exist in file system, show a warning and skip
                 // Probably, the file has been deleted
                 if (!fs.existsSync(filepath)) {
-                    console.warn(`${filepath} does not exist in file system.`);
+                    logger.warn.ok(`${filepath} does not exist in file system.`);
                     return;
                 }
                 // set livereload path
                 lrPath = filepath;
                 // TODO: use parse extension
                 // Incremental update for pages
-                const logger = book.getLogger();
                 if (lastOutput && filepath.endsWith(".md")) {
-                    logger.info.ok("Rebuild " + filepath);
+                    logger.warn.ok("Rebuild " + filepath);
                     const changedOutput = lastOutput.reloadPage(lastOutput.book.getContentRoot(), filepath).merge({
                         incrementalChangeFileSet: Immutable.Set([filepath])
                     });

--- a/packages/honkit/src/models/book.ts
+++ b/packages/honkit/src/models/book.ts
@@ -10,7 +10,7 @@ import Languages from "./languages";
 import Ignore from "./ignore";
 
 class Book extends Immutable.Record({
-    // Logger for outptu message
+    // Logger for outptut message
 
     // @ts-expect-error ts-migrate(2554) FIXME: Expected 2 arguments, but got 0.
     logger: Logger(),
@@ -32,7 +32,7 @@ class Book extends Immutable.Record({
     language: String(),
 
     // List of children, if multilingual (String -> Book)
-    books: Immutable.OrderedMap(),
+    books: Immutable.OrderedMap()
 }) {
     getLogger() {
         return this.get("logger");
@@ -248,7 +248,7 @@ class Book extends Immutable.Record({
      */
     static createForFS(fs) {
         return new Book({
-            fs: fs,
+            fs: fs
         });
     }
 
@@ -346,7 +346,7 @@ class Book extends Immutable.Record({
 
             language: language,
 
-            fs: FS.reduceScope(parent.getContentFS(), language),
+            fs: FS.reduceScope(parent.getContentFS(), language)
         });
     }
 }


### PR DESCRIPTION
Show warning message instead of process exiting.

```
$ yarn run honkit:serve --reload
yarn run v1.22.19
$ honkit serve --reload
Live reload server started on port: 35729
Press CTRL+C to quit ...

info: >> Starting server ...
info: >> Clear cache
info: 3 plugins are installed
info: 3 explicitly listed
info: plugin "@honkit/honkit-plugin-theme" is loaded
info: plugin "livereload" is loaded
info: plugin "highlight" is loaded
info: found 23 pages
info: found 0 asset files
info: >> generation finished with success in 0.7s !
Serving book on http://localhost:4000

# Delete config.md

warn: >> /Users/azu/ghq/github.com/honkit/honkit/docs/config.md does not exist in file system.
```

fix #372 


---

`honkit serve`でwatchしてるファイルを削除すると、プロセスが終了する問題を修正するPRです。

cc @misaki-s