### PR TITLE
chore: correct typos in documentation files

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -201,9 +201,9 @@ git checkout -b "release/$(date '+%Y-%m-%d')"
 `npm run versionup:*` script update version and generate CHANGELOG.md
 
 ```
-# bump vesrion and update changelog
+# bump version and update changelog
 npm run versionup
-## Also, availble npm run versionup:{patch,minor,major}
+## Also, available npm run versionup:{patch,minor,major}
 # push the changes to release branch
 git push origin HEAD -u
 ```

--- a/docs/syntax/asciidoc.md
+++ b/docs/syntax/asciidoc.md
@@ -2,7 +2,7 @@
 
 Since version `2.0.0`, HonKit can also accept AsciiDoc as an input format.
 
-Please refer to the [AsciiDoc Syntax Quick Reference](http://asciidoctor.org/docs/asciidoc-syntax-quick-reference/) for more informations about the format.
+Please refer to the [AsciiDoc Syntax Quick Reference](http://asciidoctor.org/docs/asciidoc-syntax-quick-reference/) for more information about the format.
 
 Just like for markdown, HonKit is using some special files to extract structures: `README.adoc`, `SUMMARY.adoc`, `LANGS.adoc` and `GLOSSARY.adoc`.
 

--- a/docs/syntax/markdown.md
+++ b/docs/syntax/markdown.md
@@ -55,7 +55,7 @@ Markdown supports ordered (numbered) and unordered (bulleted) lists.
 
 ##### Unordered
 
-Unordered lists use asterisks, pluses, and hyphens — interchangably — as list markers:
+Unordered lists use asterisks, pluses, and hyphens — interchangeably — as list markers:
 
 ```markdown
 * Item 1

--- a/docs/templating/README.md
+++ b/docs/templating/README.md
@@ -86,7 +86,7 @@ Current version is {{ softwareVersion }}.
 
 ##### include and block
 
-Inclusion and inheritance is detailled in the [Content References](conrefs.md) section.
+Inclusion and inheritance is detailed in the [Content References](conrefs.md) section.
 
 ### Escaping
 


### PR DESCRIPTION
 correct typos in documentation files