### PR TITLE
refactor: remove try-resolve dependency and implement custom path utility

### DIFF
--- a/packages/honkit/package.json
+++ b/packages/honkit/package.json
@@ -86,7 +86,6 @@
     "send": "^0.17.2",
     "tiny-lr": "^1.1.1",
     "tmp": "0.0.28",
-    "try-resolve": "^1.0.1",
     "urijs": "^1.19.11"
   },
   "devDependencies": {

--- a/packages/honkit/src/plugins/PluginResolver.ts
+++ b/packages/honkit/src/plugins/PluginResolver.ts
@@ -3,7 +3,7 @@
 
 import path from "path";
 import * as util from "./package-name-util";
-import tryResolve from "try-resolve";
+import PathUtils from "../utils/path";
 
 const SPECIAL_PACKAGE_NAME = [
     "fontsettings", // → @honkit/honkit-plugin-fontsettings
@@ -50,11 +50,11 @@ export class PluginResolver {
         const honkitScopePackageName = `@honkit/${honkitFullPackageName}`;
         // In sometimes, HonKit package has not main field - so search package.json
         const pkgPath =
-            tryResolve(path.join(baseDir, honkitFullPackageName, "/package.json")) ||
-            tryResolve(path.join(baseDir, gitbookFullPackageName, "/package.json")) ||
-            tryResolve(path.join(baseDir, packageName, "/package.json")) ||
+            PathUtils.tryResolve(path.join(baseDir, honkitFullPackageName, "/package.json")) ||
+            PathUtils.tryResolve(path.join(baseDir, gitbookFullPackageName, "/package.json")) ||
+            PathUtils.tryResolve(path.join(baseDir, packageName, "/package.json")) ||
             (SPECIAL_PACKAGE_NAME.includes(packageName) &&
-                tryResolve(path.join(baseDir, honkitScopePackageName, "/package.json")));
+                PathUtils.tryResolve(path.join(baseDir, honkitScopePackageName, "/package.json")));
         if (!pkgPath) {
             throw new ReferenceError(`Failed to load HonKit's plugin module: "${packageName}" is not found.
 

--- a/packages/honkit/src/utils/path.ts
+++ b/packages/honkit/src/utils/path.ts
@@ -43,7 +43,7 @@ function resolveInRoot(root) {
     return result;
 }
 
-// Chnage extension of a file
+// Change extension of a file
 function setExtension(filename, ext) {
     return path.join(path.dirname(filename), path.basename(filename, path.extname(filename)) + ext);
 }
@@ -58,10 +58,24 @@ function isPureRelative(filename) {
     return filename.indexOf("./") === 0 || filename.indexOf("../") === 0;
 }
 
+/**
+ * Try to resolve package name
+ * if `packageName` is found, return resolved absolute path.
+ * if `packageName` is not found, return `undefined`
+ **/
+function tryResolve(packageName: string): string | undefined {
+    try {
+        return require.resolve(packageName);
+    } catch {
+        return undefined;
+    }
+}
+
 export default {
     isInRoot: isInRoot,
     resolveInRoot: resolveInRoot,
     normalize: normalizePath,
     setExtension: setExtension,
-    isPureRelative: isPureRelative
+    isPureRelative: isPureRelative,
+    tryResolve: tryResolve
 };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -509,9 +509,6 @@ importers:
       tmp:
         specifier: 0.0.28
         version: 0.0.28
-      try-resolve:
-        specifier: ^1.0.1
-        version: 1.0.1
       urijs:
         specifier: ^1.19.11
         version: 1.19.11
@@ -5299,10 +5296,6 @@ packages:
   trough@1.0.5:
     resolution: {integrity: sha512-rvuRbTarPXmMb79SmzEp8aqXNKcK+y0XaB298IXueQ8I2PsrATcPBCSPyK/dDNa2iWOhKlfNnOjdAOTBU/nkFA==}
 
-  try-resolve@1.0.1:
-    resolution: {integrity: sha512-yHeaPjCBzVaXwWl5IMUapTaTC2rn/eBYg2fsG2L+CvJd+ttFbk0ylDnpTO3wVhosmE1tQEvcebbBeKLCwScQSQ==}
-    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
-
   ts-jest@29.2.5:
     resolution: {integrity: sha512-KD8zB2aAZrcKIdGk4OwpJggeLcH1FgrICqDSROWqlnJXGCXK4Mn6FcdK2B6670Xr73lHMG1kHw8R87A0ecZ+vA==}
     engines: {node: ^14.15.0 || ^16.10.0 || ^18.0.0 || >=20.0.0}
@@ -5792,7 +5785,7 @@ snapshots:
       '@babel/traverse': 7.25.7
       '@babel/types': 7.25.7
       convert-source-map: 2.0.0
-      debug: 4.3.7(supports-color@8.1.1)
+      debug: 4.3.7
       gensync: 1.0.0-beta.2
       json5: 2.2.3
       semver: 6.3.1
@@ -5960,7 +5953,7 @@ snapshots:
       '@babel/parser': 7.25.7
       '@babel/template': 7.25.7
       '@babel/types': 7.25.7
-      debug: 4.3.7(supports-color@8.1.1)
+      debug: 4.3.7
       globals: 11.12.0
     transitivePeerDependencies:
       - supports-color
@@ -7849,6 +7842,10 @@ snapshots:
     dependencies:
       ms: 2.1.2
 
+  debug@4.3.7:
+    dependencies:
+      ms: 2.1.3
+
   debug@4.3.7(supports-color@8.1.1):
     dependencies:
       ms: 2.1.3
@@ -9169,7 +9166,7 @@ snapshots:
 
   istanbul-lib-source-maps@4.0.1:
     dependencies:
-      debug: 4.3.7(supports-color@8.1.1)
+      debug: 4.3.7
       istanbul-lib-coverage: 3.2.2
       source-map: 0.6.1
     transitivePeerDependencies:
@@ -11557,8 +11554,6 @@ snapshots:
   trim@0.0.1: {}
 
   trough@1.0.5: {}
-
-  try-resolve@1.0.1: {}
 
   ts-jest@29.2.5(@babel/core@7.25.7)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.25.7))(jest@29.7.0(@types/node@22.7.4)(ts-node@10.9.2(@types/node@22.7.4)(typescript@5.6.2)))(typescript@5.6.2):
     dependencies:


### PR DESCRIPTION
Remove deprecated try-resolve and directly implement.

Closes #457.