### PR TITLE
fix: use pnpm for npm publish in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -80,7 +80,7 @@ jobs:
       
       - name: Publish to npm with provenance
         if: steps.tag-check.outputs.exists == 'false'
-        run: npm -r publish --access public
+        run: pnpm -r publish --access public --no-git-checks
         env:
           NPM_CONFIG_PROVENANCE: true
       


### PR DESCRIPTION
## Summary

This PR fixes the package publishing step in the release workflow by switching from npm to pnpm for consistency and proper workspace handling.

## Problem

The release workflow was using `npm -r publish` instead of `pnpm -r publish`, which caused several issues:

- **Inconsistent package manager usage**: The workflow uses pnpm everywhere else (installation, dependency management) but was using npm for publishing
- **Private package handling**: The root package `honkit-root` is marked as `"private": true` in package.json, but npm's recursive publish doesn't properly respect workspace configurations
- **Missing git checks flag**: The pnpm publish command needs `--no-git-checks` flag in CI environments

## Solution

Changed the publish command from:
```bash
npm -r publish --access public
```

To:
```bash
pnpm -r publish --access public --no-git-checks
```

This ensures:
- Consistent use of pnpm throughout the entire workflow
- Proper handling of private packages in the monorepo workspace
- Successful publishing in CI environment with the `--no-git-checks` flag

## Test Plan

N/A - This change affects the automated release workflow which runs when a Release PR is merged. The change will be validated when the next release is published.

🤖 Generated with [Claude Code](https://claude.ai/code)