### PR TITLE
fix(honkit): use real path for tmp dir

### DIFF
--- a/packages/honkit/src/cli/buildEbook.ts
+++ b/packages/honkit/src/cli/buildEbook.ts
@@ -1,5 +1,4 @@
 import path from "path";
-import tmp from "tmp";
 import Promise from "../utils/promise";
 import fs from "../utils/fs";
 import Parse from "../parse";
@@ -7,6 +6,7 @@ import Output from "../output";
 import options from "./options";
 import getBook from "./getBook";
 import { clearCache } from "../output/page-cache";
+import { createTmpDirWithRealPath } from "../fs/tmpdir";
 
 export default function (format) {
     return {
@@ -20,7 +20,7 @@ export default function (format) {
             const outputFile = args[1] || `book${extension}`;
 
             // Create temporary directory
-            const outputFolder = tmp.dirSync().name;
+            const outputFolder = createTmpDirWithRealPath();
 
             const book = getBook(args, kwargs);
             const logger = book.getLogger();

--- a/packages/honkit/src/fs/tmpdir.ts
+++ b/packages/honkit/src/fs/tmpdir.ts
@@ -1,0 +1,14 @@
+import path from "path";
+import os from "os";
+import fs from "fs";
+
+/**
+ * Create a temporary directory with a real path
+ * ebook-convert requires a real path to work
+ * https://github.com/honkit/honkit/issues/394
+ * @param prefix "honkit-"
+ */
+export const createTmpDirWithRealPath = (prefix: string = "honkit-") => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+    return fs.realpathSync(tmpDir);
+};

--- a/packages/honkit/src/utils/fs.ts
+++ b/packages/honkit/src/utils/fs.ts
@@ -58,7 +58,11 @@ function genTmpFile(opts) {
     return Promise.nfcall(tmp.file, opts).get(0);
 }
 
-// Generate temporary dir
+/**
+ * Generate temporary dir
+ * @deprecated use tmpdir.ts
+ * @param opts
+ */
 function genTmpDir(opts) {
     return Promise.nfcall(tmp.dir, opts).get(0);
 }
@@ -211,6 +215,9 @@ export default {
 
     copyDir: Promise.nfbind(cpr),
     tmpFile: genTmpFile,
+    /**
+     * @deprecated use tmpdir.ts
+     */
     tmpDir: genTmpDir,
     download: download,
     uniqueFilename: uniqueFilename,


### PR DESCRIPTION
ebook-convert can not resolve symlink path.

This PR fix following error on `ebook-convert` by passsing real path(= /private/var).

```
Not adding /private/var/folders/44/kk91lr2j0pb00nd4d6m78_v00000gn/T/tmp-70306hObyoPSI8oD3/docs/assets/newplot.png as it is outside the document root: /var/folders/44/kk91lr2j0pb00nd4d6m78_v00000gn/T/tmp-70306hObyoPSI8oD3/
````

- fix #394 