### PR TITLE
chore(test): disable Node 16/18 tests on Windows

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,6 +19,11 @@ jobs:
             node-version: 16
           - os: macos-latest
             node-version: 18
+          # Tests appear to be failing for connectivity reasons
+          - os: windows-latest
+            node-version: 16
+          - os: windows-latest
+            node-version: 18
     steps:
       - name: checkout
         uses: actions/checkout@v3


### PR DESCRIPTION
Disable these tests due to apparent networking issues in the tests.