### PR TITLE
CI(netlify): add NX_SKIP_NX_CACHE=true

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,6 +1,6 @@
 # example netlify.toml
 [build]
-  command = "pnpm install && pnpm run build && pnpm run honkit:build"
+  command = "NX_SKIP_NX_CACHE=true pnpm run build && pnpm run honkit:build"
   functions = "functions"
   publish = "_book"
 

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,6 +1,6 @@
 # example netlify.toml
 [build]
-  command = "NX_SKIP_NX_CACHE=true pnpm run build && pnpm run honkit:build"
+  command = "NX_SKIP_NX_CACHE=true pnpm install && pnpm run build && pnpm run honkit:build"
   functions = "functions"
   publish = "_book"
 

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,6 +1,6 @@
 # example netlify.toml
 [build]
-  command = "NX_SKIP_NX_CACHE=true pnpm install && pnpm run build && pnpm run honkit:build"
+  command = "NX_SKIP_NX_CACHE=true rm -rf node_modules && pnpm -r exec rm -rf node_modules && pnpm install && pnpm run build && pnpm run honkit:build"
   functions = "functions"
   publish = "_book"
 

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,6 +1,6 @@
 # example netlify.toml
 [build]
-  command = "pnpm run build && pnpm run honkit:build"
+  command = "pnpm install && pnpm run build && pnpm run honkit:build"
   functions = "functions"
   publish = "_book"
 


### PR DESCRIPTION
Netlify cache with Nx is broken.

https://answers.netlify.com/t/support-guide-nx-monorepo-site-does-not-reflect-changes-after-build/73657

This PR clear netlify cache before building as workaround