### PR TITLE
feat: migrate Docker image registry from Docker Hub to GHCR

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ on:
       - closed
 
 env:
-  DOCKER_HUB_BASE_NAME: honkit/honkit
+  IMAGE_NAME: ghcr.io/honkit/honkit
   NODE_VERSION: 24
 
 jobs:
@@ -136,6 +136,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      packages: write
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -157,25 +158,24 @@ jobs:
           docker buildx build \
             --build-arg NODE_VERSION=${NODE_VERSION} \
             --build-arg PACKAGE_VERSION=${PACKAGE_VERSION} \
-            --tag ${DOCKER_HUB_BASE_NAME}:v${PACKAGE_VERSION} \
+            --tag ${IMAGE_NAME}:v${PACKAGE_VERSION} \
             --cache-from type=local,src=/tmp/.buildx-cache \
             --cache-to type=local,dest=/tmp/.buildx-cache-new,mode=max \
             --load \
             .
         working-directory: ./docker
       - name: Print node version in container image
-        run: docker run --rm ${DOCKER_HUB_BASE_NAME}:v${PACKAGE_VERSION} --version
+        run: docker run --rm ${IMAGE_NAME}:v${PACKAGE_VERSION} --version
       - name: Set latest tag
-        run: docker tag ${DOCKER_HUB_BASE_NAME}:v${PACKAGE_VERSION} ${DOCKER_HUB_BASE_NAME}:latest
+        run: docker tag ${IMAGE_NAME}:v${PACKAGE_VERSION} ${IMAGE_NAME}:latest
       - name: Set major version tag
-        run: docker tag ${DOCKER_HUB_BASE_NAME}:v${PACKAGE_VERSION} ${DOCKER_HUB_BASE_NAME}:v$(echo $PACKAGE_VERSION | cut -f 1 -d . | tr -d "\n")
-      - name: Login to Registries
-        run: echo "${DOCKER_HUB_TOKEN}" | docker login -u ${DOCKER_HUB_USER} --password-stdin
+        run: docker tag ${IMAGE_NAME}:v${PACKAGE_VERSION} ${IMAGE_NAME}:v$(echo $PACKAGE_VERSION | cut -f 1 -d . | tr -d "\n")
+      - name: Login to GitHub Container Registry
+        run: echo "${GITHUB_TOKEN}" | docker login ghcr.io -u ${GITHUB_ACTOR} --password-stdin
         env:
-          DOCKER_HUB_USER: ${{ secrets.DOCKER_HUB_USER }}
-          DOCKER_HUB_TOKEN: ${{ secrets.DOCKER_HUB_TOKEN }}
-      - name: Push to Docker Hub
-        run: docker push ${DOCKER_HUB_BASE_NAME} --all-tags
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Push to GitHub Container Registry
+        run: docker push ${IMAGE_NAME} --all-tags
       - name: Move cache
         run: |
           rm -rf /tmp/.buildx-cache

