### PR TITLE
fix: Update repository URLs for npm OIDC publishing

### DIFF
--- a/packages/@honkit/markup-it/package.json
+++ b/packages/@honkit/markup-it/package.json
@@ -8,13 +8,13 @@
     "asciidoc",
     "gitbook"
   ],
-  "homepage": "https://github.com/GitbookIO/markup-it#readme",
+  "homepage": "https://github.com/honkit/honkit#readme",
   "bugs": {
-    "url": "https://github.com/GitbookIO/markup-it/issues"
+    "url": "https://github.com/honkit/honkit/issues"
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/GitbookIO/draft-markup.git"
+    "url": "https://github.com/honkit/honkit.git"
   },
   "license": "Apache-2.0",
   "author": "azu",

--- a/packages/@honkit/theme-default/font-awesome/package.json
+++ b/packages/@honkit/theme-default/font-awesome/package.json
@@ -4,9 +4,9 @@
   "version": "4.6.3",
   "style": "css/font-awesome.css",
   "keywords": ["font", "awesome", "fontawesome", "icon", "font", "bootstrap"],
-  "homepage": "http://fontawesome.io/",
+  "homepage": "https://github.com/honkit/honkit#readme",
   "bugs": {
-    "url" : "http://github.com/FortAwesome/Font-Awesome/issues"
+    "url" : "https://github.com/honkit/honkit/issues"
   },
   "author": {
     "name": "Dave Gandy",
@@ -15,7 +15,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/FortAwesome/Font-Awesome.git"
+    "url": "https://github.com/honkit/honkit.git"
   },
   "contributors": [
     {


### PR DESCRIPTION
## Summary

This PR fixes npm OIDC (OpenID Connect) publishing failures by updating repository URLs in package.json files to match the expected provenance information.

The main issue was with `@honkit/markup-it` package, which had outdated repository URLs pointing to GitbookIO repositories. When publishing with npm's new OIDC provenance verification, the mismatch between the package.json repository URL and the actual GitHub repository caused publishing to fail with a 422 error.

## Changes

### Critical Fix
- **`@honkit/markup-it`**: Updated repository URL from `git+https://github.com/GitbookIO/draft-markup.git` to `https://github.com/honkit/honkit.git`
  - Also updated homepage and bugs URLs for consistency
  - This package is published to npm and requires correct URLs for OIDC provenance

### Consistency Update
- **`font-awesome` (theme-default)**: Updated repository URLs from FortAwesome to honkit/honkit
  - This is an internal package that is NOT published to npm
  - Changed for repository consistency only

## Context

The error encountered during npm publish:
```
npm error 422 Unprocessable Entity - PUT https://registry.npmjs.org/@honkit%2fmarkup-it
Error verifying sigstore provenance bundle: Failed to validate repository information:
package.json: "repository.url" is "git+https://github.com/GitbookIO/draft-markup.git",
expected to match "https://github.com/honkit/honkit" from provenance
```

## Test Plan

- [ ] Verify `@honkit/markup-it` can be published successfully with npm OIDC provenance
- [ ] Confirm no regression in local development workflow
- [ ] Ensure theme-default continues to work correctly (internal package, not published)

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>