### PR TITLE
chore: remove unused 'q' dependency

### DIFF
--- a/packages/@honkit/html/package.json
+++ b/packages/@honkit/html/package.json
@@ -39,8 +39,7 @@
   },
   "dependencies": {
     "cheerio": "^1.0.0",
-    "lodash": "^4.17.21",
-    "q": "^1.5.1"
+    "lodash": "^4.17.21"
   },
   "devDependencies": {
     "mocha": "^10.7.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -154,9 +154,6 @@ importers:
       lodash:
         specifier: ^4.17.21
         version: 4.17.21
-      q:
-        specifier: ^1.5.1
-        version: 1.5.1
     devDependencies:
       mocha:
         specifier: ^10.7.3


### PR DESCRIPTION
remove unused 'q' dependency