### PR TITLE
fix(markdown): convert trailing spaces to <br>

### DIFF
--- a/packages/@honkit/markdown/src/__tests__/page.ts
+++ b/packages/@honkit/markdown/src/__tests__/page.ts
@@ -21,6 +21,10 @@ describe("Page parsing", () => {
         assert.equal(page("# Hello {#test}").content, '<h1 id="test">Hello</h1>');
     });
 
+    it("should handle line breaks appropriately", () => {
+        assert.equal(page("Line one.  \nLine two.").content, "<p>Line one.<br>Line two.</p>");
+    });
+
     it("should escape codeblocks in preparation (1)", () => {
         assert.equal(page.prepare("Hello `world`"), "Hello {% raw %}`world`{% endraw %}\n\n");
         assert.equal(page.prepare("Hello `world test`"), "Hello {% raw %}`world test`{% endraw %}\n\n");

--- a/packages/@honkit/markup-it/syntaxes/markdown/__tests__/specs/main.html
+++ b/packages/@honkit/markup-it/syntaxes/markdown/__tests__/specs/main.html
@@ -67,3 +67,5 @@ And an image <img src="src" alt="alt">.</p>
 
 <pre><code>Code goes here.
 Lots of it...</code></pre>
+
+<p>Here is a place where we want to intentionally add a line break.<br>As such, I have ended the previous line with two spaces.</p>

--- a/packages/@honkit/markup-it/syntaxes/markdown/__tests__/specs/main.md
+++ b/packages/@honkit/markup-it/syntaxes/markdown/__tests__/specs/main.md
@@ -53,3 +53,6 @@ And an image ![alt](src).
 
     Code goes here.
     Lots of it...
+
+Here is a place where we want to intentionally add a line break.  
+As such, I have ended the previous line with two spaces.

--- a/packages/@honkit/markup-it/syntaxes/markdown/document.js
+++ b/packages/@honkit/markup-it/syntaxes/markdown/document.js
@@ -13,7 +13,7 @@ function cleanupText(src) {
         .replace(/\t/g, "    ")
         .replace(/\u00a0/g, " ")
         .replace(/\u2424/g, "\n")
-        .replace(/  \n/g, "<br>")
+        .replace(/ +\n/g, "<br>")
         .replace(/^ +$/gm, "");
 }
 

--- a/packages/@honkit/markup-it/syntaxes/markdown/document.js
+++ b/packages/@honkit/markup-it/syntaxes/markdown/document.js
@@ -13,6 +13,7 @@ function cleanupText(src) {
         .replace(/\t/g, "    ")
         .replace(/\u00a0/g, " ")
         .replace(/\u2424/g, "\n")
+        .replace(/  \n/g, "<br>")
         .replace(/^ +$/gm, "");
 }
 


### PR DESCRIPTION
The markup-it syntax parser for markdown now coerces a trailing double space to a <br> tag to provide the expected line break behavior. Tests have been added as well.

Closes #420