### PR TITLE
Fixed calibre crash when using Docker Image

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,6 +2,7 @@ name: test
 on: [push, pull_request]
 env:
   CI: true
+  NODE_VERSION: 18
 permissions:
   contents: read
 jobs:
@@ -35,3 +36,14 @@ jobs:
       - name: Run E2E
         run: yarn run build
         working-directory: examples/benchmark
+
+  docker-image:
+    name: "Build docker image and generate pdf"
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout
+        uses: actions/checkout@v3
+      - name: Build docker image
+        run: docker buildx build -t testing --build-arg NODE_VERSION=${NODE_VERSION} ./docker
+      - name: Generate pdf
+        run: docker run -v `pwd`/examples/book:/work -w /work --rm testing honkit pdf

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -6,20 +6,17 @@ LABEL Description="Docker Container for HonKit"
 
 COPY calibre-tarball.3.48.0.txz calibre-tarball.txz
 # Calibre dependencies
-RUN apt-get update; \
-    apt-get install --no-install-recommends --allow-unauthenticated -y \
+RUN apt-get update \
+ && apt-get install --no-install-recommends --allow-unauthenticated -y \
     ca-certificates \
     libgl1 \
-    libxcomposite-dev \
+    libxcomposite1 \
     python3 \
-    qt5-default \
-    qt5-image-formats-plugins \
     wget \
     xdg-utils \
     xz-utils \
-    ; \
-    apt-get clean; \
-    rm -rf /var/tmp/* /tmp/* /var/lib/apt/lists/*
+ && apt-get clean \
+ && rm -rf /var/tmp/* /tmp/* /var/lib/apt/lists/*
 RUN mkdir -p /usr/local/calibre \
     && tar xvf ./calibre-tarball.txz -C /usr/local/calibre \
     && /usr/local/calibre/calibre_postinstall


### PR DESCRIPTION
Fixed a crash in Docker Image `honkit/honkit:v5` with commands that use calibre such as `honkit pdf`, and added Docker Image behavior testing, including Dockerfile refactoring and calibre.

1. Add Docker Image build and pdf generation from build result to CI as a test

   * We can see how the pdf generation is failing before the fix from [here](https://github.com/KentarouTakeda/honkit-honkit/actions/runs/7335808647/job/19974218986) in my repository.
   * We can confirm that there is no problem after this fix from the CI of this Pull Request.
   * If it is difficult to maintain, feel free delete this test. (Or you can mention me if this test breaks)

2. Modifying dependent packages by updating the base image OS version

   * Base Image has been changed from `debian:10` to `debian:12` on `node:18`. The configuration of dependent packages has been changed, so this has been addressed.

3. Refactoring the Dockerfile

   * Changed command concatenation from `;` to `&&`.
   * An error occurred during the build due to the dependency package change mentioned above, but since the build process continued with `;`, the build appeared to be successful even though the dependencies were missing. .