--- a/README.md
+++ b/README.md
@@ -58,14 +58,14 @@ For more details, see [HonKit's documentation](https://honkit.netlify.app/).
 
 ## Docker support
 
-Honkit provide docker image at [honkit/honkit](https://hub.docker.com/r/honkit/honkit).
+Honkit provide docker image at [ghcr.io/honkit/honkit](https://github.com/honkit/honkit/pkgs/container/honkit).
 
 This docker image includes built-in dependencies for PDF/epub.
 
 ```
-docker pull honkit/honkit
-docker run -v `pwd`:`pwd` -w `pwd` --rm -it honkit/honkit honkit build
-docker run -v `pwd`:`pwd` -w `pwd` --rm -it honkit/honkit honkit pdf
+docker pull ghcr.io/honkit/honkit
+docker run -v `pwd`:`pwd` -w `pwd` --rm -it ghcr.io/honkit/honkit honkit build
+docker run -v `pwd`:`pwd` -w `pwd` --rm -it ghcr.io/honkit/honkit honkit pdf
 ```
 
 For more details, see [docker/](./docker/).

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,28 +1,28 @@
 # Docker Container
 
-- https://hub.docker.com/r/honkit/honkit
+- https://github.com/honkit/honkit/pkgs/container/honkit
 
 ## Installation
 
-    docker pull honkit/honkit
+    docker pull ghcr.io/honkit/honkit
 
 ## Usage
 
 Show help 
 
-    $ docker run -v `pwd`:`pwd` -w `pwd` --rm -it honkit/honkit honkit --help
+    $ docker run -v `pwd`:`pwd` -w `pwd` --rm -it ghcr.io/honkit/honkit honkit --help
 
 Build
 
-    $ docker run -v `pwd`:`pwd` -w `pwd` --rm -it honkit/honkit honkit build
+    $ docker run -v `pwd`:`pwd` -w `pwd` --rm -it ghcr.io/honkit/honkit honkit build
 
 PDF build
 
-    $ docker run -v `pwd`:`pwd` -w `pwd` --rm -it honkit/honkit honkit pdf
+    $ docker run -v `pwd`:`pwd` -w `pwd` --rm -it ghcr.io/honkit/honkit honkit pdf
 
 Serve on port 4000
 
-    $ docker run -it --init -p 4000:4000  -v `pwd`:`pwd` -w `pwd` --rm  honkit/honkit honkit serve
+    $ docker run -it --init -p 4000:4000  -v `pwd`:`pwd` -w `pwd` --rm  ghcr.io/honkit/honkit honkit serve
 
 ## Tips
 
@@ -31,7 +31,7 @@ Serve on port 4000
 You can create new image includes custom font based on honkit image.
 
 ```
-FROM honkit/honkit:latest
+FROM ghcr.io/honkit/honkit:latest
 LABEL maintainer="your@example.com"
 
 # Install fonts


### PR DESCRIPTION
## Summary

Switch the published Docker image from `honkit/honkit` on Docker Hub to `ghcr.io/honkit/honkit` on GitHub Container Registry. This removes the need for separate Docker Hub credentials and uses the built-in `GITHUB_TOKEN` for authentication.

**Note on versioning**

This change moves the published Docker image from `honkit/honkit` (Docker Hub) to `ghcr.io/honkit/honkit`. At first glance this looks like a breaking change, but it does **not** break existing installations:

- The npm package (`honkit`) is unaffected — only the Docker image distribution location changes.
- Images already pulled from Docker Hub keep working. Existing Dockerfiles based on `FROM honkit/honkit:...` continue to build.
- The previously published Docker Hub tags remain available; they simply stop receiving new versions.

Users who want to track new releases via Docker need to switch their pull/`FROM` references to `ghcr.io/honkit/honkit`. This is documented in the README.

Since no auto-update path is broken, this is being released as a **minor** version bump rather than a major one.


## Changes

- `.github/workflows/release.yml`
  - Replace `DOCKER_HUB_BASE_NAME` env with `IMAGE_NAME: ghcr.io/honkit/honkit`
  - Add `packages: write` permission to the `docker` job
  - Replace Docker Hub login (`DOCKER_HUB_USER` / `DOCKER_HUB_TOKEN` secrets) with GHCR login using `GITHUB_TOKEN` and `GITHUB_ACTOR`
  - Update tag/push steps to use the new `IMAGE_NAME`
- `README.md` and `docker/README.md`
  - Update image references and links from `honkit/honkit` (Docker Hub) to `ghcr.io/honkit/honkit` (GHCR)

## Breaking Changes

Users pulling the image must update their references:

- Before: `docker pull honkit/honkit`
- After: `docker pull ghcr.io/honkit/honkit`

The Docker Hub image will no longer be updated after this change is released.

## Test Plan

- [ ] Verify the `docker` job in `release.yml` succeeds on the next release run
- [ ] Confirm the image is published at `ghcr.io/honkit/honkit` with `v<version>`, `v<major>`, and `latest` tags
- [ ] `docker pull ghcr.io/honkit/honkit` works and `docker run --rm ghcr.io/honkit/honkit --version` prints the expected version
- [ ] `DOCKER_HUB_USER` / `DOCKER_HUB_TOKEN` secrets can be removed from the repository settings after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)
