### PR TITLE
docs(changelog): point to releases for changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
-# Change Log
+# Change Log (Deprecated)
 
-All notable changes to this project will be documented in this file.
+See [Releases on GitHub](https://github.com/honkit/honkit/releases) for the newest releases with notable changes provided.
+
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
 ## [4.0.6](https://github.com/honkit/honkit/compare/v4.0.5...v4.0.6) (2023-03-26)

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -45,6 +45,6 @@
 
 * [FAQ](faq.md)
 * [Examples](examples.md)
-* [Release notes](https://github.com/honkit/honkit/blob/master/CHANGELOG.md)
+* [Release History](https://github.com/honkit/honkit/releases)
 
 


### PR DESCRIPTION
Points the documentation link to the GitHub releases page and adds a deprecation notice and link to the top of the old changelog file as it is out of date and a duplicate effort.