### PR TITLE
docs(api.md): fix typo

### DIFF
--- a/docs/plugins/api.md
+++ b/docs/plugins/api.md
@@ -4,7 +4,7 @@ HonKits provides different APIs and contexts to plugins. These APIs can vary acc
 
 #### Book instance
 
-The `Book` class is the central point of HonKit, it centralize all access read methods. This class is defined in [book.ts][(https://github.com/honkit/honkit/blob/master/lib/book.js](https://github.com/honkit/honkit/blob/master/packages/honkit/src/models/book.ts)).
+The `Book` class is the central point of HonKit, it centralize all access read methods. This class is defined in [book.ts](https://github.com/honkit/honkit/blob/master/packages/honkit/src/models/book.ts).
 
 ```js
 // Read configuration from book.json


### PR DESCRIPTION
The display on [this page](https://honkit.netlify.app/plugins/api) is corrupted due to incorrect markdown and unnecessary characters.
<img width="469" alt="honkit-docs-typo" src="https://github.com/honkit/honkit/assets/90051826/4e85991c-5260-4b10-a14f-b7afa011973d">
