### PR TITLE
docs(api): fix link

### DIFF
--- a/docs/plugins/api.md
+++ b/docs/plugins/api.md
@@ -2,9 +2,12 @@
 
 HonKits provides different APIs and contexts to plugins. These APIs can vary according to the HonKit version being used, your plugin should specify the `engines.gitbook` field in `package.json` accordingly.
 
+:warning: This API is too internal and should probably be avoided as much as possible.
+It may be removed in the future.
+
 #### Book instance
 
-The `Book` class is the central point of HonKit, it centralize all access read methods. This class is defined in [book.js](https://github.com/honkit/honkit/blob/master/lib/book.js).
+The `Book` class is the central point of HonKit, it centralize all access read methods. This class is defined in [book.ts][(https://github.com/honkit/honkit/blob/master/lib/book.js](https://github.com/honkit/honkit/blob/master/packages/honkit/src/models/book.ts)).
 
 ```js
 // Read configuration from book.json

--- a/docs/plugins/api.md
+++ b/docs/plugins/api.md
@@ -2,9 +2,6 @@
 
 HonKits provides different APIs and contexts to plugins. These APIs can vary according to the HonKit version being used, your plugin should specify the `engines.gitbook` field in `package.json` accordingly.
 
-:warning: This API is too internal and should probably be avoided as much as possible.
-It may be removed in the future.
-
 #### Book instance
 
 The `Book` class is the central point of HonKit, it centralize all access read methods. This class is defined in [book.ts][(https://github.com/honkit/honkit/blob/master/lib/book.js](https://github.com/honkit/honkit/blob/master/packages/honkit/src/models/book.ts)).
@@ -26,6 +23,8 @@ book.renderBlock('markdown', '* This is **Markdown**')
 ```
 
 #### Output instance
+
+:warning: This API is too internal and should probably be avoided as much as possible. It may be removed in the future.
 
 The `Output` class represent the output/write process.
 


### PR DESCRIPTION
Fix broken link.

Also, Deprecate `Output` APIs.
This just exposes the model to the outside world, which is not a good API.

fix #377 