### PR TITLE
fix: update release workflow for npm OIDC publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,6 +24,7 @@ jobs:
       github.event.pull_request.merged == true &&
       contains(github.event.pull_request.labels.*.name, 'Type: Release')
     runs-on: ubuntu-latest
+    environment: npm
     permissions:
       contents: write
       id-token: write  # Required for OIDC npm authentication
@@ -73,9 +74,13 @@ jobs:
         if: steps.tag-check.outputs.exists == 'false'
         run: pnpm install --frozen-lockfile
       
-      - name: Build and Publish to npm with provenance
+      - name: Build packages
         if: steps.tag-check.outputs.exists == 'false'
-        run: pnpm run ci:release
+        run: npm run build
+      
+      - name: Publish to npm with provenance
+        if: steps.tag-check.outputs.exists == 'false'
+        run: npm -r publish --access public
         env:
           NPM_CONFIG_PROVENANCE: true
       

--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
     "test": "pnpm -r --filter \"!@example/*\" run test",
     "updateSnapshot": "pnpm -r --filter \"!@example/*\" run updateSnapshot",
     "versionup": "echo 'Error: Please use CI for versioning. Run gh workflow run create-release-pr instead.' && exit 1",
-    "release": "echo 'Error: Please use CI for releases. Merge a Release PR instead.' && exit 1",
     "honkit:build": "npm run build && honkit build",
     "honkit:serve": "honkit serve",
     "format": "prettier --write \"**/*.{mjs,js,jsx,ts,tsx,css}\"",


### PR DESCRIPTION
## Summary

This PR updates the release workflow to properly support npm OIDC (OpenID Connect) publishing without long-lived tokens.

## Changes

- Added `environment: npm` to the release job for OIDC authentication  
- Separated build and publish into distinct workflow steps for better clarity
- Removed unused `release` script from package.json (releases are only done via CI)
- Use npm commands directly in the workflow for publishing with provenance

## Related

Part of the migration to npm trusted publishing with OIDC.